### PR TITLE
Require authentication to POST reservations

### DIFF
--- a/reservations/api.py
+++ b/reservations/api.py
@@ -11,6 +11,6 @@ class ReservationSerializer(serializers.ModelSerializer):
 
 class ReservationViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     renderer_classes = [renderers.JSONRenderer]
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [permissions.IsAuthenticated]
     serializer_class = ReservationSerializer
     queryset = Reservation.objects.all()


### PR DESCRIPTION
`CORS_ORIGIN_WHITELIST` does not ban requests from non-front urls.
This will ensure that only UI will POST reservations.