### PR TITLE
Do not throttle on OSErrors

### DIFF
--- a/reservations/signals.py
+++ b/reservations/signals.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from raven import Client
 
 from notifications.enums import NotificationType
 from notifications.utils import send_notification
@@ -10,7 +11,11 @@ from .models import Reservation
 @receiver(post_save, sender=Reservation)
 def reservation_notification_handler(sender, instance, created, **kwargs):
     if created:
-        send_notification(instance.email, NotificationType.RESERVATION_CREATED)
+        try:
+            send_notification(instance.email, NotificationType.RESERVATION_CREATED)
+        except OSError:
+            raven_client = Client()
+            raven_client.captureException()
 
 
 if settings.NOTIFICATIONS_ENABLED:


### PR DESCRIPTION
This way failure while sending notifications does not
fail the entire POST request from the frontend.