### PR TITLE
Catch Anymail exceptions when sending notifications

### DIFF
--- a/reservations/signals.py
+++ b/reservations/signals.py
@@ -1,3 +1,4 @@
+from anymail.exceptions import AnymailError
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -13,7 +14,7 @@ def reservation_notification_handler(sender, instance, created, **kwargs):
     if created:
         try:
             send_notification(instance.email, NotificationType.RESERVATION_CREATED)
-        except OSError:
+        except (OSError, AnymailError):
             raven_client = Client()
             raven_client.captureException()
 


### PR DESCRIPTION
Catch Anymail exceptions in order to prevent complete failure
of requests from the frontend, when Anymail fails to deliver
notification for some reason.