### PR TITLE
Switch to django mailer

### DIFF
--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -73,6 +73,7 @@ if env('MAIL_MAILGUN_KEY'):
     }
 
 EMAIL_BACKEND = "mailer.backend.DbBackend"
+MAILER_EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
 
 RAVEN_CONFIG = {'dsn': env.str('SENTRY_DSN'), 'release': version, 'environment': env('SENTRY_ENVIRONMENT')}
 

--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -27,7 +27,7 @@ env = environ.Env(
     USE_X_FORWARDED_HOST=(bool, False),
     DATABASE_URL=(str, 'postgis://berth_reservations:berth_reservations@localhost/berth_reservations'),
     CACHE_URL=(str, 'locmemcache://'),
-    EMAIL_URL=(str, 'consolemail://'),
+    MAILER_EMAIL_BACKEND=(str, 'django.core.mail.backends.console.EmailBackend'),
     DEFAULT_FROM_EMAIL=(str, 'venepaikkavaraukset@hel.fi'),
     MAIL_MAILGUN_KEY=(str, ''),
     MAIL_MAILGUN_DOMAIN=(str, ''),
@@ -63,7 +63,6 @@ DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 
 CACHES = {'default': env.cache()}
 
-vars().update(env.email_url())  # EMAIL_BACKEND etc.
 DEFAULT_FROM_EMAIL = env.str('DEFAULT_FROM_EMAIL')
 if env('MAIL_MAILGUN_KEY'):
     ANYMAIL = {
@@ -73,7 +72,7 @@ if env('MAIL_MAILGUN_KEY'):
     }
 
 EMAIL_BACKEND = "mailer.backend.DbBackend"
-MAILER_EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+MAILER_EMAIL_BACKEND = env.str('MAILER_EMAIL_BACKEND')
 
 RAVEN_CONFIG = {'dsn': env.str('SENTRY_DSN'), 'release': version, 'environment': env('SENTRY_ENVIRONMENT')}
 

--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -71,7 +71,8 @@ if env('MAIL_MAILGUN_KEY'):
         'MAILGUN_SENDER_DOMAIN': env('MAIL_MAILGUN_DOMAIN'),
         'MAILGUN_API_URL': env('MAIL_MAILGUN_API'),
     }
-    EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+
+EMAIL_BACKEND = "mailer.backend.DbBackend"
 
 RAVEN_CONFIG = {'dsn': env.str('SENTRY_DSN'), 'release': version, 'environment': env('SENTRY_ENVIRONMENT')}
 
@@ -114,6 +115,7 @@ INSTALLED_APPS = [
     'anymail',
     'mptt',
     'munigeo',
+    'mailer',
 
     'reservations',
     'notifications',

--- a/notifications/apps.py
+++ b/notifications/apps.py
@@ -5,3 +5,6 @@ from django.utils.translation import ugettext_lazy as _
 class NotificationsConfig(AppConfig):
     name = 'notifications'
     verbose_name = _('Notifications')
+
+    def ready(self):
+        import notifications.signals  # noqa

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -1,0 +1,20 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from mailer.models import MessageLog, RESULT_FAILURE
+from raven import Client
+
+
+class MailerFailureException(Exception):
+    pass
+
+
+@receiver(post_save, sender=MessageLog)
+def mailer_message_failure_handler(sender, **kwargs):
+    message_failure_log = kwargs.get('instance')
+    created = kwargs.get('created')
+
+    if created and message_failure_log.result == RESULT_FAILURE:
+        raven_client = Client()
+        raven_client.captureException(
+            exc_info=MailerFailureException(message_failure_log.log_message)
+        )

--- a/notifications/tests/conftest.py
+++ b/notifications/tests/conftest.py
@@ -2,8 +2,42 @@ import pytest
 
 from berth_reservations.tests.conftest import *  # noqa
 
+from ..enums import NotificationType
+from ..models import NotificationTemplate
+
 
 @pytest.fixture(autouse=True)
 def email_setup(settings):
-    settings.EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+    settings.EMAIL_BACKEND = 'mailer.backend.DbBackend'
     settings.NOTIFICATIONS_ENABLED = True
+
+
+@pytest.fixture
+def notification_template(settings):
+    settings.LANGUAGES = (('fi', 'Finnish'), ('en', 'English'))
+
+    template = NotificationTemplate.objects.language('en').create(
+        type=NotificationType.RESERVATION_CREATED,
+        subject="test subject, variable value: {{ subject_var }}!",
+        html_body="<b>test html body</b>, variable value: {{ html_body_var }}!",
+        text_body="test text body, variable value: {{ text_body_var }}!",
+
+    )
+    template.set_current_language('fi')
+    template.subject = "testiotsikko, muuttujan arvo: {{ subject_var }}!"
+    template.html_body = "<b>testihötömölöruumis</b>, muuttujan arvo: {{ html_body_var }}!"
+    template.text_body = "testitekstiruumis, muuttujan arvo: {{ text_body_var }}!"
+
+    template.save()
+
+    return template
+
+
+@pytest.fixture
+def dummy_context():
+    return {
+        'extra_var': 'foo',
+        'subject_var': 'bar',
+        'html_body_var': 'html_baz',
+        'text_body_var': 'text_baz',
+    }

--- a/notifications/tests/test_mailer_integration.py
+++ b/notifications/tests/test_mailer_integration.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+from django.conf import settings
+from django.core import mail
+from mailer.models import (
+    Message, MessageLog, PRIORITY_DEFERRED, RESULT_FAILURE, RESULT_SUCCESS
+)
+from raven import Client
+
+from ..utils import send_notification
+
+
+def test_mailer_fired_automatically(notification_template, dummy_context):
+    assert not Message.objects.exists()
+    assert not MessageLog.objects.exists()
+
+    # Ensure mailer will fail as SMTP is not configured
+    settings.MAILER_EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    # Mailer will attempt to send the message but it will be deferred
+    send_notification(
+        'receiver@example.com', notification_template.type, dummy_context)
+
+    assert Message.objects.filter(priority=PRIORITY_DEFERRED).count() == 1
+    assert MessageLog.objects.filter(result=RESULT_FAILURE).count() == 1
+
+    # Now messages will be sent successfully
+    settings.MAILER_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+    send_notification(
+        'receiver@example.com', notification_template.type, dummy_context)
+
+    assert Message.objects.filter(priority=PRIORITY_DEFERRED).count() == 0
+    assert MessageLog.objects.filter(result=RESULT_SUCCESS).count() == 2
+
+
+@mock.patch('notifications.signals.MailerFailureException')
+@mock.patch.object(Client, 'captureException')
+def test_mailer_failure_gets_sent_to_sentry(raven_client, mailer_exception):
+    msg = ('Subject', 'Body', 'sender@example.com', ['receiver@example.com'])
+    mail.send_mass_mail((msg,))
+
+    mailer_message = Message.objects.first()
+
+    log = MessageLog.objects.log(
+        message=mailer_message,
+        result_code=RESULT_FAILURE,
+        log_message="Houston, we have a problem",
+    )
+
+    raven_client.assert_called_once_with(exc_info=mailer_exception(log.log_message))
+
+
+@mock.patch.object(Client, 'captureException')
+def test_mailer_success_not_sent_to_sentry(raven_client):
+    msg = ('Subject', 'Body', 'sender@example.com', ['receiver@example.com'])
+    mail.send_mass_mail((msg,))
+
+    mailer_message = Message.objects.first()
+
+    MessageLog.objects.log(
+        message=mailer_message,
+        result_code=RESULT_SUCCESS,
+        log_message="Houston, life is good",
+    )
+
+    raven_client.assert_not_called()

--- a/notifications/tests/test_notifications_render.py
+++ b/notifications/tests/test_notifications_render.py
@@ -1,31 +1,7 @@
 import pytest
 
-from notifications.enums import NotificationType
-from notifications.models import (
-    NotificationTemplate, NotificationTemplateException
-)
+from notifications.models import NotificationTemplateException
 from notifications.utils import render_notification_template
-
-
-@pytest.fixture
-def notification_template(settings):
-    settings.LANGUAGES = (('fi', 'Finnish'), ('en', 'English'))
-
-    template = NotificationTemplate.objects.language('en').create(
-        type=NotificationType.RESERVATION_CREATED,
-        subject="test subject, variable value: {{ subject_var }}!",
-        html_body="<b>test html body</b>, variable value: {{ html_body_var }}!",
-        text_body="test text body, variable value: {{ text_body_var }}!",
-
-    )
-    template.set_current_language('fi')
-    template.subject = "testiotsikko, muuttujan arvo: {{ subject_var }}!"
-    template.html_body = "<b>testihötömölöruumis</b>, muuttujan arvo: {{ html_body_var }}!"
-    template.text_body = "testitekstiruumis, muuttujan arvo: {{ text_body_var }}!"
-
-    template.save()
-
-    return template
 
 
 def test_notification_template_rendering(notification_template):
@@ -49,13 +25,9 @@ def test_notification_template_rendering(notification_template):
     assert rendered.text_body == "testitekstiruumis, muuttujan arvo: text_baz!"
 
 
-def test_notification_template_rendering_no_text_body_provided(notification_template):
-    context = {
-        'extra_var': 'foo',
-        'subject_var': 'bar',
-        'html_body_var': 'html_baz',
-        'text_body_var': 'text_baz',
-    }
+def test_notification_template_rendering_no_text_body_provided(
+    notification_template, dummy_context
+):
     notification_template.set_current_language('fi')
     notification_template.text_body = ''
     notification_template.save()
@@ -63,26 +35,22 @@ def test_notification_template_rendering_no_text_body_provided(notification_temp
     notification_template.text_body = ''
     notification_template.save()
 
-    rendered = render_notification_template(notification_template, context, 'en')
+    rendered = render_notification_template(notification_template, dummy_context, 'en')
     assert len(rendered) == 3
     assert rendered.subject == "test subject, variable value: bar!"
     assert rendered.html_body == "<b>test html body</b>, variable value: html_baz!"
     assert rendered.text_body == "test html body, variable value: html_baz!"
 
-    rendered = render_notification_template(notification_template, context, 'fi')
+    rendered = render_notification_template(notification_template, dummy_context, 'fi')
     assert len(rendered) == 3
     assert rendered.subject == "testiotsikko, muuttujan arvo: bar!"
     assert rendered.html_body == "<b>testihötömölöruumis</b>, muuttujan arvo: html_baz!"
     assert rendered.text_body == "testihötömölöruumis, muuttujan arvo: html_baz!"
 
 
-def test_undefined_rendering_context_variable(notification_template):
-    context = {
-        'extra_var': 'foo',
-        'subject_var': 'bar',
-        'text_body_var': 'baz',
-    }
+def test_undefined_rendering_context_variable(notification_template, dummy_context):
+    dummy_context.pop('html_body_var')
 
     with pytest.raises(NotificationTemplateException) as e:
-        render_notification_template(notification_template, context, 'fi')
+        render_notification_template(notification_template, dummy_context, 'fi')
     assert "'html_body_var' is undefined" in str(e)

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -7,6 +7,8 @@ from django.utils.html import strip_tags
 from jinja2 import StrictUndefined
 from jinja2.exceptions import TemplateError
 from jinja2.sandbox import SandboxedEnvironment
+from mailer.engine import send_all
+from mailer.models import Message
 from parler.utils.context import switch_language
 
 from notifications.models import (
@@ -67,6 +69,10 @@ def send_notification(email, notification_type, context=None, language=DEFAULT_L
 
         for admin in template.admins_to_notify.all():
             send_mail(admin_subject, admin_text, admin.email, from_email=template.from_email)
+
+    # also immediately fire django-mailer's commands
+    Message.objects.retry_deferred()
+    send_all()
 
 
 def render_notification_template(template, context, language_code=DEFAULT_LANGUAGE):

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ django-anymail
 pillow
 django-parler-rest
 django-munigeo
+django-mailer

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-enumfields==0.10.1
 django-environ==0.4.5
 django-filter==2.0.0
 django-js-asset==1.1.0    # via django-mptt
+django-mailer==1.2.5
 django-mptt==0.9.1        # via django-munigeo
 django-munigeo==0.3.1
 django-parler-rest==2.0
@@ -23,6 +24,7 @@ djangorestframework==3.9.0
 idna==2.7                 # via requests
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
+lockfile==0.12.2          # via django-mailer
 markupsafe==1.0           # via jinja2
 pillow==5.3.0
 psycopg2-binary==2.7.5


### PR DESCRIPTION
Anymail recommends using some kind of queueing for
the emails to be sent, as the requests can fail quite easily.
https://anymail.readthedocs.io/en/stable/tips/transient_errors/

The easiest way to do this is django-mailer.