### PR TITLE
Send notification when reservation is fully saved

### DIFF
--- a/reservations/api.py
+++ b/reservations/api.py
@@ -2,6 +2,7 @@ from rest_framework import mixins, permissions, renderers, serializers, viewsets
 
 from harbors.models import BoatType, Harbor
 from .models import HarborChoice, Reservation
+from .signals import reservation_saved
 
 
 class HarborChoiceSerializer(serializers.ModelSerializer):
@@ -38,6 +39,8 @@ class ReservationSerializer(serializers.ModelSerializer):
                     priority=choice["priority"],
                     reservation=reservation
                 )
+        # Send notifications when all m2m relations are saved
+        reservation_saved.send(sender=reservation)
         return reservation
 
 

--- a/reservations/models.py
+++ b/reservations/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from harbors.models import BoatType, Harbor
+from .utils import localize_datetime
 
 
 class HarborChoice(models.Model):
@@ -140,3 +141,10 @@ class Reservation(models.Model):
 
     def __str__(self):
         return '{}: {} {}'.format(self.pk, self.first_name, self.last_name)
+
+    def get_notification_context(self):
+        return {
+            'created_at': localize_datetime(self.created_at, self.language),
+            'harbor_choices': self.harborchoice_set.all(),
+            'reservation': self
+        }

--- a/reservations/signals.py
+++ b/reservations/signals.py
@@ -1,23 +1,27 @@
 from anymail.exceptions import AnymailError
 from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.dispatch import Signal
 from raven import Client
 
 from notifications.enums import NotificationType
 from notifications.utils import send_notification
-from .models import Reservation
 
 
-@receiver(post_save, sender=Reservation)
-def reservation_notification_handler(sender, instance, created, **kwargs):
-    if created:
-        try:
-            send_notification(instance.email, NotificationType.RESERVATION_CREATED)
-        except (OSError, AnymailError):
-            raven_client = Client()
-            raven_client.captureException()
+reservation_saved = Signal()
+
+
+def reservation_notification_handler(sender, **kwargs):
+    try:
+        send_notification(
+            sender.email,
+            NotificationType.RESERVATION_CREATED,
+            sender.get_notification_context(),
+            sender.language
+        )
+    except (OSError, AnymailError):
+        raven_client = Client()
+        raven_client.captureException()
 
 
 if settings.NOTIFICATIONS_ENABLED:
-    post_save.connect(reservation_notification_handler, Reservation)
+    reservation_saved.connect(reservation_notification_handler)

--- a/reservations/utils.py
+++ b/reservations/utils.py
@@ -1,5 +1,8 @@
 from csv import DictWriter
 
+from django.conf import settings
+from django.utils import dateformat, formats, timezone, translation
+
 
 def export_reservations_as_csv(reservations, stream):
     fieldnames = [
@@ -21,3 +24,9 @@ def export_reservations_as_csv(reservations, stream):
             'data': reservation.data
         })
     return stream
+
+
+def localize_datetime(dt, language=settings.LANGUAGES[0][0]):
+    translation.activate(language)
+    return dateformat.format(
+        timezone.localtime(dt), formats.get_format('DATETIME_FORMAT', lang=language))


### PR DESCRIPTION
We need to fire a custom signal when all m2m relations are saved.
Otherwise, post_save catches reservations before its HarborChoices
have been created and connected to it.

Notifications should be aware of the reservartion's language.