### PR TITLE
Localize decimal fields for reservations' endpoint

### DIFF
--- a/reservations/api.py
+++ b/reservations/api.py
@@ -26,6 +26,19 @@ class ReservationSerializer(serializers.ModelSerializer):
         slug_field='identifier'
     )
 
+    boat_length = serializers.DecimalField(
+        decimal_places=2, max_digits=5, localize=True
+    )
+    boat_width = serializers.DecimalField(
+        decimal_places=2, max_digits=5, localize=True
+    )
+    boat_draught = serializers.DecimalField(
+        decimal_places=2, max_digits=5, localize=True
+    )
+    boat_weight = serializers.DecimalField(
+        decimal_places=2, max_digits=10, localize=True
+    )
+
     class Meta:
         model = Reservation
         fields = '__all__'


### PR DESCRIPTION
This way, when API's language is set to Finnish or any other
language, where commas are the standard decimal separator, the
endpoint will accept both dots and commas in decimal fields.

NOTE: if the language is set to languages, where dot is the
standard decimal separator, f.ex. English, then only dots will
be allowed.