### PR TITLE
Fix berth reservation mutation for switch applications

### DIFF
--- a/reservations/schema.py
+++ b/reservations/schema.py
@@ -125,7 +125,7 @@ class CreateBerthReservation(graphene.Mutation):
             old_harbor = Harbor.objects.get(id=harbor_id)
             berth_switch = BerthSwitch.objects.create(
                 harbor=old_harbor,
-                pier=switch_data.get("pier"),
+                pier=switch_data.get("pier", ""),
                 berth_number=switch_data.get("berth_number"),
             )
             reservation_data["berth_switch"] = berth_switch


### PR DESCRIPTION
Store pier field as blank, when no info given.