### PR TITLE
Send graphql errors to sentry always

### DIFF
--- a/berth_reservations/urls.py
+++ b/berth_reservations/urls.py
@@ -3,11 +3,12 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
-from graphene_django.views import GraphQLView
+
+from .views import SentryGraphQLView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    path("graphql/", csrf_exempt(SentryGraphQLView.as_view(graphiql=True))),
 ]
 
 if settings.DEBUG:

--- a/berth_reservations/views.py
+++ b/berth_reservations/views.py
@@ -1,0 +1,17 @@
+from graphene_django.views import GraphQLView
+from sentry_sdk import capture_exception
+
+
+class SentryGraphQLView(GraphQLView):
+    def execute_graphql_request(self, *args, **kwargs):
+        """
+        Extract any exceptions and send them to Sentry
+        """
+        result = super().execute_graphql_request(*args, **kwargs)
+        if result.errors:
+            for error in result.errors:
+                try:
+                    raise error.original_error
+                except Exception as e:
+                    capture_exception(e)
+        return result


### PR DESCRIPTION
By default the graphql errors in django-graphene are silenced.
This makes for a difficult debugging experience, so let's send
them explicitly to sentry whenever possible.