### PR TITLE
Fix error lookup for graphql calls

### DIFF
--- a/berth_reservations/views.py
+++ b/berth_reservations/views.py
@@ -8,7 +8,7 @@ class SentryGraphQLView(GraphQLView):
         Extract any exceptions and send them to Sentry
         """
         result = super().execute_graphql_request(*args, **kwargs)
-        if result.errors:
+        if result and result.errors:
             for error in result.errors:
                 try:
                     raise error.original_error


### PR DESCRIPTION
If the request has no graphql entities (queries or mutations)
the result is `None` and checking for errors on it leads to
TypeErrors.