### PR TITLE
Expose Berth mooring type enum members as a query

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -25,6 +25,23 @@ BerthMooringTypeEnum = graphene.Enum.from_enum(
 )
 
 
+class BerthMooringTypeEnumObject(graphene.ObjectType):
+    """
+    BerthMooringTypeEnum as an ObjectType
+
+    Used to expose both names/values and descriptions of the
+    enum members through the 'berthMooringTypes' query.
+    Needed because an introspection query ("__type") would
+    not come through the apollo-gateway to this project's API.
+    """
+
+    name = graphene.String()
+    description = graphene.String()
+
+    def resolve_description(self, info, **kwargs):
+        return self.label
+
+
 class AvailabilityLevelType(DjangoObjectType):
     class Meta:
         model = AvailabilityLevel
@@ -161,6 +178,7 @@ class Query:
     availability_levels = DjangoListField(AvailabilityLevelType)
     boat_types = DjangoListField(BoatTypeType)
 
+    berth_mooring_types = graphene.List(BerthMooringTypeEnumObject)
     berth_type = relay.Node.Field(BerthTypeNode)
     berth_types = DjangoConnectionField(BerthTypeNode)
 
@@ -190,6 +208,10 @@ class Query:
 
     def resolve_boat_types(self, info, **kwargs):
         return BoatType.objects.all()
+
+    def resolve_berth_mooring_types(self, info, **kwargs):
+        # return all enum members
+        return BerthMooringType
 
     def resolve_berths(self, info, **kwargs):
         return Berth.objects.prefetch_related(

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -5,6 +5,37 @@ from berth_reservations.tests.utils import GraphQLTestClient
 client = GraphQLTestClient()
 
 
+def test_berth_mooring_type_object_list_has_all_enums():
+    enum_query = """
+        {
+            __type(name: "BerthMooringType") {
+                enumValues {
+                    name
+                    description
+                }
+            }
+        }
+    """
+    executed_enum_query = client.execute(query=enum_query, graphql_url="/graphql_v2/")
+    list_of_enums = executed_enum_query["data"]["__type"]["enumValues"]
+
+    object_query = """
+        {
+            berthMooringTypes {
+                name
+                description
+            }
+        }
+    """
+    executed_object_query = client.execute(
+        query=object_query, graphql_url="/graphql_v2/"
+    )
+    list_of_objects = executed_object_query["data"]["berthMooringTypes"]
+
+    for enum_dict in list_of_enums:
+        assert enum_dict in list_of_objects
+
+
 def test_get_boat_type(boat_type):
     query = """
         {


### PR DESCRIPTION
We need them to be available through a regular GQL query and not
just an introspection query ("__type" query). This way when the
forntend fetches them from the apollo gateway, the request will
come through the gateway to our GQL API.

Refs VEN-364