### PR TITLE
VEN-143 | BerthType mutations

### DIFF
--- a/berth_reservations/tests/utils.py
+++ b/berth_reservations/tests/utils.py
@@ -77,3 +77,10 @@ def assert_field_missing(field_name, executed):
     errors = str(executed["errors"])
     assert field_name in errors
     assert "found null" in errors
+
+
+def assert_invalid_enum(field_name, expected_value, executed):
+    errors = str(executed["errors"])
+    assert expected_value in errors
+    assert field_name in errors
+    assert f'Expected type "{expected_value}"' in errors

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -276,6 +276,29 @@ class CreateBerthTypeMutation(graphene.ClientIDMutation):
         return CreateBerthTypeMutation(berth_type=berth_type)
 
 
+class DeleteBerthTypeMutation(graphene.ClientIDMutation):
+    class Input:
+        id = graphene.ID(required=True)
+
+    @classmethod
+    @login_required
+    @superuser_required
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        # TODO: Should check if the user has permissions to
+        # delete the specific resource
+        id = from_global_id(kwargs.get("id"))[1]
+
+        try:
+            berth_type = BerthType.objects.get(pk=id)
+        except BerthType.DoesNotExist as e:
+            raise VenepaikkaGraphQLError(e)
+
+        berth_type.delete()
+
+        return DeleteBerthTypeMutation()
+
+
 class Query:
     availability_levels = DjangoListField(AvailabilityLevelType)
     boat_types = DjangoListField(BoatTypeType)
@@ -398,3 +421,4 @@ class Mutation:
 
     # BerthType
     create_berth_type = CreateBerthTypeMutation.Field()
+    delete_berth_type = DeleteBerthTypeMutation.Field()

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -252,6 +252,30 @@ class DeleteBerthMutation(graphene.ClientIDMutation):
         return DeleteBerthMutation()
 
 
+class CreateBerthTypeMutation(graphene.ClientIDMutation):
+    class Input:
+        mooring_type = BerthMooringTypeEnum(required=True)
+        width = graphene.Int(required=True)
+        length = graphene.Int(required=True)
+
+    berth_type = graphene.Field(BerthTypeNode)
+
+    @classmethod
+    @login_required
+    @superuser_required
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        # TODO: Should check if the user has permissions to
+        # delete the specific resource
+
+        berth_type = BerthType.objects.create(
+            mooring_type=kwargs.get("mooring_type"),
+            width=kwargs.get("width"),
+            length=kwargs.get("length"),
+        )
+        return CreateBerthTypeMutation(berth_type=berth_type)
+
+
 class Query:
     availability_levels = DjangoListField(AvailabilityLevelType)
     boat_types = DjangoListField(BoatTypeType)
@@ -367,6 +391,10 @@ class Query:
 
 
 class Mutation:
+    # Berths
     create_berth = CreateBerthMutation.Field()
     delete_berth = DeleteBerthMutation.Field()
     update_berth = UpdateBerthMutation.Field()
+
+    # BerthType
+    create_berth_type = CreateBerthTypeMutation.Field()

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -276,6 +276,35 @@ class CreateBerthTypeMutation(graphene.ClientIDMutation):
         return CreateBerthTypeMutation(berth_type=berth_type)
 
 
+class UpdateBerthTypeMutation(graphene.ClientIDMutation):
+    class Input:
+        id = graphene.ID(required=True)
+        mooring_type = BerthMooringTypeEnum()
+        width = graphene.Int()
+        length = graphene.Int()
+
+    berth_type = graphene.Field(BerthTypeNode)
+
+    @classmethod
+    @login_required
+    @superuser_required
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **kwargs):
+        # TODO: Should check if the user has permissions to
+        # modify the specific resource
+        # GQL IDs have to be translated to Django model UUIDs
+        id = from_global_id(kwargs.pop("id"))[1]
+
+        try:
+            berth_type = BerthType.objects.get(pk=id)
+        except BerthType.DoesNotExist as e:
+            raise VenepaikkaGraphQLError(e)
+
+        update_object(berth_type, kwargs)
+
+        return UpdateBerthTypeMutation(berth_type=berth_type)
+
+
 class DeleteBerthTypeMutation(graphene.ClientIDMutation):
     class Input:
         id = graphene.ID(required=True)
@@ -422,3 +451,4 @@ class Mutation:
     # BerthType
     create_berth_type = CreateBerthTypeMutation.Field()
     delete_berth_type = DeleteBerthTypeMutation.Field()
+    update_berth_type = UpdateBerthTypeMutation.Field()

--- a/resources/tests/test_resources_mutations.py
+++ b/resources/tests/test_resources_mutations.py
@@ -6,10 +6,11 @@ from graphql_relay import to_global_id
 from berth_reservations.tests.utils import (
     assert_doesnt_exist,
     assert_field_missing,
+    assert_invalid_enum,
     assert_not_enough_permissions,
     GraphQLTestClient,
 )
-from resources.models import Berth
+from resources.models import Berth, BerthType
 
 client = GraphQLTestClient()
 
@@ -67,7 +68,7 @@ def test_create_berth_not_enough_permissions(user, pier, berth_type):
         query=CREATE_BERTH_MUTATION,
         variables=variables,
         graphql_url=GRAPHQL_URL,
-        user=None,
+        user=user,
     )
 
     assert Berth.objects.count() == 0
@@ -248,3 +249,78 @@ def test_update_berth_not_enough_permissions(berth, pier, berth_type, user):
 
     assert Berth.objects.count() == 1
     assert_not_enough_permissions(executed)
+
+
+CREATE_BERTH_TYPE_MUTATION = """
+mutation CreateBerthTypeMutation($input: CreateBerthTypeMutationInput!) {
+  createBerthType(input: $input) {
+    berthType {
+      id
+      width
+      length
+      mooringType
+    }
+  }
+}
+"""
+
+
+def test_create_berth_type(superuser):
+    variables = {"mooringType": "DINGHY_PLACE", "width": 666, "length": 333}
+
+    assert BerthType.objects.count() == 0
+
+    executed = client.execute(
+        query=CREATE_BERTH_TYPE_MUTATION,
+        variables=variables,
+        graphql_url=GRAPHQL_URL,
+        user=superuser,
+    )
+
+    assert BerthType.objects.count() == 1
+    assert executed["data"]["createBerthType"]["berthType"]["id"] is not None
+    assert (
+        executed["data"]["createBerthType"]["berthType"]["mooringType"]
+        == variables["mooringType"]
+    )
+    assert (
+        executed["data"]["createBerthType"]["berthType"]["width"] == variables["width"]
+    )
+    assert (
+        executed["data"]["createBerthType"]["berthType"]["length"]
+        == variables["length"]
+    )
+
+
+@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
+def test_create_berth_type_not_enough_permissions(user):
+    variables = {"mooringType": "DINGHY_PLACE", "width": 666, "length": 333}
+
+    assert BerthType.objects.count() == 0
+
+    executed = client.execute(
+        query=CREATE_BERTH_TYPE_MUTATION,
+        variables=variables,
+        graphql_url=GRAPHQL_URL,
+        user=user,
+    )
+
+    assert BerthType.objects.count() == 0
+    assert_not_enough_permissions(executed)
+
+
+def test_create_berth_type_invalid_mooring(superuser):
+    variables = {"mooringType": "INVALID_VALUE", "width": 666, "length": 333}
+
+    assert BerthType.objects.count() == 0
+
+    executed = client.execute(
+        query=CREATE_BERTH_TYPE_MUTATION,
+        variables=variables,
+        graphql_url=GRAPHQL_URL,
+        user=superuser,
+    )
+
+    assert BerthType.objects.count() == 0
+
+    assert_invalid_enum("mooringType", "BerthMooringType", executed)


### PR DESCRIPTION
## Description :sparkles:
* Add mutation and tests for the `BerthType` resource.

## Issues :bug:
Partially closes VEN-143

## Testing :alembic:
To manually test the mutations, you can run the following queries on GraphiQL with the inputs provided. Just add valid IDs and you're ready to test. :rocket:

```graphql
query FetchBerthTypes {
  berthTypes {
    edges {
      node {
        id
        width
        length
        mooringType
      }
    }
  }
}

query	FetchBerthType {
  berthType(id: "") {
    id
    width
    length
    mooringType
  }
}

mutation CreateBerthTypeMutation($input: CreateBerthTypeMutationInput!) {
  createBerthType(input: $input) {
		berthType {
    	id
      width
      length
      mooringType
    }
  }
}

mutation UpdateBerthTypeMutation($updateInput: UpdateBerthTypeMutationInput!){
  updateBerthType(input: $updateInput) {
  	berthType {
     	id
      width
      length
      mooringType
    }
  }
}

mutation DeleteBerthType($deleteInput:DeleteBerthTypeMutationInput!) {
  deleteBerthType(input: $deleteInput) {
    __typename
  }
}
```

```json
{
  "input": {
    "mooringType": "DINGHY_PLACE",
    "width": 150,
    "length": 333
  },
  "deleteInput": {
    "id": ""
  },
  "updateInput": {
    "id": "",
		"mooringType": "NO_STERN_TO_MOORING"
  }
}
```