### PR TITLE
Add error handling for Sentry

### DIFF
--- a/berth_reservations/views.py
+++ b/berth_reservations/views.py
@@ -1,20 +1,33 @@
+import sentry_sdk
 from graphene_django.views import GraphQLView
-from sentry_sdk import capture_exception
+
+from .exceptions import VenepaikkaGraphQLError
 
 
 class SentryGraphQLView(GraphQLView):
-    def execute_graphql_request(self, *args, **kwargs):
+    def execute_graphql_request(self, request, data, query, *args, **kwargs):
         """
-        Extract any exceptions and send them to Sentry
+        Extract any exceptions and send some of them to Sentry.
+        Avoid sending "common" errors, as objects not found and other stuff that is not relevant to be logged.
         """
-        result = super().execute_graphql_request(*args, **kwargs)
-        if result and result.errors:
-            for error in result.errors:
-                try:
-                    # try to capture the error directly
-                    capture_exception(error)
-                except Exception as e:
-                    # or send this one if the previous
-                    # error variable was not the right type
-                    capture_exception(e)
+        result = super().execute_graphql_request(request, data, query, *args, **kwargs)
+
+        if result and result.errors and not result.invalid:
+            errors = [
+                e
+                for e in result.errors
+                if not isinstance(
+                    getattr(e, "original_error", None), VenepaikkaGraphQLError
+                )
+            ]
+            if errors:
+                self._capture_sentry_exceptions(result.errors, query)
         return result
+
+    def _capture_sentry_exceptions(self, errors, query):
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_extra("graphql_query", query)
+            for error in errors:
+                if hasattr(error, "original_error"):
+                    error = error.original_error
+                sentry_sdk.capture_exception(error)


### PR DESCRIPTION
## Description ✨ 
Update the view sending the errors to Sentry to avoid sending "common" errors, as objects not found and other stuff that is not relevant to be logged.

It implements the same code as [Kukkuu](https://github.com/City-of-Helsinki/kukkuu/blob/develop/kukkuu/views.py).

## Issues 🐛 
Closes [VEN-389](https://helsinkisolutionoffice.atlassian.net/browse/VEN-389)

## Testing ⚗️ 
If you want to test locally without running Sentry, you can replace [L23](https://github.com/City-of-Helsinki/berth-reservations/pull/117/files#diff-9309524292bdc615bcbca2b085950214R23)
```python
if errors:
    self._capture_sentry_exceptions(result.errors, query)
```
for
```python
if errors:
    # self._capture_sentry_exceptions(result.errors, query)
    print("🔥🔥🔥🔥 Exception caught 🔥🔥🔥🔥")
```

And add a `raise Exception("message")` in any of the GQL queries/mutations.