### PR TITLE
Hotfix: Add required to harbor ID on HarborChoiceType

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -17,29 +17,25 @@ ApplicationStatusEnum = graphene.Enum.from_enum(ApplicationStatus)
 
 
 class HarborChoiceType(DjangoObjectType):
-    harbor = graphene.String()
+    harbor = graphene.String(required=True)
 
     class Meta:
         model = HarborChoice
         exclude = ("id", "application")
 
     def resolve_harbor(self, info, **kwargs):
-        if self.harbor:
-            return self.harbor.servicemap_id
-        return None
+        return self.harbor.servicemap_id
 
 
 class BerthSwitchType(OldBerthSwitchType):
-    harbor = graphene.String()
+    harbor = graphene.String(required=True)
 
     class Meta:
         model = BerthSwitch
         exclude = ("berthapplication_set",)
 
     def resolve_harbor(self, info, **kwargs):
-        if self.harbor:
-            return self.harbor.servicemap_id
-        return None
+        return self.harbor.servicemap_id
 
 
 class BerthApplicationFilter(django_filters.FilterSet):


### PR DESCRIPTION
Since we’re treating harbor as an id, it shouldn’t be a nullable value.

```graphql
type HarborChoiceType {
  harbor: String!
  priority: Int!
}
```