### PR TITLE
Include harbor name in harbor choices at GQL API

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -18,6 +18,7 @@ ApplicationStatusEnum = graphene.Enum.from_enum(ApplicationStatus)
 
 class HarborChoiceType(DjangoObjectType):
     harbor = graphene.String(required=True)
+    harbor_name = graphene.String(required=True)
 
     class Meta:
         model = HarborChoice
@@ -26,9 +27,13 @@ class HarborChoiceType(DjangoObjectType):
     def resolve_harbor(self, info, **kwargs):
         return self.harbor.servicemap_id
 
+    def resolve_harbor_name(self, info, **kwargs):
+        return self.harbor.safe_translation_getter("name")
+
 
 class BerthSwitchType(OldBerthSwitchType):
     harbor = graphene.String(required=True)
+    harbor_name = graphene.String(required=True)
 
     class Meta:
         model = BerthSwitch
@@ -36,6 +41,9 @@ class BerthSwitchType(OldBerthSwitchType):
 
     def resolve_harbor(self, info, **kwargs):
         return self.harbor.servicemap_id
+
+    def resolve_harbor_name(self, info, **kwargs):
+        return self.harbor.safe_translation_getter("name")
 
 
 class BerthApplicationFilter(django_filters.FilterSet):


### PR DESCRIPTION
Frontend would like to display the name right away, without
fetching the harbor object. This way FE can build the full link
as is specified by the designs using just one "berthApplications"
query.