### PR TITLE
VEN-348 | Expose leases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description :sparkles:
+
+## Issues :bug:
+
+## Testing :alembic:
+
+## Screenshots :camera_flash:
+
+## Additional notes :spiral_notepad:

--- a/applications/schema.py
+++ b/applications/schema.py
@@ -28,6 +28,10 @@ class HarborChoiceType(DjangoObjectType):
 class BerthReservationType(DjangoObjectType):
     class Meta:
         model = BerthApplication
+        exclude = (
+            "customer",
+            "lease",
+        )
 
 
 class BerthSwitchType(DjangoObjectType):

--- a/berth_reservations/new_schema.py
+++ b/berth_reservations/new_schema.py
@@ -1,0 +1,38 @@
+import graphene
+from graphene_federation import build_schema
+
+import applications.new_schema
+import customers.schema
+import leases.schema
+import resources.schema
+
+# =====================================================
+# New GraphQL API for the new 'resources' app
+#
+# Needed to avoid conflicting types and names with
+# the old resources from the 'harbors' app.
+# =====================================================
+
+
+class Query(
+    applications.new_schema.Query,
+    customers.schema.Query,
+    leases.schema.Query,
+    resources.schema.Query,
+    graphene.ObjectType,
+):
+    pass
+
+
+class Mutation(
+    applications.new_schema.Mutation, resources.schema.Mutation, graphene.ObjectType
+):
+    pass
+
+
+# We need to list all the extended types separately,
+# otherwise graphene will not generate their schemas.
+extended_types = [customers.schema.ProfileNode]
+
+
+new_schema = build_schema(query=Query, mutation=Mutation, types=extended_types)

--- a/berth_reservations/schema.py
+++ b/berth_reservations/schema.py
@@ -1,11 +1,7 @@
 import graphene
-from graphene_federation import build_schema
 
-import applications.new_schema
 import applications.schema
-import customers.schema
 import harbors.schema
-import resources.schema
 
 
 class Query(harbors.schema.Query, applications.schema.Query, graphene.ObjectType):
@@ -17,34 +13,3 @@ class Mutation(applications.schema.Mutation, graphene.ObjectType):
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)
-
-
-# =====================================================
-# New GraphQL API for the new 'resources' app
-#
-# Needed to avoid conflicting types and names with
-# the old resources from the 'harbors' app.
-# =====================================================
-
-
-class Query(
-    applications.new_schema.Query,
-    customers.schema.Query,
-    resources.schema.Query,
-    graphene.ObjectType,
-):
-    pass
-
-
-class Mutation(
-    applications.new_schema.Mutation, resources.schema.Mutation, graphene.ObjectType
-):
-    pass
-
-
-# We need to list all the extended types separately,
-# otherwise graphene will not generate their schemas.
-extended_types = [customers.schema.ProfileNode]
-
-
-new_schema = build_schema(query=Query, mutation=Mutation, types=extended_types)

--- a/berth_reservations/tests/utils.py
+++ b/berth_reservations/tests/utils.py
@@ -63,10 +63,8 @@ class GraphQLTestClient(Client):
 
 
 def assert_not_enough_permissions(executed):
-    assert (
-        executed["errors"][0]["message"]
-        == "You do not have permission to perform this action"
-    )
+    errors = str(executed["errors"])
+    assert "You do not have permission to perform this action" in errors
 
 
 def assert_doesnt_exist(model, executed):

--- a/berth_reservations/urls.py
+++ b/berth_reservations/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 from helusers.admin_site import admin
 
-from .schema import new_schema
+from .new_schema import new_schema
 from .views import SentryGraphQLView
 
 urlpatterns = [

--- a/customers/schema.py
+++ b/customers/schema.py
@@ -9,7 +9,7 @@ from graphql_jwt.decorators import login_required
 from berth_reservations.exceptions import VenepaikkaGraphQLError
 
 from .enums import InvoicingType
-from .models import CustomerProfile
+from .models import Boat, CustomerProfile
 
 InvoicingTypeEnum = graphene.Enum.from_enum(InvoicingType)
 
@@ -82,6 +82,11 @@ class BerthProfileNode(DjangoObjectType):
             raise VenepaikkaGraphQLError(
                 _("You do not have permission to perform this action.")
             )
+
+
+class BoatNode(DjangoObjectType):
+    class Meta:
+        model = Boat
 
 
 class Query:

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -1,0 +1,54 @@
+import graphene
+from django.utils.translation import ugettext_lazy as _
+from graphene_django import DjangoConnectionField, DjangoObjectType
+from graphql_jwt.decorators import login_required, superuser_required
+
+from berth_reservations.exceptions import VenepaikkaGraphQLError
+from resources.schema import BerthNode
+
+from .enums import LeaseStatus
+from .models import BerthLease
+
+LeaseStatusEnum = graphene.Enum.from_enum(LeaseStatus)
+
+
+class BerthLeaseNode(DjangoObjectType):
+    berth = graphene.Field(BerthNode)
+    status = LeaseStatusEnum()
+
+    class Meta:
+        model = BerthLease
+        interfaces = (graphene.relay.Node,)
+
+    @classmethod
+    @login_required
+    def get_node(cls, info, id):
+        node = super().get_node(info, id)
+        if not node:
+            return None
+
+        user = info.context.user
+        # TODO: implement proper permissions
+        if (node.customer and node.customer.user == user) or user.is_superuser:
+            return node
+        else:
+            raise VenepaikkaGraphQLError(
+                _("You do not have permission to perform this action.")
+            )
+
+
+class Query:
+    berth_lease = graphene.relay.Node.Field(BerthLeaseNode)
+    berth_leases = DjangoConnectionField(BerthLeaseNode)
+
+    @login_required
+    @superuser_required
+    # TODO: Should check if the user has permissions to access these objects
+    def resolve_berth_leases(self, info, **kwargs):
+        return BerthLease.objects.select_related(
+            "application",
+            "application__customer",
+            "berth",
+            "berth__pier",
+            "berth__pier__harbor",
+        ).prefetch_related("application__customer__boats")

--- a/leases/tests/conftest.py
+++ b/leases/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from applications.tests.conftest import *  # noqa
 from berth_reservations.tests.conftest import *  # noqa
 from customers.tests.factories import BoatFactory
 

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -1,0 +1,177 @@
+import pytest
+from graphql_relay import to_global_id
+
+from berth_reservations.tests.utils import (
+    assert_not_enough_permissions,
+    GraphQLTestClient,
+)
+
+client = GraphQLTestClient()
+
+GRAPHQL_URL = "/graphql_v2/"
+
+QUERY_BERTH_LEASES = """
+query GetBerthLeases {
+  berthLeases {
+    edges {
+      node {
+        id
+        status
+        startDate
+        endDate
+        comment
+        boat {
+          id
+        }
+        customer {
+          id
+          boats {
+            id
+          }
+        }
+        application {
+          id
+          customer {
+            id
+          }
+        }
+        berth {
+          id
+          number
+          berthType {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_query_berth_leases(superuser, berth_lease, berth_application):
+    berth_application.customer = berth_lease.customer
+    berth_application.save()
+    berth_lease.application = berth_application
+    berth_lease.save()
+
+    executed = client.execute(
+        query=QUERY_BERTH_LEASES, graphql_url=GRAPHQL_URL, user=superuser,
+    )
+
+    berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
+    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
+    berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
+    customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
+    boat_id = str(berth_lease.boat.id)
+
+    assert executed["data"]["berthLeases"]["edges"][0]["node"] == {
+        "id": berth_lease_id,
+        "status": "OFFERED",
+        "startDate": str(berth_lease.start_date),
+        "endDate": str(berth_lease.end_date),
+        "comment": berth_lease.comment,
+        "boat": {"id": boat_id},
+        "customer": {"id": customer_id, "boats": [{"id": boat_id}]},
+        "application": {"id": berth_application_id, "customer": {"id": customer_id}},
+        "berth": {
+            "id": to_global_id("BerthNode", berth_lease.berth.id),
+            "number": str(berth_lease.berth.number),
+            "berthType": {"id": berth_type_id},
+        },
+    }
+
+
+@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
+def test_query_berth_leases_not_enough_permissions(user):
+    executed = client.execute(
+        query=QUERY_BERTH_LEASES, graphql_url=GRAPHQL_URL, user=user,
+    )
+
+    assert_not_enough_permissions(executed)
+
+
+QUERY_BERTH_LEASE = """
+query GetBerthLease {
+  berthLease(id: "%s") {
+    id
+    status
+    startDate
+    endDate
+    comment
+    boat {
+      id
+    }
+    customer {
+      id
+      boats {
+        id
+      }
+    }
+    application {
+      id
+      customer {
+        id
+      }
+    }
+    berth {
+      id
+      number
+      berthType {
+        id
+      }
+    }
+  }
+}
+"""
+
+
+def test_query_berth_lease(superuser, berth_lease, berth_application):
+    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
+
+    berth_application.customer = berth_lease.customer
+    berth_application.save()
+    berth_lease.application = berth_application
+    berth_lease.save()
+
+    query = QUERY_BERTH_LEASE % berth_lease_id
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser,)
+
+    berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
+    berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
+    customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
+    boat_id = str(berth_lease.boat.id)
+
+    assert executed["data"]["berthLease"] == {
+        "id": berth_lease_id,
+        "status": "OFFERED",
+        "startDate": str(berth_lease.start_date),
+        "endDate": str(berth_lease.end_date),
+        "comment": berth_lease.comment,
+        "boat": {"id": boat_id},
+        "customer": {"id": customer_id, "boats": [{"id": boat_id}]},
+        "application": {"id": berth_application_id, "customer": {"id": customer_id}},
+        "berth": {
+            "id": to_global_id("BerthNode", berth_lease.berth.id),
+            "number": str(berth_lease.berth.number),
+            "berthType": {"id": berth_type_id},
+        },
+    }
+
+
+@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
+def test_query_berth_lease_not_enough_permissions_valid_id(user, berth_lease):
+    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
+
+    query = QUERY_BERTH_LEASE % berth_lease_id
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=user,)
+
+    assert_not_enough_permissions(executed)
+
+
+def test_query_berth_lease_invalid_id(user):
+    executed = client.execute(
+        query=QUERY_BERTH_LEASE, graphql_url=GRAPHQL_URL, user=user,
+    )
+
+    assert executed["data"]["berthLease"] is None


### PR DESCRIPTION
## Description ✨ 
* Split the "old" and "new" GQL schemas in two sparate files to avoid type conflicts
* Add a custom `AuthorizationNode(graphene.relay.Node)` to secure `Node` queries which require permissions
* Add queries to fetch `Leases`

## Issues 🐛 
Close [VEN-348](https://helsinkisolutionoffice.atlassian.net/browse/VEN-348)

## Test ⚗️ 
To test using `pytest`, run:
```sh
$  pytest leases/tests/test_lease_queries.py
```

To test manually, run the following queries:
```graphql
query GetLeases {
  berthLeases {
    edges {
      node {
        id
        createdAt
        modifiedAt
        status
        startDate
        endDate
        comment
        boat {
          id
          name
        }
        customer {
          id
          invoicingType
          comment
          createdAt
          modifiedAt
          boats {
            id
            name
          }
        }
        application {
          id
          customer {
            boats {
              name
            }
          }
        }
        berth {
          id
          number
          berthType {
            id
          }
        }
      }
    }
  }
}

query GetLease {
  berthLease(id: "") {
    id
    application {
      id
      customer {
        boats {
          name
        }
      }
    }
    berth {
      id
      number
      berthType {
        id
        width
        length
      }
    }
  }
}
```