### PR TITLE
Use Node from relay to resolve BerthProfileNode

### DIFF
--- a/customers/schema.py
+++ b/customers/schema.py
@@ -90,7 +90,7 @@ class BoatNode(DjangoObjectType):
 
 
 class Query:
-    berth_profile = graphene.Field(BerthProfileNode)
+    berth_profile = graphene.relay.Node.Field(BerthProfileNode)
     berth_profiles = DjangoFilterConnectionField(BerthProfileNode)
 
     @login_required


### PR DESCRIPTION
## Description :sparkles:

Since BerthProfileNode implements relay.Node, we should use it to
resolve single nodes too.

