### PR TITLE
Specify explicitly available fields on berths and winter places

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -85,6 +85,7 @@ class BerthTypeNode(DjangoObjectType):
 class BerthNode(DjangoObjectType):
     class Meta:
         model = Berth
+        fields = ("id", "number", "pier", "berth_type", "comment")
         interfaces = (relay.Node,)
 
 
@@ -126,6 +127,7 @@ class WinterStoragePlaceTypeNode(DjangoObjectType):
 class WinterStoragePlaceNode(DjangoObjectType):
     class Meta:
         model = WinterStoragePlace
+        fields = ("id", "number", "winter_storage_section", "place_type")
         interfaces = (relay.Node,)
 
 


### PR DESCRIPTION
## Description :sparkles:

This way we ensure that this public types only have the fields
we explicitly marked as available.

