### PR TITLE
VEN-435 | servicemap_id filter

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -590,6 +590,9 @@ class Query:
     piers = DjangoFilterConnectionField(PierNode)
 
     harbor = relay.Node.Field(HarborNode)
+    harbor_by_servicemap_id = graphene.Field(
+        HarborNode, servicemap_id=graphene.String(required=True)
+    )
     harbors = DjangoFilterConnectionField(
         HarborNode, servicemap_ids=graphene.List(graphene.String)
     )
@@ -633,6 +636,9 @@ class Query:
             "harbor__availability_level__translations",
             "harbor__municipality__translations",
         ).select_related("harbor", "harbor__availability_level", "harbor__municipality")
+
+    def resolve_harbor_by_servicemap_id(self, info, **kwargs):
+        return Harbor.objects.filter(servicemap_id=kwargs.get("servicemap_id")).first()
 
     def resolve_harbors(self, info, **kwargs):
         # TODO: optimize this further

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -590,7 +590,9 @@ class Query:
     piers = DjangoFilterConnectionField(PierNode)
 
     harbor = relay.Node.Field(HarborNode)
-    harbors = DjangoFilterConnectionField(HarborNode)
+    harbors = DjangoFilterConnectionField(
+        HarborNode, servicemap_ids=graphene.List(graphene.String)
+    )
 
     winter_storage_place_type = relay.Node.Field(WinterStoragePlaceTypeNode)
     winter_storage_place_types = DjangoConnectionField(WinterStoragePlaceTypeNode)
@@ -638,20 +640,22 @@ class Query:
         # although, django-graphene might introduce fixes for this
         # so, check the state of this against a newer version later
 
-        return (
-            Harbor.objects.all()
-            .prefetch_related(
-                "translations",
-                Prefetch(
-                    "piers",
-                    queryset=Pier.objects.prefetch_related(
-                        Prefetch("berths", queryset=Berth.objects.all())
-                    ),
-                ),
-                "piers__suitable_boat_types",
-            )
-            .select_related("availability_level", "municipality")
+        servicemap_ids = kwargs.get("servicemap_ids", None)
+        qs = (
+            Harbor.objects.filter(servicemap_id__in=servicemap_ids)
+            if servicemap_ids
+            else Harbor.objects.all()
         )
+        return qs.prefetch_related(
+            "translations",
+            Prefetch(
+                "piers",
+                queryset=Pier.objects.prefetch_related(
+                    Prefetch("berths", queryset=Berth.objects.all())
+                ),
+            ),
+            "piers__suitable_boat_types",
+        ).select_related("availability_level", "municipality")
 
     def resolve_winter_storage_places(self, info, **kwargs):
         return WinterStoragePlace.objects.prefetch_related(


### PR DESCRIPTION
## Description :sparkles:
* Add a `servicemapIds` filter to the `harbors` query
  * The query takes as filter a string containing a comma serparated list of the desired IDs: `harbors(servicemapIds: ["41234", "41321"]) {}`
* Add a query `harborByServicemapId` to fetch a specific harbor

## Issues :bug:
Closes [VEN-435](https://helsinkisolutionoffice.atlassian.net/browse/VEN-435)
## Testing :alembic:
```graphql
query HarborIds {
  harbors(servicemapIds: ["41234"]) {
    edges {
      node {
        id
        properties {
          name
          servicemapId
        }
      }
    }
  }
}

query Harbor {
  harborByServicemapId(servicemapId: "41234") {
    id
    properties {
      name
      servicemapId
    }
  }
}
```