### PR TITLE
Fix resources' schema

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -75,13 +75,12 @@ class PierNode(graphql_geojson.GeoJSONType):
 
 
 class BerthTypeNode(DjangoObjectType):
-    width = graphene.Float(description=_("width (m)"))
-    length = graphene.Float(description=_("length (m)"))
-
     class Meta:
         model = BerthType
         interfaces = (relay.Node,)
 
+    width = graphene.Float(description=_("width (m)"), required=True)
+    length = graphene.Float(description=_("length (m)"), required=True)
     mooring_type = BerthMooringTypeEnum(required=True)
 
 
@@ -122,12 +121,12 @@ class HarborNode(graphql_geojson.GeoJSONType):
 
 
 class WinterStoragePlaceTypeNode(DjangoObjectType):
-    width = graphene.Float(description=_("width (m)"))
-    length = graphene.Float(description=_("length (m)"))
-
     class Meta:
         model = WinterStoragePlaceType
         interfaces = (relay.Node,)
+
+    width = graphene.Float(description=_("width (m)"), required=True)
+    length = graphene.Float(description=_("length (m)"), required=True)
 
 
 class WinterStoragePlaceNode(DjangoObjectType):


### PR DESCRIPTION
## Description :sparkles:

BerthType and WinterStoragePlaceType have non-nullable dimensions,
so mark them as required in the schema. Also, this file has fields
after the Meta options of each type, so move these there. At some
point we should decide if fields should come before or after Meta
options and use that across the entire codebase.

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/24206160/74508297-5ead4300-4f07-11ea-9b2f-4835f5444876.png)
