### PR TITLE
Add NO_CUSTOMER filter to applications and test

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -50,6 +50,9 @@ class BerthApplicationFilter(django_filters.FilterSet):
     switch_applications = django_filters.BooleanFilter(
         field_name="berth_switch", method="filter_berth_switch"
     )
+    no_customer = django_filters.BooleanFilter(
+        field_name="customer", lookup_expr="isnull"
+    )
 
     def filter_berth_switch(self, queryset, name, value):
         lookup = "__".join([name, "isnull"])

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -1,0 +1,66 @@
+from graphql_relay.node.node import to_global_id
+
+from berth_reservations.tests.utils import GraphQLTestClient
+
+GRAPHQL_URL = "/graphql_v2/"
+
+
+def test_berth_applications_no_customer_filter_true(berth_application, superuser):
+    berth_application.customer = None
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(noCustomer: true) {
+                edges {
+                    node {
+                        id
+                        customer {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+
+    assert executed["data"] == {
+        "berthApplications": {
+            "edges": [
+                {
+                    "node": {
+                        "id": to_global_id(
+                            "BerthApplicationNode", berth_application.id
+                        ),
+                        "customer": None,
+                    }
+                }
+            ]
+        }
+    }
+
+
+def test_berth_applications_no_customer_filter_false(berth_application, superuser):
+    berth_application.customer = None
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(noCustomer: false) {
+                edges {
+                    node {
+                        id
+                        customer {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+
+    assert executed["data"] == {"berthApplications": {"edges": []}}


### PR DESCRIPTION
## Description :sparkles:
* Add a filter for `BerthApplications` to filter based on whether the application has a customer or not
* Add tests for the filtered query

## Issues :bug:
Close [VEN-484](https://helsinkisolutionoffice.atlassian.net/browse/VEN-484)

## Testing :alembic:
**Automated tests ⚙️**
```shell
$ pytest applications/tests/test_applications_new_schema_queries.py
```

**Manual testing 👷** 
```graphql
query APPLICATIONS {
  berthApplications(noCustomer: true) {
    edges {
      node {
        id
        berthSwitch {
          reason {
            id
          }
        }
      }
    }
  }
}
```

## Screenshots :camera_flash:
**No customer= true**
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/15201480/75141419-8bc4d700-56f9-11ea-9330-9c0d0f05ab5c.png">

**No customer = false**
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/15201480/75141445-9bdcb680-56f9-11ea-9656-a2b81e7e0bbe.png">
