### PR TITLE
VEN-483 | Delete drafted BerthLeases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,9 @@
 ## Issues :bug:
 
 ## Testing :alembic:
+**Automated tests ⚙️**
+
+**Manual testing 👷** 
 
 ## Screenshots :camera_flash:
 


### PR DESCRIPTION
## Description :sparkles:
* Add mutation to delete BerthLease and tests

## Issues :bug:
Closes [VEN-483](https://helsinkisolutionoffice.atlassian.net/browse/VEN-483)

## Testing :alembic:
**Automated tests ⚙️**
```shell
$ pytest leases/tests/test_lease_mutations.py
```

**Manual testing 👷** 
```graphql
mutation DELETE_DRAFTED_APPLICATION($input: DeleteBerthLeaseMutationInput!) {
  deleteBerthLease(input: $input) {
    __typename
  }
}
```
Input:
```json
{
  "input": {
    "id": ""
  }
}
```

## Screenshots 📸 
<img width="349" alt="image" src="https://user-images.githubusercontent.com/15201480/75151862-511a6900-5710-11ea-897e-865183f7a371.png">


## Additional notes :spiral_notepad:
As per the [task descripiton](https://helsinkisolutionoffice.atlassian.net/browse/VEN-483):
> MVP solution: only allow deleting if the status is DRAFTED

If the BerthLease receives a lease that has already been moved from `DRAFTED`, it will throw a `VenepaikkaGraphQLError` saying:
```python
raise VenepaikkaGraphQLError(
    _(f"Lease object is not DRAFTED anymore: {lease.status}")
)
```