### PR TITLE
Rename objects and fields reservation -> application

### DIFF
--- a/applications/schema.py
+++ b/applications/schema.py
@@ -25,7 +25,7 @@ class HarborChoiceType(DjangoObjectType):
         model = HarborChoice
 
 
-class BerthReservationType(DjangoObjectType):
+class BerthApplicationType(DjangoObjectType):
     class Meta:
         model = BerthApplication
         exclude = (
@@ -48,7 +48,7 @@ class BerthSwitchReasonType(DjangoObjectType):
     title = graphene.String()
 
 
-class WinterStorageReservationType(DjangoObjectType):
+class WinterStorageApplicationType(DjangoObjectType):
     class Meta:
         model = WinterStorageApplication
 
@@ -70,7 +70,7 @@ class BerthSwitchInput(graphene.InputObjectType):
     reason = graphene.ID()
 
 
-class BaseReservationInput(graphene.InputObjectType):
+class BaseApplicationInput(graphene.InputObjectType):
     language = graphene.String(required=True)
     first_name = graphene.String(required=True)
     last_name = graphene.String(required=True)
@@ -95,7 +95,7 @@ class BaseReservationInput(graphene.InputObjectType):
     information_accuracy_confirmed = graphene.Boolean(required=True)
 
 
-class BerthReservationInput(BaseReservationInput):
+class BerthApplicationInput(BaseApplicationInput):
     boat_draught = graphene.Float()
     boat_weight = graphene.Float()
     accessibility_required = graphene.Boolean()
@@ -111,7 +111,7 @@ class BerthReservationInput(BaseReservationInput):
     choices = graphene.List(graphene.NonNull(HarborChoiceInput), required=True)
 
 
-class WinterStorageReservationInput(BaseReservationInput):
+class WinterStorageApplicationInput(BaseApplicationInput):
     storage_method = WinterStorageMethodEnum(required=True)
     trailer_registration_number = graphene.String()
     chosen_areas = graphene.List(
@@ -119,20 +119,20 @@ class WinterStorageReservationInput(BaseReservationInput):
     )
 
 
-class CreateBerthReservation(graphene.Mutation):
+class CreateBerthApplication(graphene.Mutation):
     class Arguments:
-        berth_reservation = BerthReservationInput(required=True)
+        berth_application = BerthApplicationInput(required=True)
         berth_switch = BerthSwitchInput()
 
     ok = graphene.Boolean()
-    berth_reservation = graphene.Field(BerthReservationType)
+    berth_application = graphene.Field(BerthApplicationType)
 
     def mutate(self, info, **kwargs):
-        reservation_data = kwargs.pop("berth_reservation")
+        application_data = kwargs.pop("berth_application")
 
-        boat_type_id = reservation_data.pop("boat_type", None)
+        boat_type_id = application_data.pop("boat_type", None)
         if boat_type_id:
-            reservation_data["boat_type"] = BoatType.objects.get(id=int(boat_type_id))
+            application_data["boat_type"] = BoatType.objects.get(id=int(boat_type_id))
 
         switch_data = kwargs.pop("berth_switch", None)
         if switch_data:
@@ -146,43 +146,43 @@ class CreateBerthReservation(graphene.Mutation):
                 berth_number=switch_data.get("berth_number"),
                 reason=reason,
             )
-            reservation_data["berth_switch"] = berth_switch
+            application_data["berth_switch"] = berth_switch
 
-        choices = reservation_data.pop("choices", [])
+        choices = application_data.pop("choices", [])
 
-        reservation = BerthApplication.objects.create(**reservation_data)
+        application = BerthApplication.objects.create(**application_data)
 
         for choice in choices:
             harbor_id = from_global_id(choice.get("harbor_id"))[1]
             harbor = Harbor.objects.get(id=harbor_id)
             HarborChoice.objects.get_or_create(
-                harbor=harbor, priority=choice.get("priority"), application=reservation
+                harbor=harbor, priority=choice.get("priority"), application=application
             )
 
         # Send notifications when all m2m relations are saved
-        application_saved.send(sender="CreateBerthReservation", application=reservation)
+        application_saved.send(sender="CreateBerthApplication", application=application)
 
         ok = True
-        return CreateBerthReservation(berth_reservation=reservation, ok=ok)
+        return CreateBerthApplication(berth_application=application, ok=ok)
 
 
-class CreateWinterStorageReservation(graphene.Mutation):
+class CreateWinterStorageApplication(graphene.Mutation):
     class Arguments:
-        winter_storage_reservation = WinterStorageReservationInput(required=True)
+        winter_storage_application = WinterStorageApplicationInput(required=True)
 
     ok = graphene.Boolean()
-    winter_storage_reservation = graphene.Field(WinterStorageReservationType)
+    winter_storage_application = graphene.Field(WinterStorageApplicationType)
 
     def mutate(self, info, **kwargs):
-        reservation_data = kwargs.pop("winter_storage_reservation")
+        application_data = kwargs.pop("winter_storage_application")
 
-        boat_type_id = reservation_data.pop("boat_type", None)
+        boat_type_id = application_data.pop("boat_type", None)
         if boat_type_id:
-            reservation_data["boat_type"] = BoatType.objects.get(id=int(boat_type_id))
+            application_data["boat_type"] = BoatType.objects.get(id=int(boat_type_id))
 
-        chosen_areas = reservation_data.pop("chosen_areas", [])
+        chosen_areas = application_data.pop("chosen_areas", [])
 
-        reservation = WinterStorageApplication.objects.create(**reservation_data)
+        application = WinterStorageApplication.objects.create(**application_data)
 
         for choice in chosen_areas:
             winter_area_id = from_global_id(choice.get("winter_area_id"))[1]
@@ -190,23 +190,23 @@ class CreateWinterStorageReservation(graphene.Mutation):
             WinterStorageAreaChoice.objects.get_or_create(
                 winter_storage_area=winter_storage_area,
                 priority=choice.get("priority"),
-                application=reservation,
+                application=application,
             )
 
         # Send notifications when all m2m relations are saved
         application_saved.send(
-            sender="CreateWinterStorageReservation", application=reservation
+            sender="CreateWinterStorageApplication", application=application
         )
 
         ok = True
-        return CreateWinterStorageReservation(
-            winter_storage_reservation=reservation, ok=ok
+        return CreateWinterStorageApplication(
+            winter_storage_application=application, ok=ok
         )
 
 
 class Mutation:
-    create_berth_reservation = CreateBerthReservation.Field()
-    create_winter_storage_reservation = CreateWinterStorageReservation.Field()
+    create_berth_application = CreateBerthApplication.Field()
+    create_winter_storage_application = CreateWinterStorageApplication.Field()
 
 
 class Query:

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -11,7 +11,7 @@ application_saved = Signal(providing_args=["application"])
 
 def application_notification_handler(sender, application, **kwargs):
     notification_type = NotificationType.BERTH_APPLICATION_CREATED.value
-    if sender == "CreateWinterStorageReservation":
+    if sender == "CreateWinterStorageApplication":
         notification_type = NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value
     try:
         send_notification(

--- a/applications/tests/test_reservations_graphql.py
+++ b/applications/tests/test_reservations_graphql.py
@@ -6,19 +6,19 @@ from berth_reservations.tests.utils import GraphQLTestClient
 from harbors.schema import HarborType, WinterStorageAreaType
 
 
-def test_create_berth_reservation(boat_type, harbor, berth_switch_reason):
+def test_create_berth_application(boat_type, harbor, berth_switch_reason):
     client = GraphQLTestClient()
     t = Template(
         """
-        mutation createBerthReservation {
-            createBerthReservation(
+        mutation createBerthApplication {
+            createBerthApplication(
                 berthSwitch: {
                     harborId: \"${current_harbor}\",
                     pier: "dinkkypier",
                     berthNumber: "D33",
                     reason: ${berth_switch_reason_id}
                 },
-                berthReservation: {
+                berthApplication: {
                     language: "en",
                     firstName: "John",
                     lastName: "Doe",
@@ -43,7 +43,7 @@ def test_create_berth_reservation(boat_type, harbor, berth_switch_reason):
                     ]
                 }
             ) {
-                berthReservation {
+                berthApplication {
                     berthSwitch {
                         berthNumber,
                         reason {
@@ -74,8 +74,8 @@ def test_create_berth_reservation(boat_type, harbor, berth_switch_reason):
     executed = client.execute(mutation)
     assert executed == {
         "data": {
-            "createBerthReservation": {
-                "berthReservation": {
+            "createBerthApplication": {
+                "berthApplication": {
                     "berthSwitch": {
                         "berthNumber": "D33",
                         "reason": {"id": str(berth_switch_reason.id)},
@@ -89,18 +89,18 @@ def test_create_berth_reservation(boat_type, harbor, berth_switch_reason):
     }
 
 
-def test_create_berth_reservation_wo_reason(boat_type, harbor):
+def test_create_berth_application_wo_reason(boat_type, harbor):
     client = GraphQLTestClient()
     t = Template(
         """
-        mutation createBerthReservation {
-            createBerthReservation(
+        mutation createBerthApplication {
+            createBerthApplication(
                 berthSwitch: {
                     harborId: \"${current_harbor}\",
                     pier: "dinkkypier",
                     berthNumber: "D33",
                 },
-                berthReservation: {
+                berthApplication: {
                     language: "en",
                     firstName: "John",
                     lastName: "Doe",
@@ -125,7 +125,7 @@ def test_create_berth_reservation_wo_reason(boat_type, harbor):
                     ]
                 }
             ) {
-                berthReservation {
+                berthApplication {
                     berthSwitch {
                         berthNumber,
                         reason {
@@ -155,8 +155,8 @@ def test_create_berth_reservation_wo_reason(boat_type, harbor):
     executed = client.execute(mutation)
     assert executed == {
         "data": {
-            "createBerthReservation": {
-                "berthReservation": {
+            "createBerthApplication": {
+                "berthApplication": {
                     "berthSwitch": {"berthNumber": "D33", "reason": None},
                     "chosenHarbors": {
                         "edges": [{"node": {"properties": {"zipCode": "00100"}}}]
@@ -167,13 +167,13 @@ def test_create_berth_reservation_wo_reason(boat_type, harbor):
     }
 
 
-def test_create_winter_storage_reservation(boat_type, winter_area):
+def test_create_winter_storage_application(boat_type, winter_area):
     client = GraphQLTestClient()
     t = Template(
         """
-        mutation createWinterStorageReservation {
-            createWinterStorageReservation(
-                winterStorageReservation: {
+        mutation createWinterStorageApplication {
+            createWinterStorageApplication(
+                winterStorageApplication: {
                     language: "en",
                     firstName: "John",
                     lastName: "Doe",
@@ -199,7 +199,7 @@ def test_create_winter_storage_reservation(boat_type, winter_area):
                     ]
                 }
             ) {
-                winterStorageReservation {
+                winterStorageApplication {
                     chosenAreas {
                         edges {
                             node {
@@ -219,8 +219,8 @@ def test_create_winter_storage_reservation(boat_type, winter_area):
     executed = client.execute(mutation)
     assert executed == {
         "data": {
-            "createWinterStorageReservation": {
-                "winterStorageReservation": {
+            "createWinterStorageApplication": {
+                "winterStorageApplication": {
                     "chosenAreas": {
                         "edges": [{"node": {"properties": {"zipCode": "00200"}}}]
                     }

--- a/applications/tests/test_reservations_notifications.py
+++ b/applications/tests/test_reservations_notifications.py
@@ -31,7 +31,7 @@ def test_berth_application_created_notification_is_sent(
     notification_template_berth_application_created,
 ):
     application = BerthApplicationFactory()
-    application_saved.send(sender="CreateBerthReservation", application=application)
+    application_saved.send(sender="CreateBerthApplication", application=application)
 
     assert len(mail.outbox) == 1
     msg = mail.outbox[0]
@@ -45,7 +45,7 @@ def test_winter_application_created_notification_is_sent(
 ):
     application = WinterStorageApplicationFactory()
     application_saved.send(
-        sender="CreateWinterStorageReservation", application=application
+        sender="CreateWinterStorageApplication", application=application
     )
 
     assert len(mail.outbox) == 1


### PR DESCRIPTION
## Description :sparkles:
* Rename all `Reservation` related stuff to `Application`

## Issues :bug:
Closes [VEN-425](https://helsinkisolutionoffice.atlassian.net/browse/VEN-425)

## Testing :alembic:
**Automated tests ⚙️**
```shell
$ pyest applications
```

## Additional notes :spiral_notepad:
Has to be merged simultaneously with [https://github.com/City-of-Helsinki/berth-reservations-ui/pull/261](https://github.com/City-of-Helsinki/berth-reservations-ui/pull/261) to avoid breaking everything.