### PR TITLE
VEN-455 | Application status filter

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -122,14 +122,29 @@ class UpdateBerthApplication(graphene.ClientIDMutation):
 class Query:
     berth_application = graphene.relay.Node.Field(BerthApplicationNode)
     berth_applications = DjangoFilterConnectionField(
-        BerthApplicationNode, filterset_class=BerthApplicationFilter
+        BerthApplicationNode,
+        filterset_class=BerthApplicationFilter,
+        statuses=graphene.List(ApplicationStatusEnum),
+        description="The `statuses` filter takes a list of `ApplicationStatus` values "
+        "representing the desired statuses. If an empty list is passed, no filter will be applied "
+        "and all the results will be returned."
+        "\n\n**Requires permissions** to access applications."
+        "\n\nErrors:"
+        "\n* A value passed is not a valid status",
     )
 
     @login_required
     @superuser_required
     # TODO: Should check if the user has permissions to access these objects
     def resolve_berth_applications(self, info, **kwargs):
-        return BerthApplication.objects.select_related(
+        statuses = kwargs.pop("statuses", [])
+
+        qs = BerthApplication.objects
+
+        if statuses:
+            qs = qs.filter(status__in=statuses)
+
+        return qs.select_related(
             "boat_type", "berth_switch", "berth_switch__harbor", "berth_switch__reason",
         ).prefetch_related(
             "berth_switch__reason__translations",

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -1,6 +1,7 @@
 from graphql_relay.node.node import to_global_id
 
-from berth_reservations.tests.utils import GraphQLTestClient
+from applications.enums import ApplicationStatus
+from berth_reservations.tests.utils import assert_in_errors, GraphQLTestClient
 
 GRAPHQL_URL = "/graphql_v2/"
 
@@ -64,3 +65,118 @@ def test_berth_applications_no_customer_filter_false(berth_application, superuse
     executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
 
     assert executed["data"] == {"berthApplications": {"edges": []}}
+
+
+def test_berth_applications_statuses_filter(berth_application, superuser):
+    berth_application.status = ApplicationStatus.HANDLED
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(statuses: [HANDLED]) {
+                edges {
+                    node {
+                        id
+                        status
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+
+    assert executed["data"] == {
+        "berthApplications": {
+            "edges": [
+                {
+                    "node": {
+                        "id": to_global_id(
+                            "BerthApplicationNode", berth_application.id
+                        ),
+                        "status": ApplicationStatus.HANDLED.name,
+                    }
+                }
+            ]
+        }
+    }
+
+
+def test_berth_applications_statuses_filter_empty(berth_application, superuser):
+    berth_application.status = ApplicationStatus.HANDLED
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(statuses: [PENDING]) {
+                edges {
+                    node {
+                        id
+                        status
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+
+    assert executed["data"] == {"berthApplications": {"edges": []}}
+
+
+def test_berth_applications_statuses_filter_invalid_enum(berth_application, superuser):
+    berth_application.status = ApplicationStatus.HANDLED
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(statuses: [FOOBAR]) {
+                edges {
+                    node {
+                        id
+                        status
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+    assert_in_errors(
+        "invalid value [FOOBAR].", executed,
+    )
+
+
+def test_berth_applications_statuses_filter_empty_list(berth_application, superuser):
+    berth_application.status = ApplicationStatus.HANDLED
+    berth_application.save()
+
+    client = GraphQLTestClient()
+    query = """
+        query APPLICATIONS {
+            berthApplications(statuses: []) {
+                edges {
+                    node {
+                        id
+                        status
+                    }
+                }
+            }
+        }
+    """
+    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser)
+
+    assert executed["data"] == {
+        "berthApplications": {
+            "edges": [
+                {
+                    "node": {
+                        "id": to_global_id(
+                            "BerthApplicationNode", berth_application.id
+                        ),
+                        "status": ApplicationStatus.HANDLED.name,
+                    }
+                }
+            ]
+        }
+    }


### PR DESCRIPTION
## Description :sparkles:
* Add a filter to pass a list of desired statuses and tests

## Issues :bug:
Closes [VEN-455](https://helsinkisolutionoffice.atlassian.net/browse/VEN-455)

## Testing :alembic:
**Automated tests ⚙️**
```shell
$ pytest applications/tests/test_applications_new_schema_queries.py
```

**Manual testing 👷** 
```graphql
query Applications {
  berthApplications(statuses:["PENDING"]) {
    edges {
      node {
        id
        status
        customer {
          id
        }
      }
    }
  }
}
```

## Screenshots :camera_flash:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/15201480/75332729-8b5d4500-588d-11ea-9452-0ecae786fc5b.png">