### PR TITLE
Make all the fields of Profile nodes nullable in our GQL API

### DIFF
--- a/customers/tests/test_customers_schema.py
+++ b/customers/tests/test_customers_schema.py
@@ -44,7 +44,11 @@ query GetBerthProfiles {
                     name
                 }
                 boats {
-                    id
+                    edges {
+                        node {
+                            id
+                        }
+                    }
                 }
                 berthApplications {
                     edges {
@@ -78,6 +82,7 @@ def test_query_berth_profiles(superuser, customer_profile):
     )
 
     customer_id = to_global_id("BerthProfileNode", customer_profile.id)
+    boat_id = to_global_id("BoatNode", boat.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
 
@@ -86,7 +91,7 @@ def test_query_berth_profiles(superuser, customer_profile):
         "invoicingType": customer_profile.invoicing_type.name,
         "comment": customer_profile.comment,
         "company": {"businessId": company.business_id, "name": company.name},
-        "boats": [{"id": str(boat.id)}],
+        "boats": {"edges": [{"node": {"id": boat_id}}]},
         "berthApplications": {"edges": [{"node": {"id": berth_application_id}}]},
         "berthLeases": {"edges": [{"node": {"id": berth_lease_id}}]},
     }
@@ -112,7 +117,11 @@ query GetBerthProfile {
             name
         }
         boats {
-            id
+            edges {
+                node {
+                    id
+                }
+            }
         }
         berthApplications {
             edges {
@@ -149,6 +158,7 @@ def test_query_berth_profile(is_superuser, superuser, customer_profile):
 
     executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=gql_user)
 
+    boat_id = to_global_id("BoatNode", boat.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
 
@@ -157,7 +167,7 @@ def test_query_berth_profile(is_superuser, superuser, customer_profile):
         "invoicingType": customer_profile.invoicing_type.name,
         "comment": customer_profile.comment,
         "company": {"businessId": company.business_id, "name": company.name},
-        "boats": [{"id": str(boat.id)}],
+        "boats": {"edges": [{"node": {"id": boat_id}}]},
         "berthApplications": {"edges": [{"node": {"id": berth_application_id}}]},
         "berthLeases": {"edges": [{"node": {"id": berth_lease_id}}]},
     }

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -79,7 +79,11 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
         input["customer"] = application.customer
 
         if input.get("boat_id", False):
-            boat = Boat.objects.filter(pk=input.pop("boat_id")).first()
+            boat_id = from_global_id(input.pop("boat_id"))[1]
+            try:
+                boat = Boat.objects.get(pk=boat_id)
+            except Boat.DoesNotExist:
+                raise VenepaikkaGraphQLError(_("There is no boat with the given id."))
 
             if boat.owner.id != input["customer"].id:
                 raise VenepaikkaGraphQLError(

--- a/leases/tests/test_lease_mutations.py
+++ b/leases/tests/test_lease_mutations.py
@@ -94,7 +94,7 @@ def test_create_berth_lease_all_arguments(
     variables = {
         "applicationId": to_global_id("BerthApplicationNode", berth_application.id),
         "berthId": to_global_id("BerthNode", berth.id),
-        "boatId": str(boat.id),
+        "boatId": to_global_id("BoatNode", boat.id),
         "startDate": "2020-03-01",
         "endDate": "2020-12-31",
         "comment": "Very wow, such comment",

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -26,7 +26,11 @@ query GetBerthLeases {
                 customer {
                     id
                     boats {
-                        id
+                        edges {
+                            node {
+                                id
+                            }
+                        }
                     }
                 }
                 application {
@@ -63,7 +67,7 @@ def test_query_berth_leases(superuser, berth_lease, berth_application):
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
     customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
-    boat_id = str(berth_lease.boat.id)
+    boat_id = to_global_id("BoatNode", berth_lease.boat.id)
 
     assert executed["data"]["berthLeases"]["edges"][0]["node"] == {
         "id": berth_lease_id,
@@ -72,7 +76,10 @@ def test_query_berth_leases(superuser, berth_lease, berth_application):
         "endDate": str(berth_lease.end_date),
         "comment": berth_lease.comment,
         "boat": {"id": boat_id},
-        "customer": {"id": customer_id, "boats": [{"id": boat_id}]},
+        "customer": {
+            "id": customer_id,
+            "boats": {"edges": [{"node": {"id": boat_id}}]},
+        },
         "application": {"id": berth_application_id, "customer": {"id": customer_id}},
         "berth": {
             "id": to_global_id("BerthNode", berth_lease.berth.id),
@@ -105,7 +112,11 @@ query GetBerthLease {
         customer {
             id
             boats {
-                id
+                edges {
+                    node {
+                        id
+                    }
+                }
             }
         }
         application {
@@ -140,7 +151,7 @@ def test_query_berth_lease(superuser, berth_lease, berth_application):
     berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
     customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
-    boat_id = str(berth_lease.boat.id)
+    boat_id = to_global_id("BoatNode", berth_lease.boat.id)
 
     assert executed["data"]["berthLease"] == {
         "id": berth_lease_id,
@@ -149,7 +160,10 @@ def test_query_berth_lease(superuser, berth_lease, berth_application):
         "endDate": str(berth_lease.end_date),
         "comment": berth_lease.comment,
         "boat": {"id": boat_id},
-        "customer": {"id": customer_id, "boats": [{"id": boat_id}]},
+        "customer": {
+            "id": customer_id,
+            "boats": {"edges": [{"node": {"id": boat_id}}]},
+        },
         "application": {"id": berth_application_id, "customer": {"id": customer_id}},
         "berth": {
             "id": to_global_id("BerthNode", berth_lease.berth.id),


### PR DESCRIPTION
## Description :sparkles:

1. Since ProfileNode is extended, none of its fields could be
non-nullable (i.e. required=True), because then the entire
ProfileNode will be null at the federation level, if the
profile object has no object in our database.

2. Make `BoatNode` actually implement `relay.Node` interface.

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/24206160/75353989-ed7d7080-58b4-11ea-86f7-daca2afd8041.png)

