### PR TITLE
VEN-405 | File Upload for Harbor

### DIFF
--- a/berth_reservations/views.py
+++ b/berth_reservations/views.py
@@ -1,10 +1,10 @@
 import sentry_sdk
-from graphene_django.views import GraphQLView
+from graphene_file_upload.django import FileUploadGraphQLView
 
 from .exceptions import VenepaikkaGraphQLError
 
 
-class SentryGraphQLView(GraphQLView):
+class SentryGraphQLView(FileUploadGraphQLView):
     def execute_graphql_request(self, request, data, query, *args, **kwargs):
         """
         Extract any exceptions and send some of them to Sentry.

--- a/requirements.in
+++ b/requirements.in
@@ -15,6 +15,7 @@ django-ilmoitin
 factory-boy
 graphene-django
 graphene-federation
+graphene-file-upload
 pillow
 psycopg2-binary
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,32 +7,33 @@
 aniso8601==7.0.0          # via graphene
 certifi==2019.9.11        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
-coreapi==2.3.3
+coreapi==2.3.3            # via -r requirements.in
 coreschema==0.0.4         # via coreapi
-django-anymail==7.0.0
-django-cors-headers==3.1.1
-django-enumfields==1.0.0
-django-environ==0.4.5
-django-filter==2.2.0
-django-graphql-geojson==0.1.4
-django-graphql-jwt==0.2.2
-django-helusers==0.5.2
-django-ilmoitin==0.2.0
+django-anymail==7.0.0     # via -r requirements.in, django-ilmoitin
+django-cors-headers==3.1.1  # via -r requirements.in
+django-enumfields==1.0.0  # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in
+django-filter==2.2.0      # via -r requirements.in
+django-graphql-geojson==0.1.4  # via -r requirements.in
+django-graphql-jwt==0.2.2  # via -r requirements.in
+django-helusers==0.5.2    # via -r requirements.in
+django-ilmoitin==0.2.0    # via -r requirements.in
 django-js-asset==1.2.2    # via django-mptt
-django-mailer==2.0
+django-mailer==2.0        # via -r requirements.in, django-ilmoitin
 django-mptt==0.10.0       # via django-munigeo
-django-munigeo==0.3.3
+django-munigeo==0.3.3     # via -r requirements.in
 django-parler-rest==2.0   # via django-munigeo
-django-parler==1.9.2
-django==2.2.6
+django-parler==1.9.2      # via -r requirements.in, django-ilmoitin, django-munigeo, django-parler-rest
+django==2.2.6             # via -r requirements.in, django-anymail, django-cors-headers, django-filter, django-graphql-geojson, django-graphql-jwt, django-helusers, django-ilmoitin, django-mailer, django-mptt, django-munigeo, drf-oidc-auth, graphene-django
 djangorestframework==3.10.3  # via django-parler-rest, drf-oidc-auth
 drf-oidc-auth==0.9        # via django-helusers
 ecdsa==0.13.3             # via python-jose
-factory-boy==2.12.0
+factory-boy==2.12.0       # via -r requirements.in
 faker==2.0.3              # via factory-boy
 future==0.18.1            # via pyjwkest, python-jose
-graphene-django==2.6.0
-graphene-federation==0.0.4
+graphene-django==2.6.0    # via -r requirements.in, django-graphql-geojson, django-graphql-jwt
+graphene-federation==0.0.4  # via -r requirements.in
+graphene-file-upload==1.2.2  # via -r requirements.in
 graphene==2.1.8           # via graphene-django, graphene-federation
 graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay
 graphql-relay==2.0.0      # via graphene
@@ -41,9 +42,9 @@ itypes==1.1.0             # via coreapi
 jinja2==2.10.3            # via coreschema, django-ilmoitin
 lockfile==0.12.2          # via django-mailer
 markupsafe==1.1.1         # via jinja2
-pillow==6.2.1
+pillow==6.2.1             # via -r requirements.in
 promise==2.2.1            # via graphene-django, graphql-core, graphql-relay
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.4    # via -r requirements.in
 pyasn1==0.4.7             # via rsa
 pycryptodomex==3.9.0      # via pyjwkest
 pyjwkest==1.4.2           # via drf-oidc-auth
@@ -56,11 +57,11 @@ requests-cache==0.5.2     # via django-munigeo
 requests==2.22.0          # via coreapi, django-anymail, django-helusers, django-munigeo, pyjwkest, requests-cache
 rsa==4.0                  # via python-jose
 rx==1.6.1                 # via graphql-core
-sentry-sdk==0.13.1
+sentry-sdk==0.13.1        # via -r requirements.in
 singledispatch==3.4.0.3   # via graphene-django
-six==1.12.0               # via django-anymail, django-mailer, django-munigeo, faker, graphene, graphene-django, graphql-core, graphql-relay, promise, pyjwkest, python-dateutil, python-jose, singledispatch
+six==1.12.0               # via django-anymail, django-mailer, django-munigeo, faker, graphene, graphene-django, graphene-file-upload, graphql-core, graphql-relay, promise, pyjwkest, python-dateutil, python-jose, singledispatch
 sqlparse==0.3.0           # via django
 text-unidecode==1.3       # via faker
 uritemplate==3.0.0        # via coreapi
 urllib3==1.25.6           # via requests, sentry-sdk
-xlsxwriter==1.2.2
+xlsxwriter==1.2.2         # via -r requirements.in

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -9,6 +9,7 @@ from graphene import relay
 from graphene_django.fields import DjangoConnectionField, DjangoListField
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
+from graphene_file_upload.scalars import Upload
 from graphql_jwt.decorators import login_required, superuser_required
 from graphql_relay import from_global_id
 from munigeo.models import Municipality
@@ -453,7 +454,7 @@ class DeleteBerthTypeMutation(graphene.ClientIDMutation):
 
 class HarborInput(AbstractAreaInput):
     municipality_id = graphene.String()
-    image_file = graphene.String()
+    image_file = Upload()
     availability_level_id = graphene.ID()
     number_of_places = graphene.Int()
     maximum_width = graphene.Int()

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -823,9 +823,19 @@ class Mutation:
     update_berth_type = UpdateBerthTypeMutation.Field()
 
     # Harbors
-    create_harbor = CreateHarborMutation.Field()
+    create_harbor = CreateHarborMutation.Field(
+        description="The `imageFile` field takes an image as input. "
+        "To provide the file, you have to perform the request with a client "
+        "that conforms to the [GraphQL Multipart Request Spec]"
+        "(https://github.com/jaydenseric/graphql-multipart-request-spec)."
+    )
     delete_harbor = DeleteHarborMutation.Field()
-    update_harbor = UpdateHarborMutation.Field()
+    update_harbor = UpdateHarborMutation.Field(
+        description="The `imageFile` field takes an image as input. "
+        "To provide the file, you have to perform the request with a client "
+        "that conforms to the [GraphQL Multipart Request Spec]"
+        "(https://github.com/jaydenseric/graphql-multipart-request-spec)."
+    )
 
     # Piers
     create_pier = CreatePierMutation.Field()


### PR DESCRIPTION
## Description :sparkles:
- Replace the `image_file` input field for `Harbor` mutations (`create` and `update`) with File `Upload` scalar

## Issues :bug:
**Closes 🙅‍♂** 
**[VEN-405](https://helsinkisolutionoffice.atlassian.net/browse/VEN-405)**

**Related 🤝**
[**[VEN-512](https://helsinkisolutionoffice.atlassian.net/browse/VEN-512)**] Add tests for file upload

## Testing :alembic:
**Automated tests ⚙️**
N/A (Refer to VEN-512)

**Manual testing 👷**
First, you have to comment/remove the `@login_required` and `@superuser_required` decorators from the [update mutation](https://github.com/City-of-Helsinki/berth-reservations/blob/ven-405/file-upload/resources/schema.py#L510) to avoid having to deal with login with cURL.

To perform an update, execute the following cURL:
```shell
 curl localhost:8000/graphql_v2/ \
  -H "Content-Type: multipart/form-data" \
  -F operations='{ "query": "mutation UpdateHarbor($updateHarbor: UpdateHarborMutationInput!) { updateHarbor(input: $updateHarbor) { harbor { id properties { imageFile name } } } }", "variables": { "updateHarbor": { "id": "SGFyYm9yTm9kZTo3OTIyZTBiZC0wNDNhLTRmMjEtYjU0ZC05ZjU5NGU1ZGNhZDY=", "imageFile": null  } } }' \
  -F map='{ "0": ["variables.updateHarbor.imageFile"] }' \
  -F 0=@relative-path-to-image.png
```

It will perform the following mutation, replacing the `null`-ed variable (`imageFile`) with the file passed. For a detailed explanation, refer to the **Additional notes** section.
```graphql
mutation UpdateHarbor($updateHarbor: UpdateHarborMutationInput!) {
  updateHarbor(input: $updateHarbor) {
    harbor {
      id
      properties {
        imageFile
        name
      }
    }
  }
}
```

## Screenshots :camera_flash:
**Description in Harbor mutations**
<img width="340" alt="image" src="https://user-images.githubusercontent.com/15201480/75772961-38800380-5d4d-11ea-9da3-d74b1d32b024.png">

## Additional notes :spiral_notepad:
The file upload follows the [GraphQL Multipart Request Spec](https://github.com/jaydenseric/graphql-multipart-request-spec), so any of the [clients that implement it](https://github.com/jaydenseric/graphql-multipart-request-spec#client) can be used to interact with it.

That document explains why [requests have that shape](https://github.com/jaydenseric/graphql-multipart-request-spec#multipart-form-field-structure) which requires `operations`, `map`, and `files`.