### PR TITLE
VEN-504 | Update BerthApplication status on lease changes

### DIFF
--- a/applications/tests/factories.py
+++ b/applications/tests/factories.py
@@ -1,5 +1,6 @@
 import factory.fuzzy
 
+from berth_reservations.tests.factories import MunicipalityFactory
 from harbors.tests.factories import (
     BoatTypeFactory,
     HarborFactory,
@@ -22,6 +23,10 @@ class BaseApplicationFactory(factory.django.DjangoModelFactory):
     boat_type = factory.SubFactory(BoatTypeFactory)
     boat_length = factory.fuzzy.FuzzyDecimal(0.1, 100.00)
     boat_width = factory.fuzzy.FuzzyDecimal(0.1, 100.00)
+    phone_number = factory.Faker("phone_number")
+    address = factory.Faker("address")
+    zip_code = factory.Faker("zipcode")
+    municipality = factory.SubFactory(MunicipalityFactory)
 
 
 class BerthApplicationFactory(BaseApplicationFactory):

--- a/applications/tests/test_application_models.py
+++ b/applications/tests/test_application_models.py
@@ -1,0 +1,27 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from ..enums import ApplicationStatus
+
+
+def test_berth_application_without_lease_valid_statuses(berth_application):
+    new_status = ApplicationStatus.PENDING
+    berth_application.lease = None
+    berth_application.status = new_status
+
+    berth_application.save()
+
+    assert berth_application.status == new_status
+
+
+def test_berth_application_without_lease_invalid_statuses(berth_application):
+    new_status = ApplicationStatus.OFFER_GENERATED
+    berth_application.lease = None
+    berth_application.status = new_status
+
+    with pytest.raises(ValidationError) as exception:
+        berth_application.save()
+
+    error_msg = str(exception.value)
+    assert new_status.name in error_msg
+    assert "BerthApplication with no lease can only be" in error_msg

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -2,6 +2,7 @@ from graphql_relay.node.node import to_global_id
 
 from applications.enums import ApplicationStatus
 from berth_reservations.tests.utils import assert_in_errors
+from leases.tests.factories import BerthLeaseFactory
 
 BERTH_APPLICATIONS_WITH_NO_CUSTOMER_FILTER_QUERY = """
     query APPLICATIONS {
@@ -73,6 +74,7 @@ BERTH_APPLICATIONS_WITH_STATUSES_FILTER_QUERY = """
 
 
 def test_berth_applications_statuses_filter(berth_application, superuser_api_client):
+    berth_application.lease = BerthLeaseFactory()
     berth_application.status = ApplicationStatus.HANDLED
     berth_application.save()
 
@@ -101,6 +103,7 @@ def test_berth_applications_statuses_filter(berth_application, superuser_api_cli
 def test_berth_applications_statuses_filter_empty(
     berth_application, superuser_api_client
 ):
+    berth_application.lease = BerthLeaseFactory()
     berth_application.status = ApplicationStatus.HANDLED
     berth_application.save()
 
@@ -116,6 +119,7 @@ def test_berth_applications_statuses_filter_empty(
 def test_berth_applications_statuses_filter_invalid_enum(
     berth_application, superuser_api_client
 ):
+    berth_application.lease = BerthLeaseFactory()
     berth_application.status = ApplicationStatus.HANDLED
     berth_application.save()
 
@@ -133,6 +137,7 @@ def test_berth_applications_statuses_filter_invalid_enum(
 def test_berth_applications_statuses_filter_empty_list(
     berth_application, superuser_api_client
 ):
+    berth_application.lease = BerthLeaseFactory()
     berth_application.status = ApplicationStatus.HANDLED
     berth_application.save()
 


### PR DESCRIPTION
## Description :sparkles:
* Move application `DRAFTED -> OFFER_SENT` when a lease is created
* Move application `DRAFTED -> PENDING` when a drafted lease is deleted

## Issues :bug:
Close [VEN-504](https://helsinkisolutionoffice.atlassian.net/browse/VEN-504)

## Testing :alembic:
**Automated tests ⚙️**
```shell
pytest leases/tests/test_lease_mutations.py
```