### PR TITLE
VNE-505 | Expose berth leases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,14 @@
 ## Description :sparkles:
 
 ## Issues :bug:
+**Closes :no_good_woman:**
+
+**Related :handshake:**
 
 ## Testing :alembic:
-**Automated tests ⚙️**
+**Automated tests :gear:️**
 
-**Manual testing 👷** 
+**Manual testing :construction_worker_man:** 
 
 ## Screenshots :camera_flash:
 

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -19,8 +19,8 @@ LeaseStatusEnum = graphene.Enum.from_enum(LeaseStatus)
 
 
 class BerthLeaseNode(DjangoObjectType):
-    berth = graphene.Field(BerthNode)
-    status = LeaseStatusEnum()
+    berth = graphene.Field(BerthNode, required=True)
+    status = LeaseStatusEnum(required=True)
 
     class Meta:
         model = BerthLease

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -166,9 +166,14 @@ class BerthNodeFilterSet(django_filters.FilterSet):
 
 
 class BerthNode(DjangoObjectType):
+    leases = DjangoConnectionField(
+        "leases.schema.BerthLeaseNode",
+        description="**Requires permissions** to query this field.",
+    )
+
     class Meta:
         model = Berth
-        fields = ("id", "number", "pier", "berth_type", "comment", "leases")
+        fields = ("id", "number", "pier", "berth_type", "comment")
         interfaces = (relay.Node,)
         filterset_class = BerthNodeFilterSet
 
@@ -751,7 +756,11 @@ class Query:
     berth_types = DjangoConnectionField(BerthTypeNode)
 
     berth = relay.Node.Field(BerthNode)
-    berths = DjangoFilterConnectionField(BerthNode)
+    berths = DjangoFilterConnectionField(
+        BerthNode,
+        description="**Requires permissions** to query `leases` field. "
+        "Otherwise, everything is available",
+    )
 
     pier = relay.Node.Field(PierNode)
     piers = DjangoFilterConnectionField(

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -168,9 +168,14 @@ class BerthNodeFilterSet(django_filters.FilterSet):
 class BerthNode(DjangoObjectType):
     class Meta:
         model = Berth
-        fields = ("id", "number", "pier", "berth_type", "comment")
+        fields = ("id", "number", "pier", "berth_type", "comment", "leases")
         interfaces = (relay.Node,)
         filterset_class = BerthNodeFilterSet
+
+    @login_required
+    @superuser_required
+    def resolve_leases(self, info, **kwargs):
+        return self.leases.all()
 
 
 class AbstractMapType:

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from applications.tests.conftest import berth_application  # noqa
 from berth_reservations.tests.conftest import *  # noqa
+from leases.tests.conftest import *  # noqa
 
 from .factories import (
     AvailabilityLevelFactory,

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from applications.tests.conftest import berth_application  # noqa
 from berth_reservations.tests.conftest import *  # noqa
-from leases.tests.conftest import *  # noqa
 
 from .factories import (
     AvailabilityLevelFactory,

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -115,7 +115,7 @@ def test_get_berths(api_client, berth):
     }
 
 
-def test_get_winter_storage_areas(api_client, winter_storage_area):
+def test_get_winter_storage_areas(winter_storage_area, api_client):
     query = """
         {
             winterStorageAreas {


### PR DESCRIPTION
## Description :sparkles:
* Expose `berth_leases` on `BerthNode`
  * Only allowed for authorised users

If the query is performed without the `leases` field, it will pass for any user. If the `leases` field is added to the query and the user doesn't have `superuser` permissions, it will return an error.

## Issues :bug:
**Closes 🙅**
[VEN-505](https://helsinkisolutionoffice.atlassian.net/browse/VEN-505)

## Testing :alembic:
**Automated tests ⚙️**
```shell
# resources/tests/test_resources_queries.py#L122
$ pytest resources/tests/test_resources_queries.py::test_get_berth_with_leases

# resources/tests/test_resources_queries.py#L151
$ pytest resources/tests/test_resources_queries.py::test_get_berth_with_leases_not_enough_permissions
```

**Manual testing 👷** 
Try the following query in a browser with an existing session and in incognito mode:
```graphql
query BERTH_LEASES {
  berth(id: "QmVydGhOb2RlOjMwNWViMDJhLTk2MGUtNDZhNy05YWE5LWVmNWJhNTRmZGRiNA==") {
    leases {
      edges {
        node {
          id
        }
      }
    }
  }
}
```
The one with the session should return a list (empty or with items) with the available leases. The incognito one should raise a permissions error:
```json
{"message": "You do not have permission to perform this action"}
```

## Screenshots :camera_flash:
**BerthNode field**
![image](https://user-images.githubusercontent.com/15201480/76201304-b9cb1080-61fb-11ea-9178-b1187b14c4e3.png)

**Berths query**
![image](https://user-images.githubusercontent.com/15201480/76201777-79b85d80-61fc-11ea-9015-0122927dcd78.png)