### PR TITLE
Refactor GraphQL Client in tests

### DIFF
--- a/applications/tests/test_applications_new_schema_mutations.py
+++ b/applications/tests/test_applications_new_schema_mutations.py
@@ -4,12 +4,7 @@ from graphql_relay import to_global_id
 from berth_reservations.tests.utils import (
     assert_field_missing,
     assert_not_enough_permissions,
-    GraphQLTestClient,
 )
-
-client = GraphQLTestClient()
-
-GRAPHQL_URL = "/graphql_v2/"
 
 UPDATE_BERTH_APPLICATION_MUTATION = """
 mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
@@ -26,7 +21,9 @@ mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
 """
 
 
-def test_update_berth_application(superuser, berth_application, customer_profile):
+def test_update_berth_application(
+    superuser_api_client, berth_application, customer_profile
+):
     berth_application_id = to_global_id(
         "BerthApplicationNode", str(berth_application.id)
     )
@@ -39,11 +36,8 @@ def test_update_berth_application(superuser, berth_application, customer_profile
 
     assert berth_application.customer is None
 
-    executed = client.execute(
-        query=UPDATE_BERTH_APPLICATION_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        UPDATE_BERTH_APPLICATION_MUTATION, input=variables,
     )
 
     assert executed == {
@@ -61,39 +55,39 @@ def test_update_berth_application(superuser, berth_application, customer_profile
     }
 
 
-def test_update_berth_application_no_application_id(superuser, customer_profile):
+def test_update_berth_application_no_application_id(
+    superuser_api_client, customer_profile
+):
     variables = {
         "customerId": to_global_id("BerthProfileNode", str(customer_profile.id)),
     }
 
-    executed = client.execute(
-        query=UPDATE_BERTH_APPLICATION_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        UPDATE_BERTH_APPLICATION_MUTATION, input=variables,
     )
 
     assert_field_missing("id", executed)
 
 
-def test_update_berth_application_no_customer_id(superuser, berth_application):
+def test_update_berth_application_no_customer_id(
+    superuser_api_client, berth_application
+):
     variables = {
         "id": to_global_id("BerthApplicationNode", str(berth_application.id)),
     }
 
-    executed = client.execute(
-        query=UPDATE_BERTH_APPLICATION_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        UPDATE_BERTH_APPLICATION_MUTATION, input=variables,
     )
 
     assert_field_missing("customerId", executed)
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
 def test_update_berth_application_not_enough_permissions(
-    user, berth_application, customer_profile
+    api_client, berth_application, customer_profile
 ):
     berth_application_id = to_global_id(
         "BerthApplicationNode", str(berth_application.id)
@@ -105,12 +99,7 @@ def test_update_berth_application_not_enough_permissions(
         "customerId": customer_id,
     }
 
-    executed = client.execute(
-        query=UPDATE_BERTH_APPLICATION_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=user,
-    )
+    executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
 
     assert berth_application.customer is None
     assert_not_enough_permissions(executed)

--- a/applications/tests/test_reservations_graphql.py
+++ b/applications/tests/test_reservations_graphql.py
@@ -2,12 +2,12 @@ from string import Template
 
 from graphql_relay.node.node import to_global_id
 
-from berth_reservations.tests.utils import GraphQLTestClient
 from harbors.schema import HarborType, WinterStorageAreaType
 
 
-def test_create_berth_application(boat_type, harbor, berth_switch_reason):
-    client = GraphQLTestClient()
+def test_create_berth_application(
+    old_schema_api_client, boat_type, harbor, berth_switch_reason
+):
     t = Template(
         """
         mutation createBerthApplication {
@@ -71,7 +71,7 @@ def test_create_berth_application(boat_type, harbor, berth_switch_reason):
         desired_harbor=harbor_node_id,
         berth_switch_reason_id=berth_switch_reason.id,
     )
-    executed = client.execute(mutation)
+    executed = old_schema_api_client.execute(mutation)
     assert executed == {
         "data": {
             "createBerthApplication": {
@@ -89,8 +89,7 @@ def test_create_berth_application(boat_type, harbor, berth_switch_reason):
     }
 
 
-def test_create_berth_application_wo_reason(boat_type, harbor):
-    client = GraphQLTestClient()
+def test_create_berth_application_wo_reason(old_schema_api_client, boat_type, harbor):
     t = Template(
         """
         mutation createBerthApplication {
@@ -152,7 +151,7 @@ def test_create_berth_application_wo_reason(boat_type, harbor):
         boat_type_id=boat_type.id,
         desired_harbor=harbor_node_id,
     )
-    executed = client.execute(mutation)
+    executed = old_schema_api_client.execute(mutation)
     assert executed == {
         "data": {
             "createBerthApplication": {
@@ -167,8 +166,9 @@ def test_create_berth_application_wo_reason(boat_type, harbor):
     }
 
 
-def test_create_winter_storage_application(boat_type, winter_area):
-    client = GraphQLTestClient()
+def test_create_winter_storage_application(
+    old_schema_api_client, boat_type, winter_area
+):
     t = Template(
         """
         mutation createWinterStorageApplication {
@@ -216,7 +216,7 @@ def test_create_winter_storage_application(boat_type, winter_area):
     )
     winter_area_node_id = to_global_id(WinterStorageAreaType._meta.name, winter_area.id)
     mutation = t.substitute(boat_type_id=boat_type.id, desired_area=winter_area_node_id)
-    executed = client.execute(mutation)
+    executed = old_schema_api_client.execute(mutation)
     assert executed == {
         "data": {
             "createWinterStorageApplication": {
@@ -230,8 +230,7 @@ def test_create_winter_storage_application(boat_type, winter_area):
     }
 
 
-def test_get_berth_switch_reasons(berth_switch_reason):
-    client = GraphQLTestClient()
+def test_get_berth_switch_reasons(old_schema_api_client, berth_switch_reason):
     query = """
         {
             berthSwitchReasons {
@@ -240,7 +239,7 @@ def test_get_berth_switch_reasons(berth_switch_reason):
             }
         }
     """
-    executed = client.execute(query)
+    executed = old_schema_api_client.execute(query)
     assert executed == {
         "data": {
             "berthSwitchReasons": [

--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from .factories import CustomerProfileFactory, MunicipalityFactory, UserFactory
+from .utils import create_api_client
 
 
 @pytest.fixture(autouse=True)
@@ -16,26 +17,52 @@ def force_settings(settings):
 
 
 @pytest.fixture
-def user(request):
-    permissions = request.param if hasattr(request, "param") else None
-
-    if permissions == "superuser":
-        user = UserFactory(is_superuser=True)
-    elif permissions == "staff":
-        user = UserFactory(is_staff=True)
-    elif permissions == "none":
-        user = None
-    # When the fixture is called without parameters, return the base user
-    elif permissions == "base" or permissions is None:
-        user = UserFactory()
-
-    return user
+def user():
+    return UserFactory()
 
 
 @pytest.fixture
 def superuser():
     user = UserFactory(is_superuser=True)
     return user
+
+
+@pytest.fixture
+def user_api_client():
+    return create_api_client(user=UserFactory())
+
+
+@pytest.fixture
+def staff_api_client():
+    return create_api_client(user=UserFactory(is_staff=True))
+
+
+@pytest.fixture
+def superuser_api_client():
+    return create_api_client(user=UserFactory(is_superuser=True))
+
+
+@pytest.fixture
+def api_client(request, user_api_client, staff_api_client, superuser_api_client):
+    client_type = request.param if hasattr(request, "param") else None
+
+    if client_type == "superuser_api_client":
+        api_client = superuser_api_client
+    elif client_type == "staff_api_client":
+        api_client = staff_api_client
+    elif client_type == "user_api_client":
+        api_client = user_api_client
+
+    # When the fixture is called without parameters, return the base api_client
+    else:
+        api_client = create_api_client()
+
+    return api_client
+
+
+@pytest.fixture
+def old_schema_api_client():
+    return create_api_client(graphql_v2=False)
 
 
 @pytest.fixture

--- a/customers/tests/test_customers_schema.py
+++ b/customers/tests/test_customers_schema.py
@@ -4,25 +4,22 @@ from graphql_relay import to_global_id
 from applications.tests.factories import BerthApplicationFactory
 from berth_reservations.tests.utils import (
     assert_not_enough_permissions,
-    GraphQLTestClient,
+    create_api_client,
 )
 from customers.tests.factories import BoatFactory, CompanyFactory
 from leases.tests.factories import BerthLeaseFactory
 
-client = GraphQLTestClient()
-
-GRAPHQL_URL = "/graphql_v2/"
-
-
-def test_profile_node_gets_extended_properly():
-    query = """
-        {
-            _service {
-                sdl
-            }
+FEDERATED_SCHEMA_QUERY = """
+    {
+        _service {
+            sdl
         }
-    """
-    executed = client.execute(query=query, graphql_url=GRAPHQL_URL)
+    }
+"""
+
+
+def test_profile_node_gets_extended_properly(api_client):
+    executed = api_client.execute(FEDERATED_SCHEMA_QUERY)
     assert (
         # TODO: remove the second "@key" when/if graphene-federartion fixes itself
         'extend type ProfileNode  implements Node  @key(fields: "id") '
@@ -71,15 +68,13 @@ query GetBerthProfiles {
 """
 
 
-def test_query_berth_profiles(superuser, customer_profile):
+def test_query_berth_profiles(superuser_api_client, customer_profile):
     berth_application = BerthApplicationFactory(customer=customer_profile)
     berth_lease = BerthLeaseFactory(customer=customer_profile)
     company = CompanyFactory(customer=customer_profile)
     boat = BoatFactory(owner=customer_profile)
 
-    executed = client.execute(
-        query=QUERY_BERTH_PROFILES, graphql_url=GRAPHQL_URL, user=superuser,
-    )
+    executed = superuser_api_client.execute(QUERY_BERTH_PROFILES)
 
     customer_id = to_global_id("BerthProfileNode", customer_profile.id)
     boat_id = to_global_id("BoatNode", boat.id)
@@ -97,11 +92,11 @@ def test_query_berth_profiles(superuser, customer_profile):
     }
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_query_berth_profiles_not_enough_permissions(user):
-    executed = client.execute(
-        query=QUERY_BERTH_PROFILES, graphql_url=GRAPHQL_URL, user=user,
-    )
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_query_berth_profiles_not_enough_permissions(api_client):
+    executed = api_client.execute(QUERY_BERTH_PROFILES)
 
     assert_not_enough_permissions(executed)
 
@@ -143,7 +138,7 @@ query GetBerthProfile {
 
 
 @pytest.mark.parametrize("is_superuser", [True, False])
-def test_query_berth_profile(is_superuser, superuser, customer_profile):
+def test_query_berth_profile(is_superuser, superuser_api_client, customer_profile):
     berth_profile_id = to_global_id("BerthProfileNode", customer_profile.id)
 
     berth_application = BerthApplicationFactory(customer=customer_profile)
@@ -154,9 +149,13 @@ def test_query_berth_profile(is_superuser, superuser, customer_profile):
     query = QUERY_BERTH_PROFILE % berth_profile_id
 
     # only superusers and profile owners can see profile node info
-    gql_user = superuser if is_superuser else customer_profile.user
+    api_client = (
+        superuser_api_client
+        if is_superuser
+        else create_api_client(customer_profile.user)
+    )
 
-    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=gql_user)
+    executed = api_client.execute(query)
 
     boat_id = to_global_id("BoatNode", boat.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
@@ -173,11 +172,16 @@ def test_query_berth_profile(is_superuser, superuser, customer_profile):
     }
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_query_berth_profile_not_enough_permissions_valid_id(user, customer_profile):
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_query_berth_profile_not_enough_permissions_valid_id(
+    api_client, customer_profile
+):
     berth_profile_id = to_global_id("BerthProfileNode", customer_profile.id)
 
     query = QUERY_BERTH_PROFILE % berth_profile_id
-    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=user)
+
+    executed = api_client.execute(query)
 
     assert_not_enough_permissions(executed)

--- a/harbors/tests/test_harbors_graphql.py
+++ b/harbors/tests/test_harbors_graphql.py
@@ -1,8 +1,4 @@
-from berth_reservations.tests.utils import GraphQLTestClient
-
-
-def test_get_boat_type(boat_type):
-    client = GraphQLTestClient()
+def test_get_boat_type(boat_type, old_schema_api_client):
     query = """
         {
             boatTypes {
@@ -10,12 +6,11 @@ def test_get_boat_type(boat_type):
             }
         }
     """
-    executed = client.execute(query)
-    assert executed == {"data": {"boatTypes": [{"name": "Dinghy"}]}}
+    executed = old_schema_api_client.execute(query)
+    assert executed["data"]["boatTypes"] == [{"name": "Dinghy"}]
 
 
-def test_get_harbors(harbor):
-    client = GraphQLTestClient()
+def test_get_harbors(harbor, old_schema_api_client):
     query = """
         {
             harbors {
@@ -30,17 +25,7 @@ def test_get_harbors(harbor):
             }
         }
     """
-    executed = client.execute(query)
-    assert executed == {
-        "data": {
-            "harbors": {
-                "edges": [
-                    {
-                        "node": {
-                            "properties": {"name": "Sunny Harbor", "zipCode": "00100"}
-                        }
-                    }
-                ]
-            }
-        }
-    }
+    executed = old_schema_api_client.execute(query)
+    assert executed["data"]["harbors"]["edges"] == [
+        {"node": {"properties": {"name": "Sunny Harbor", "zipCode": "00100"}}}
+    ]

--- a/leases/tests/test_lease_mutations.py
+++ b/leases/tests/test_lease_mutations.py
@@ -10,14 +10,9 @@ from berth_reservations.tests.utils import (
     assert_field_missing,
     assert_in_errors,
     assert_not_enough_permissions,
-    GraphQLTestClient,
 )
 from leases.enums import LeaseStatus
 from leases.models import BerthLease
-
-client = GraphQLTestClient()
-
-GRAPHQL_URL = "/graphql_v2/"
 
 CREATE_BERTH_LEASE_MUTATION = """
 mutation CreateBerthLease($input: CreateBerthLeaseMutationInput!) {
@@ -47,7 +42,9 @@ mutation CreateBerthLease($input: CreateBerthLeaseMutationInput!) {
 
 
 @freeze_time("2020-01-01T08:00:00Z")
-def test_create_berth_lease(superuser, berth_application, berth, customer_profile):
+def test_create_berth_lease(
+    superuser_api_client, berth_application, berth, customer_profile
+):
     berth_application.customer = customer_profile
     berth_application.save()
 
@@ -58,11 +55,8 @@ def test_create_berth_lease(superuser, berth_application, berth, customer_profil
 
     assert BerthLease.objects.count() == 0
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert BerthLease.objects.count() == 1
@@ -84,7 +78,7 @@ def test_create_berth_lease(superuser, berth_application, berth, customer_profil
 
 @freeze_time("2020-01-01T08:00:00Z")
 def test_create_berth_lease_all_arguments(
-    superuser, berth_application, berth, boat, customer_profile
+    superuser_api_client, berth_application, berth, boat, customer_profile
 ):
     berth_application.customer = customer_profile
     berth_application.save()
@@ -102,11 +96,8 @@ def test_create_berth_lease_all_arguments(
 
     assert BerthLease.objects.count() == 0
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert BerthLease.objects.count() == 1
@@ -126,87 +117,74 @@ def test_create_berth_lease_all_arguments(
     }
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_create_berth_lease_not_enough_permissions(user, berth_application, berth):
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_create_berth_lease_not_enough_permissions(
+    api_client, berth_application, berth
+):
     variables = {
         "applicationId": to_global_id("BerthApplicationNode", berth_application.id),
         "berthId": to_global_id("BerthNode", berth.id),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=user,
-    )
+    executed = api_client.execute(CREATE_BERTH_LEASE_MUTATION, input=variables)
 
     assert_not_enough_permissions(executed)
 
 
-def test_create_berth_lease_application_doesnt_exist(superuser, berth):
+def test_create_berth_lease_application_doesnt_exist(superuser_api_client, berth):
     variables = {
         "applicationId": to_global_id("BerthApplicationNode", randint(0, 999)),
         "berthId": to_global_id("BerthNode", berth.id),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_doesnt_exist("BerthApplication", executed)
 
 
-def test_create_berth_lease_berth_doesnt_exist(superuser, berth_application):
+def test_create_berth_lease_berth_doesnt_exist(superuser_api_client, berth_application):
     variables = {
         "applicationId": to_global_id("BerthApplicationNode", berth_application.id),
         "berthId": to_global_id("BerthNode", uuid.uuid4()),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_doesnt_exist("Berth", executed)
 
 
-def test_create_berth_lease_application_id_missing(superuser):
+def test_create_berth_lease_application_id_missing(superuser_api_client):
     variables = {
         "berthId": to_global_id("BerthNode", uuid.uuid4()),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_field_missing("applicationId", executed)
 
 
-def test_create_berth_lease_berth_id_missing(superuser):
+def test_create_berth_lease_berth_id_missing(superuser_api_client):
     variables = {
         "berthId": to_global_id("BerthApplicationNode", randint(0, 999)),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_field_missing("berthId", executed)
 
 
 def test_create_berth_lease_application_without_customer(
-    superuser, berth_application, berth
+    superuser_api_client, berth_application, berth
 ):
     berth_application.customer = None
     berth_application.save()
@@ -216,11 +194,8 @@ def test_create_berth_lease_application_without_customer(
         "berthId": to_global_id("BerthNode", berth.id),
     }
 
-    executed = client.execute(
-        query=CREATE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        CREATE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_in_errors(
@@ -237,22 +212,19 @@ mutation DELETE_DRAFTED_LEASE($input: DeleteBerthLeaseMutationInput!) {
 """
 
 
-def test_delete_berth_lease_drafted(berth_lease, superuser):
+def test_delete_berth_lease_drafted(berth_lease, superuser_api_client):
     variables = {"id": to_global_id("BerthLeaseNode", berth_lease.id)}
 
     assert BerthLease.objects.count() == 1
 
-    client.execute(
-        query=DELETE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    superuser_api_client.execute(
+        DELETE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert BerthLease.objects.count() == 0
 
 
-def test_delete_berth_lease_not_drafted(berth_lease, superuser):
+def test_delete_berth_lease_not_drafted(berth_lease, superuser_api_client):
     berth_lease.status = LeaseStatus.OFFERED
     berth_lease.save()
 
@@ -260,11 +232,8 @@ def test_delete_berth_lease_not_drafted(berth_lease, superuser):
 
     assert BerthLease.objects.count() == 1
 
-    executed = client.execute(
-        query=DELETE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        DELETE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert BerthLease.objects.count() == 1
@@ -273,35 +242,29 @@ def test_delete_berth_lease_not_drafted(berth_lease, superuser):
     )
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_delete_berth_lease_not_enough_permissions(user, berth_lease):
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_delete_berth_lease_not_enough_permissions(api_client, berth_lease):
     variables = {
         "id": to_global_id("BerthLeaseNode", berth_lease.id),
     }
 
     assert BerthLease.objects.count() == 1
 
-    executed = client.execute(
-        query=DELETE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=user,
-    )
+    executed = api_client.execute(DELETE_BERTH_LEASE_MUTATION, input=variables,)
 
     assert BerthLease.objects.count() == 1
     assert_not_enough_permissions(executed)
 
 
-def test_delete_berth_lease_inexistent_lease(superuser):
+def test_delete_berth_lease_inexistent_lease(superuser_api_client):
     variables = {
         "id": to_global_id("BerthLeaseNode", uuid.uuid4()),
     }
 
-    executed = client.execute(
-        query=DELETE_BERTH_LEASE_MUTATION,
-        variables=variables,
-        graphql_url=GRAPHQL_URL,
-        user=superuser,
+    executed = superuser_api_client.execute(
+        DELETE_BERTH_LEASE_MUTATION, input=variables,
     )
 
     assert_doesnt_exist("BerthLease", executed)

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -1,14 +1,7 @@
 import pytest
 from graphql_relay import to_global_id
 
-from berth_reservations.tests.utils import (
-    assert_not_enough_permissions,
-    GraphQLTestClient,
-)
-
-client = GraphQLTestClient()
-
-GRAPHQL_URL = "/graphql_v2/"
+from berth_reservations.tests.utils import assert_not_enough_permissions
 
 QUERY_BERTH_LEASES = """
 query GetBerthLeases {
@@ -53,15 +46,13 @@ query GetBerthLeases {
 """
 
 
-def test_query_berth_leases(superuser, berth_lease, berth_application):
+def test_query_berth_leases(superuser_api_client, berth_lease, berth_application):
     berth_application.customer = berth_lease.customer
     berth_application.save()
     berth_lease.application = berth_application
     berth_lease.save()
 
-    executed = client.execute(
-        query=QUERY_BERTH_LEASES, graphql_url=GRAPHQL_URL, user=superuser,
-    )
+    executed = superuser_api_client.execute(QUERY_BERTH_LEASES)
 
     berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
@@ -89,11 +80,11 @@ def test_query_berth_leases(superuser, berth_lease, berth_application):
     }
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_query_berth_leases_not_enough_permissions(user):
-    executed = client.execute(
-        query=QUERY_BERTH_LEASES, graphql_url=GRAPHQL_URL, user=user,
-    )
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_query_berth_leases_not_enough_permissions(api_client):
+    executed = api_client.execute(QUERY_BERTH_LEASES)
 
     assert_not_enough_permissions(executed)
 
@@ -137,7 +128,7 @@ query GetBerthLease {
 """
 
 
-def test_query_berth_lease(superuser, berth_lease, berth_application):
+def test_query_berth_lease(superuser_api_client, berth_lease, berth_application):
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
 
     berth_application.customer = berth_lease.customer
@@ -146,7 +137,7 @@ def test_query_berth_lease(superuser, berth_lease, berth_application):
     berth_lease.save()
 
     query = QUERY_BERTH_LEASE % berth_lease_id
-    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=superuser,)
+    executed = superuser_api_client.execute(query)
 
     berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
     berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
@@ -173,19 +164,20 @@ def test_query_berth_lease(superuser, berth_lease, berth_application):
     }
 
 
-@pytest.mark.parametrize("user", ["none", "base", "staff"], indirect=True)
-def test_query_berth_lease_not_enough_permissions_valid_id(user, berth_lease):
+@pytest.mark.parametrize(
+    "api_client", ["api_client", "user_api_client", "staff_api_client"], indirect=True
+)
+def test_query_berth_lease_not_enough_permissions_valid_id(api_client, berth_lease):
     berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
 
     query = QUERY_BERTH_LEASE % berth_lease_id
-    executed = client.execute(query=query, graphql_url=GRAPHQL_URL, user=user,)
+
+    executed = api_client.execute(query)
 
     assert_not_enough_permissions(executed)
 
 
-def test_query_berth_lease_invalid_id(user):
-    executed = client.execute(
-        query=QUERY_BERTH_LEASE, graphql_url=GRAPHQL_URL, user=user,
-    )
+def test_query_berth_lease_invalid_id(user_api_client):
+    executed = user_api_client.execute(QUERY_BERTH_LEASE)
 
     assert executed["data"]["berthLease"] is None

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -67,7 +67,7 @@ def _resolve_piers(info, **kwargs):
 
     if application_global_id:
         user = info.context.user
-        if user.is_authenticated and user.is_superuser:
+        if user and user.is_authenticated and user.is_superuser:
             application_id = from_global_id(application_global_id)[1]
             try:
                 application = BerthApplication.objects.get(pk=application_id)


### PR DESCRIPTION
## Description :sparkles:

1. Switch to using Graphene's test CLient for GQL tests.
2. Initialize clients for anonymous user, regular user, staff user
   and superuser as pytest fixtures.
3. Initialize separate clients for old schema and new schema (v2).

## Issues :bug:

Still needs some tests to ensure that `Accept-Language` header works
as expected using the old `GraphQLDjangoTestClient`. Coming in another PR.

## Testing :alembic:
**Automated tests ⚙️**

```shell
pytest
```
