### PR TITLE
Fix resend notifications for applications in Django admin

### DIFF
--- a/applications/admin.py
+++ b/applications/admin.py
@@ -194,7 +194,7 @@ class BerthApplicationAdmin(admin.ModelAdmin):
             try:
                 send_notification(
                     application.email,
-                    NotificationType.BERTH_APPLICATION_CREATED,
+                    NotificationType.BERTH_APPLICATION_CREATED.value,
                     application.get_notification_context(),
                     application.language,
                 )
@@ -317,7 +317,7 @@ class WinterStorageApplicationAdmin(admin.ModelAdmin):
             try:
                 send_notification(
                     application.email,
-                    NotificationType.WINTER_STORAGE_APPLICATION_CREATED,
+                    NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value,
                     application.get_notification_context(),
                     application.language,
                 )


### PR DESCRIPTION
## Description :sparkles:

Since we started using django-ilmoitin, we need to pass the enums'
value, when we fire send_notification helper function.
