### PR TITLE
VEN-512 | File upload tests

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -516,7 +516,8 @@ class HarborInput(AbstractAreaInput):
 def add_map_files(model, map_files, instance):
     try:
         for map_file in map_files:
-            model.objects.create(map_file, instance)
+            map_instance = model(map_file=map_file)
+            instance.maps.add(map_instance, bulk=False)
     except IntegrityError as e:
         raise VenepaikkaGraphQLError(e)
 


### PR DESCRIPTION
## Description :sparkles:
* Update the `create/update_harbor` tests to support `ImageFile` uploads
* Update the `create/update_harbor` tests to support `addHarborMaps` uploads
* Add another `update_harbor` tests for `removeHarborMaps` uploads
* Fix an issue 🐛 that was not saving map instances properly

## Issues :bug:
### Closes :no_good_woman:
- **[VEN-512](https://helsinkisolutionoffice.atlassian.net/browse/VEN-512):** Add tests for file upload

### Related :handshake:
- **[VEN-405](https://helsinkisolutionoffice.atlassian.net/browse/VEN-405):** Support file upload for Resources (#160)
- **[VEN-479](https://helsinkisolutionoffice.atlassian.net/browse/VEN-479):** Backend: add maps to harbors / winter storage areas (#161)

## Testing :alembic:
### Automated tests :gear:️
```shell
# Test all
$  pytest resources/tests/test_resources_mutations.py

# Create Harbor (tests for image file and add_map_files)
$ pytest resources/tests/test_resources_mutations.py::test_create_harbor

# Update Harbor (tests for image file and_map_files)
$ pytest resources/tests/test_resources_mutations.py::test_update_harbor

# Update Harbor (tests for remove_map_files)
$ pytest resources/tests/test_resources_mutations.py::test_update_harbor_remove_map
```

### Manual testing :construction_worker_man:
N/A