### PR TITLE
VEN-511 | Check if application already has a lease

### DIFF
--- a/leases/schema.py
+++ b/leases/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 from graphene_django import DjangoConnectionField, DjangoObjectType
@@ -93,7 +94,10 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
 
             input["boat"] = boat
 
-        lease = BerthLease.objects.create(**input)
+        try:
+            lease = BerthLease.objects.create(**input)
+        except ValidationError as e:
+            raise VenepaikkaGraphQLError(e)
 
         application.status = ApplicationStatus.OFFER_GENERATED
         application.save()


### PR DESCRIPTION
## Description :sparkles:
*  Catch the `ValidationError` raised when the `application` passed to a `lease` already has another `lease` assigned.
* Add a test

## Issues :bug:
### Closes :no_good_woman:
**[VEN-511](https://helsinkisolutionoffice.atlassian.net/browse/VEN-511):** CreateBerthLease mutation does not check if application has lease already

### Related :handshake:
Sentry [error trace](https://sentry.hel.ninja/aok/berth-api/issues/10542/)

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_mutations.py::test_create_berth_lease_application_already_has_lease
```