### PR TITLE
VEN-514 | Sort applications and leases by created_at

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -53,6 +53,10 @@ class BerthApplicationFilter(django_filters.FilterSet):
     no_customer = django_filters.BooleanFilter(
         field_name="customer", lookup_expr="isnull"
     )
+    order_by = django_filters.OrderingFilter(
+        fields=(("created_at", "createdAt"),),
+        label="Supports only `createdAt` and `-createdAt`.",
+    )
 
     def filter_berth_switch(self, queryset, name, value):
         lookup = "__".join([name, "isnull"])

--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -132,6 +132,7 @@ class Query:
         description="The `statuses` filter takes a list of `ApplicationStatus` values "
         "representing the desired statuses. If an empty list is passed, no filter will be applied "
         "and all the results will be returned."
+        "\n\n`BerthApplications` are ordered by `createdAt` in ascending order by default."
         "\n\n**Requires permissions** to access applications."
         "\n\nErrors:"
         "\n* A value passed is not a valid status",
@@ -148,12 +149,19 @@ class Query:
         if statuses:
             qs = qs.filter(status__in=statuses)
 
-        return qs.select_related(
-            "boat_type", "berth_switch", "berth_switch__harbor", "berth_switch__reason",
-        ).prefetch_related(
-            "berth_switch__reason__translations",
-            "harborchoice_set",
-            "harborchoice_set__harbor",
+        return (
+            qs.select_related(
+                "boat_type",
+                "berth_switch",
+                "berth_switch__harbor",
+                "berth_switch__reason",
+            )
+            .prefetch_related(
+                "berth_switch__reason__translations",
+                "harborchoice_set",
+                "harborchoice_set__harbor",
+            )
+            .order_by("created_at")
         )
 
 

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -1,22 +1,26 @@
+import pytest
+from dateutil.parser import isoparse
+from freezegun import freeze_time
 from graphql_relay.node.node import to_global_id
 
 from applications.enums import ApplicationStatus
+from applications.tests.factories import BerthApplicationFactory
 from berth_reservations.tests.utils import assert_in_errors
 from leases.tests.factories import BerthLeaseFactory
 
 BERTH_APPLICATIONS_WITH_NO_CUSTOMER_FILTER_QUERY = """
-    query APPLICATIONS {
-        berthApplications(noCustomer: %s) {
-            edges {
-                node {
+query APPLICATIONS {
+    berthApplications(noCustomer: %s) {
+        edges {
+            node {
+                id
+                customer {
                     id
-                    customer {
-                        id
-                    }
                 }
             }
         }
     }
+}
 """
 
 
@@ -60,16 +64,16 @@ def test_berth_applications_no_customer_filter_false(
 
 
 BERTH_APPLICATIONS_WITH_STATUSES_FILTER_QUERY = """
-    query APPLICATIONS {
-        berthApplications(statuses: [%s]) {
-            edges {
-                node {
-                    id
-                    status
-                }
+query APPLICATIONS {
+    berthApplications(statuses: [%s]) {
+        edges {
+            node {
+                id
+                status
             }
         }
     }
+}
 """
 
 
@@ -161,3 +165,44 @@ def test_berth_applications_statuses_filter_empty_list(
             ]
         }
     }
+
+
+BERTH_APPLICATIONS_WITH_ORDER_BY = """
+query APPLICATIONS {
+    berthApplications(orderBy: "%s") {
+        edges {
+            node {
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "order_by,ascending", [("createdAt", True), ("-createdAt", False)]
+)
+def test_berth_applications_order_by_created(order_by, ascending, superuser_api_client):
+    with freeze_time("2020-02-01"):
+        BerthApplicationFactory()
+
+    with freeze_time("2020-01-01"):
+        BerthApplicationFactory()
+
+    query = BERTH_APPLICATIONS_WITH_ORDER_BY % order_by
+
+    executed = superuser_api_client.execute(query)
+
+    first_date = isoparse(
+        executed["data"]["berthApplications"]["edges"][0 if ascending else 1]["node"][
+            "createdAt"
+        ]
+    )
+    second_date = isoparse(
+        executed["data"]["berthApplications"]["edges"][1 if ascending else 0]["node"][
+            "createdAt"
+        ]
+    )
+
+    assert first_date < second_date

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -206,3 +206,35 @@ def test_berth_applications_order_by_created(order_by, ascending, superuser_api_
     )
 
     assert first_date < second_date
+
+
+BERTH_APPLICATIONS_QUERY = """
+query APPLICATIONS {
+    berthApplications {
+        edges {
+            node {
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+def test_berth_applications_order_by_created_at_default(superuser_api_client):
+    with freeze_time("2020-02-01"):
+        BerthApplicationFactory()
+
+    with freeze_time("2020-01-01"):
+        BerthApplicationFactory()
+
+    executed = superuser_api_client.execute(BERTH_APPLICATIONS_QUERY)
+
+    first_date = isoparse(
+        executed["data"]["berthApplications"]["edges"][0]["node"]["createdAt"]
+    )
+    second_date = isoparse(
+        executed["data"]["berthApplications"]["edges"][1]["node"]["createdAt"]
+    )
+
+    assert first_date < second_date

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -149,20 +149,26 @@ class DeleteBerthLeaseMutation(graphene.ClientIDMutation):
 class Query:
     berth_lease = graphene.relay.Node.Field(BerthLeaseNode)
     berth_leases = DjangoFilterConnectionField(
-        BerthLeaseNode, filterset_class=BerthLeaseNodeFilter
+        BerthLeaseNode,
+        filterset_class=BerthLeaseNodeFilter,
+        description="`BerthLeases` are ordered by `createdAt` in ascending order by default.",
     )
 
     @login_required
     @superuser_required
     # TODO: Should check if the user has permissions to access these objects
     def resolve_berth_leases(self, info, **kwargs):
-        return BerthLease.objects.select_related(
-            "application",
-            "application__customer",
-            "berth",
-            "berth__pier",
-            "berth__pier__harbor",
-        ).prefetch_related("application__customer__boats")
+        return (
+            BerthLease.objects.select_related(
+                "application",
+                "application__customer",
+                "berth",
+                "berth__pier",
+                "berth__pier__harbor",
+            )
+            .prefetch_related("application__customer__boats")
+            .order_by("created_at")
+        )
 
 
 class Mutation:

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -1,8 +1,10 @@
+import django_filters
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
-from graphene_django import DjangoConnectionField, DjangoObjectType
+from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
 from graphql_jwt.decorators import login_required, superuser_required
 from graphql_relay import from_global_id
 
@@ -17,6 +19,13 @@ from .enums import LeaseStatus
 from .models import BerthLease
 
 LeaseStatusEnum = graphene.Enum.from_enum(LeaseStatus)
+
+
+class BerthLeaseNodeFilter(django_filters.FilterSet):
+    order_by = django_filters.OrderingFilter(
+        fields=(("created_at", "createdAt"),),
+        label="Supports only `createdAt` and `-createdAt`.",
+    )
 
 
 class BerthLeaseNode(DjangoObjectType):
@@ -139,7 +148,9 @@ class DeleteBerthLeaseMutation(graphene.ClientIDMutation):
 
 class Query:
     berth_lease = graphene.relay.Node.Field(BerthLeaseNode)
-    berth_leases = DjangoConnectionField(BerthLeaseNode)
+    berth_leases = DjangoFilterConnectionField(
+        BerthLeaseNode, filterset_class=BerthLeaseNodeFilter
+    )
 
     @login_required
     @superuser_required

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -227,3 +227,35 @@ def test_query_berth_leases_order_by_created_at(
     )
 
     assert first_date < second_date
+
+
+QUERY_BERTH_LEASE_CREATED_AT = """
+query BerthLeaseCreatedAt {
+    berthLeases {
+        edges {
+            node {
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+def test_query_berth_leases_order_by_created_at_default(superuser_api_client):
+    with freeze_time("2020-02-01"):
+        BerthLeaseFactory()
+
+    with freeze_time("2020-01-01"):
+        BerthLeaseFactory()
+
+    executed = superuser_api_client.execute(QUERY_BERTH_LEASE_CREATED_AT)
+
+    first_date = isoparse(
+        executed["data"]["berthLeases"]["edges"][0]["node"]["createdAt"]
+    )
+    second_date = isoparse(
+        executed["data"]["berthLeases"]["edges"][1]["node"]["createdAt"]
+    )
+
+    assert first_date < second_date

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -1,7 +1,10 @@
 import pytest
+from dateutil.parser import isoparse
+from freezegun import freeze_time
 from graphql_relay import to_global_id
 
 from berth_reservations.tests.utils import assert_not_enough_permissions
+from leases.tests.factories import BerthLeaseFactory
 
 QUERY_BERTH_LEASES = """
 query GetBerthLeases {
@@ -181,3 +184,46 @@ def test_query_berth_lease_invalid_id(user_api_client):
     executed = user_api_client.execute(QUERY_BERTH_LEASE)
 
     assert executed["data"]["berthLease"] is None
+
+
+BERTH_LEASES_WITH_ORDER_BY = """
+query LEASES {
+    berthLeases(orderBy: "%s") {
+        edges {
+            node {
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "order_by,ascending", [("createdAt", True), ("-createdAt", False)]
+)
+def test_query_berth_leases_order_by_created_at(
+    order_by, ascending, superuser_api_client
+):
+    with freeze_time("2020-02-01"):
+        BerthLeaseFactory()
+
+    with freeze_time("2020-01-01"):
+        BerthLeaseFactory()
+
+    query = BERTH_LEASES_WITH_ORDER_BY % order_by
+
+    executed = superuser_api_client.execute(query)
+
+    first_date = isoparse(
+        executed["data"]["berthLeases"]["edges"][0 if ascending else 1]["node"][
+            "createdAt"
+        ]
+    )
+    second_date = isoparse(
+        executed["data"]["berthLeases"]["edges"][1 if ascending else 0]["node"][
+            "createdAt"
+        ]
+    )
+
+    assert first_date < second_date


### PR DESCRIPTION
## Description :sparkles:
* Add a `orderBy` argument to `berthApplications` and `berthLeases` queries
  * The `orderBy` parameter takes either `createdAt` (ascending) or `-createdAt` (descending)
* Set `created_at | ASC` as default ordering
* Add tests for custom ordering and deafult ordering

## Issues :bug:
### Closes :no_good_woman:
**[VEN-514](https://helsinkisolutionoffice.atlassian.net/browse/VEN-514):** sort berth applications and leases query by the created_at field

## Testing :alembic:
### Automated tests :gear:️
```shell
# BerthApplications
# Specific tests:
#   - test_berth_applications_order_by_created_at_asc
#   - test_berth_applications_order_by_created_at_desc
#   - test_berth_applications_order_by_created_at_default
$ pytest applications/tests/test_applications_new_schema_queries.py

# BerthLeases
# Specific tests:
#   - test_query_berth_leases_order_by_created_at_asc
#   - test_query_berth_leases_order_by_created_at_desc
#   - test_query_berth_leases_order_by_created_at_default
$ pytest leases/tests/test_lease_queries.py
```

### Manual testing :construction_worker_man:
```graphql
query APPLICATIONS {
  berthApplications(orderBy:"-createdAt") {
    edges {
      node {
        createdAt
      }
    }
  }
}

query LEASES {
  berthLeases(orderBy:"createdAt") {
    edges {
      node {
        id
        createdAt
      }
    }
  }
}
```

## Screenshots :camera_flash:
**BerthApplications query**
<img width="347" alt="image" src="https://user-images.githubusercontent.com/15201480/76739509-f5725700-6774-11ea-9cbc-fb395aed8a24.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/15201480/76739615-1f2b7e00-6775-11ea-817b-f8ce02f59474.png">

**BerthLeases query**
<img width="346" alt="image" src="https://user-images.githubusercontent.com/15201480/76739555-0753fa00-6775-11ea-81a4-09df32d9c282.png">

<img width="349" alt="image" src="https://user-images.githubusercontent.com/15201480/76739583-15a21600-6775-11ea-8708-0ea3db1810ad.png">