### PR TITLE
VEN-523 | Replace hard-coded GQL class names with meta names

### DIFF
--- a/applications/tests/test_applications_new_schema_mutations.py
+++ b/applications/tests/test_applications_new_schema_mutations.py
@@ -1,10 +1,12 @@
 import pytest
 from graphql_relay import to_global_id
 
+from applications.new_schema import BerthApplicationNode
 from berth_reservations.tests.utils import (
     assert_field_missing,
     assert_not_enough_permissions,
 )
+from customers.schema import BerthProfileNode
 
 UPDATE_BERTH_APPLICATION_MUTATION = """
 mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
@@ -26,9 +28,9 @@ mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
 )
 def test_update_berth_application(api_client, berth_application, customer_profile):
     berth_application_id = to_global_id(
-        "BerthApplicationNode", str(berth_application.id)
+        BerthApplicationNode._meta.name, str(berth_application.id)
     )
-    customer_id = to_global_id("BerthProfileNode", str(customer_profile.id))
+    customer_id = to_global_id(BerthProfileNode._meta.name, str(customer_profile.id))
 
     variables = {
         "id": berth_application_id,
@@ -59,7 +61,9 @@ def test_update_berth_application(api_client, berth_application, customer_profil
 )
 def test_update_berth_application_no_application_id(api_client, customer_profile):
     variables = {
-        "customerId": to_global_id("BerthProfileNode", str(customer_profile.id)),
+        "customerId": to_global_id(
+            BerthProfileNode._meta.name, str(customer_profile.id)
+        ),
     }
 
     executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
@@ -72,7 +76,7 @@ def test_update_berth_application_no_application_id(api_client, customer_profile
 )
 def test_update_berth_application_no_customer_id(api_client, berth_application):
     variables = {
-        "id": to_global_id("BerthApplicationNode", str(berth_application.id)),
+        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
     }
 
     executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
@@ -89,9 +93,9 @@ def test_update_berth_application_not_enough_permissions(
     api_client, berth_application, customer_profile
 ):
     berth_application_id = to_global_id(
-        "BerthApplicationNode", str(berth_application.id)
+        BerthApplicationNode._meta.name, str(berth_application.id)
     )
-    customer_id = to_global_id("BerthProfileNode", str(customer_profile.id))
+    customer_id = to_global_id(BerthProfileNode._meta.name, str(customer_profile.id))
 
     variables = {
         "id": berth_application_id,

--- a/applications/tests/test_applications_new_schema_queries.py
+++ b/applications/tests/test_applications_new_schema_queries.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 from graphql_relay.node.node import to_global_id
 
 from applications.enums import ApplicationStatus
+from applications.new_schema import BerthApplicationNode
 from applications.tests.factories import BerthApplicationFactory
 from berth_reservations.tests.utils import assert_in_errors
 from leases.tests.factories import BerthLeaseFactory
@@ -43,7 +44,7 @@ def test_berth_applications_no_customer_filter_true(berth_application, api_clien
                 {
                     "node": {
                         "id": to_global_id(
-                            "BerthApplicationNode", berth_application.id
+                            BerthApplicationNode._meta.name, berth_application.id
                         ),
                         "customer": None,
                     }
@@ -105,7 +106,7 @@ def test_berth_applications_statuses_filter(berth_application, api_client):
                 {
                     "node": {
                         "id": to_global_id(
-                            "BerthApplicationNode", berth_application.id
+                            BerthApplicationNode._meta.name, berth_application.id
                         ),
                         "status": status_enum_str,
                     }
@@ -177,7 +178,7 @@ def test_berth_applications_statuses_filter_empty_list(berth_application, api_cl
                 {
                     "node": {
                         "id": to_global_id(
-                            "BerthApplicationNode", berth_application.id
+                            BerthApplicationNode._meta.name, berth_application.id
                         ),
                         "status": ApplicationStatus.HANDLED.name,
                     }

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -3,8 +3,12 @@ from dateutil.parser import isoparse
 from freezegun import freeze_time
 from graphql_relay import to_global_id
 
+from applications.new_schema import BerthApplicationNode
 from berth_reservations.tests.utils import assert_not_enough_permissions
+from customers.schema import BerthProfileNode, BoatNode
+from leases.schema import BerthLeaseNode
 from leases.tests.factories import BerthLeaseFactory
+from resources.schema import BerthNode, BerthTypeNode
 
 QUERY_BERTH_LEASES = """
 query GetBerthLeases {
@@ -62,11 +66,15 @@ def test_query_berth_leases(api_client, berth_lease, berth_application):
 
     executed = api_client.execute(QUERY_BERTH_LEASES)
 
-    berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
-    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
-    berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
-    customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
-    boat_id = to_global_id("BoatNode", berth_lease.boat.id)
+    berth_type_id = to_global_id(
+        BerthTypeNode._meta.name, berth_lease.berth.berth_type.id
+    )
+    berth_lease_id = to_global_id(BerthLeaseNode._meta.name, berth_lease.id)
+    berth_application_id = to_global_id(
+        BerthApplicationNode._meta.name, berth_application.id
+    )
+    customer_id = to_global_id(BerthProfileNode._meta.name, berth_lease.customer.id)
+    boat_id = to_global_id(BoatNode._meta.name, berth_lease.boat.id)
 
     assert executed["data"]["berthLeases"]["edges"][0]["node"] == {
         "id": berth_lease_id,
@@ -81,7 +89,7 @@ def test_query_berth_leases(api_client, berth_lease, berth_application):
         },
         "application": {"id": berth_application_id, "customer": {"id": customer_id}},
         "berth": {
-            "id": to_global_id("BerthNode", berth_lease.berth.id),
+            "id": to_global_id(BerthNode._meta.name, berth_lease.berth.id),
             "number": str(berth_lease.berth.number),
             "berthType": {"id": berth_type_id},
         },
@@ -142,7 +150,7 @@ query GetBerthLease {
     indirect=True,
 )
 def test_query_berth_lease(api_client, berth_lease, berth_application):
-    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
+    berth_lease_id = to_global_id(BerthLeaseNode._meta.name, berth_lease.id)
 
     berth_application.customer = berth_lease.customer
     berth_application.save()
@@ -152,10 +160,14 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
     query = QUERY_BERTH_LEASE % berth_lease_id
     executed = api_client.execute(query)
 
-    berth_type_id = to_global_id("BerthTypeNode", berth_lease.berth.berth_type.id)
-    berth_application_id = to_global_id("BerthApplicationNode", berth_application.id)
-    customer_id = to_global_id("BerthProfileNode", berth_lease.customer.id)
-    boat_id = to_global_id("BoatNode", berth_lease.boat.id)
+    berth_type_id = to_global_id(
+        BerthTypeNode._meta.name, berth_lease.berth.berth_type.id
+    )
+    berth_application_id = to_global_id(
+        BerthApplicationNode._meta.name, berth_application.id
+    )
+    customer_id = to_global_id(BerthProfileNode._meta.name, berth_lease.customer.id)
+    boat_id = to_global_id(BoatNode._meta.name, berth_lease.boat.id)
 
     assert executed["data"]["berthLease"] == {
         "id": berth_lease_id,
@@ -170,7 +182,7 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
         },
         "application": {"id": berth_application_id, "customer": {"id": customer_id}},
         "berth": {
-            "id": to_global_id("BerthNode", berth_lease.berth.id),
+            "id": to_global_id(BerthNode._meta.name, berth_lease.berth.id),
             "number": str(berth_lease.berth.number),
             "berthType": {"id": berth_type_id},
         },
@@ -181,7 +193,7 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
     "api_client", ["api_client", "user", "harbor_services"], indirect=True
 )
 def test_query_berth_lease_not_enough_permissions_valid_id(api_client, berth_lease):
-    berth_lease_id = to_global_id("BerthLeaseNode", berth_lease.id)
+    berth_lease_id = to_global_id(BerthLeaseNode._meta.name, berth_lease.id)
 
     query = QUERY_BERTH_LEASE % berth_lease_id
 

--- a/resources/tests/test_resources_mutations.py
+++ b/resources/tests/test_resources_mutations.py
@@ -19,6 +19,7 @@ from resources.models import (
     HarborMap,
     Pier,
 )
+from resources.schema import BerthNode, BerthTypeNode, HarborNode, PierNode
 
 CREATE_BERTH_MUTATION = """
 mutation CreateBerth($input: CreateBerthMutationInput!) {
@@ -41,8 +42,8 @@ def test_create_berth(pier, berth_type, api_client):
     variables = {
         "number": "9999",
         "comment": "foobar",
-        "pierId": to_global_id("PierNode", str(pier.id)),
-        "berthTypeId": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "pierId": to_global_id(PierNode._meta.name, str(pier.id)),
+        "berthTypeId": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
 
     assert Berth.objects.count() == 0
@@ -68,8 +69,8 @@ def test_create_berth_not_enough_permissions(api_client, pier, berth_type):
     variables = {
         "number": "9999",
         "comment": "foobar",
-        "pierId": to_global_id("PierNode", str(pier.id)),
-        "berthTypeId": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "pierId": to_global_id(PierNode._meta.name, str(pier.id)),
+        "berthTypeId": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
 
     assert Berth.objects.count() == 0
@@ -82,8 +83,8 @@ def test_create_berth_not_enough_permissions(api_client, pier, berth_type):
 
 def test_create_berth_no_number(pier, berth_type, superuser_api_client):
     variables = {
-        "pierId": to_global_id("PierNode", str(pier.id)),
-        "berthTypeId": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "pierId": to_global_id(PierNode._meta.name, str(pier.id)),
+        "berthTypeId": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
 
     assert Berth.objects.count() == 0
@@ -108,7 +109,7 @@ mutation DeleteBerth($input: DeleteBerthMutationInput!) {
 )
 def test_delete_berth(api_client, berth):
     variables = {
-        "id": to_global_id("BerthNode", str(berth.id)),
+        "id": to_global_id(BerthNode._meta.name, str(berth.id)),
     }
 
     assert Berth.objects.count() == 1
@@ -125,7 +126,7 @@ def test_delete_berth(api_client, berth):
 )
 def test_delete_berth_not_enough_permissions(api_client, berth):
     variables = {
-        "id": to_global_id("BerthNode", str(berth.id)),
+        "id": to_global_id(BerthNode._meta.name, str(berth.id)),
     }
 
     assert Berth.objects.count() == 1
@@ -138,7 +139,7 @@ def test_delete_berth_not_enough_permissions(api_client, berth):
 
 def test_delete_berth_inexistent_berth(superuser_api_client):
     variables = {
-        "id": to_global_id("BerthNode", uuid.uuid4()),
+        "id": to_global_id(BerthNode._meta.name, uuid.uuid4()),
     }
 
     executed = superuser_api_client.execute(DELETE_BERTH_MUTATION, input=variables)
@@ -170,9 +171,9 @@ mutation UpdateBerth($input: UpdateBerthMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_update_berth(berth, pier, berth_type, api_client):
-    global_id = to_global_id("BerthNode", str(berth.id))
-    pier_id = to_global_id("PierNode", str(pier.id))
-    berth_type_id = to_global_id("BerthTypeNode", str(berth_type.id))
+    global_id = to_global_id(BerthNode._meta.name, str(berth.id))
+    pier_id = to_global_id(PierNode._meta.name, str(pier.id))
+    berth_type_id = to_global_id(BerthTypeNode._meta.name, str(berth_type.id))
 
     variables = {
         "id": global_id,
@@ -199,8 +200,8 @@ def test_update_berth(berth, pier, berth_type, api_client):
 
 
 def test_update_berth_no_id(berth, pier, berth_type, superuser_api_client):
-    pier_id = to_global_id("PierNode", str(pier.id))
-    berth_type_id = to_global_id("BerthTypeNode", str(berth_type.id))
+    pier_id = to_global_id(PierNode._meta.name, str(pier.id))
+    berth_type_id = to_global_id(BerthTypeNode._meta.name, str(berth_type.id))
 
     variables = {
         "number": "666",
@@ -223,8 +224,8 @@ def test_update_berth_no_id(berth, pier, berth_type, superuser_api_client):
     indirect=True,
 )
 def test_update_berth_not_enough_permissions(api_client, berth, pier, berth_type):
-    pier_id = to_global_id("PierNode", str(pier.id))
-    berth_type_id = to_global_id("BerthTypeNode", str(berth_type.id))
+    pier_id = to_global_id(PierNode._meta.name, str(pier.id))
+    berth_type_id = to_global_id(BerthTypeNode._meta.name, str(berth_type.id))
 
     variables = {
         "number": "666",
@@ -323,7 +324,7 @@ mutation DeleteBerthType($input: DeleteBerthTypeMutationInput!) {
 )
 def test_delete_berth_type(api_client, berth_type):
     variables = {
-        "id": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "id": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
 
     assert BerthType.objects.count() == 1
@@ -340,7 +341,7 @@ def test_delete_berth_type(api_client, berth_type):
 )
 def test_delete_berth_type_not_enough_permissions(api_client, berth_type):
     variables = {
-        "id": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "id": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
 
     assert BerthType.objects.count() == 1
@@ -353,7 +354,7 @@ def test_delete_berth_type_not_enough_permissions(api_client, berth_type):
 
 def test_delete_berth_type_inexistent_berth(superuser_api_client):
     variables = {
-        "id": to_global_id("BerthTypeNode", uuid.uuid4()),
+        "id": to_global_id(BerthTypeNode._meta.name, uuid.uuid4()),
     }
 
     executed = superuser_api_client.execute(DELETE_BERTH_TYPE_MUTATION, input=variables)
@@ -380,7 +381,7 @@ mutation UpdateBerthTypeMutation($input: UpdateBerthTypeMutationInput!){
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_update_berth_type(berth_type, api_client):
-    global_id = to_global_id("BerthTypeNode", str(berth_type.id))
+    global_id = to_global_id(BerthTypeNode._meta.name, str(berth_type.id))
 
     variables = {
         "id": global_id,
@@ -433,7 +434,7 @@ def test_update_berth_type_no_id(superuser_api_client, berth_type):
 )
 def test_update_berth_type_not_enough_permissions(api_client, berth_type):
     variables = {
-        "id": to_global_id("BerthTypeNode", str(berth_type.id)),
+        "id": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
     }
     assert BerthType.objects.count() == 1
 
@@ -601,7 +602,7 @@ mutation DeleteHarbor($input: DeleteHarborMutationInput!) {
 )
 def test_delete_harbor(api_client, harbor):
     variables = {
-        "id": to_global_id("HarborNode", str(harbor.id)),
+        "id": to_global_id(HarborNode._meta.name, str(harbor.id)),
     }
 
     assert Harbor.objects.count() == 1
@@ -618,7 +619,7 @@ def test_delete_harbor(api_client, harbor):
 )
 def test_delete_harbor_not_enough_permissions(api_client, harbor):
     variables = {
-        "id": to_global_id("HarborNode", str(harbor.id)),
+        "id": to_global_id(HarborNode._meta.name, str(harbor.id)),
     }
 
     assert Harbor.objects.count() == 1
@@ -631,7 +632,7 @@ def test_delete_harbor_not_enough_permissions(api_client, harbor):
 
 def test_delete_harbor_inexistent_harbor(superuser_api_client):
     variables = {
-        "id": to_global_id("HarborNode", uuid.uuid4()),
+        "id": to_global_id(HarborNode._meta.name, uuid.uuid4()),
     }
 
     executed = superuser_api_client.execute(DELETE_HARBOR_MUTATION, input=variables)
@@ -678,7 +679,7 @@ mutation UpdateHarbor($input: UpdateHarborMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_update_harbor(api_client, harbor, availability_level, municipality):
-    global_id = to_global_id("HarborNode", str(harbor.id))
+    global_id = to_global_id(HarborNode._meta.name, str(harbor.id))
     image_file_name = "image.png"
     map_file_names = ["map1.pdf", "map2.pdf", "map3.pdf"]
 
@@ -756,7 +757,7 @@ def test_update_harbor(api_client, harbor, availability_level, municipality):
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_update_harbor_remove_map(api_client, harbor):
-    global_id = to_global_id("HarborNode", str(harbor.id))
+    global_id = to_global_id(HarborNode._meta.name, str(harbor.id))
     map_file_names = ["map1.pdf", "map2.pdf", "map3.pdf"]
 
     # Create map objects and get only the IDs
@@ -797,7 +798,7 @@ def test_update_harbor_no_id(superuser_api_client, harbor):
 )
 def test_update_harbor_not_enough_permissions(api_client, harbor):
     variables = {
-        "id": to_global_id("HarborNode", str(harbor.id)),
+        "id": to_global_id(HarborNode._meta.name, str(harbor.id)),
     }
     assert Harbor.objects.count() == 1
 
@@ -809,7 +810,7 @@ def test_update_harbor_not_enough_permissions(api_client, harbor):
 
 def test_update_harbor_availability_level_doesnt_exist(harbor, superuser_api_client):
     variables = {
-        "id": to_global_id("HarborNode", harbor.id),
+        "id": to_global_id(HarborNode._meta.name, harbor.id),
         "availabilityLevelId": "9999",
     }
 
@@ -823,7 +824,7 @@ def test_update_harbor_availability_level_doesnt_exist(harbor, superuser_api_cli
 
 def test_update_harbor_municipality_doesnt_exist(harbor, superuser_api_client):
     variables = {
-        "id": to_global_id("HarborNode", harbor.id),
+        "id": to_global_id(HarborNode._meta.name, harbor.id),
         "municipalityId": "foobarland",
     }
 
@@ -865,7 +866,7 @@ mutation CreatePier($input: CreatePierMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_create_pier(api_client, harbor, boat_type):
-    harbor_id = to_global_id("HarborNode", harbor.id)
+    harbor_id = to_global_id(HarborNode._meta.name, harbor.id)
     boat_types = [boat_type.id]
 
     variables = {
@@ -916,7 +917,7 @@ def test_create_pier_not_enough_permissions(api_client):
 
 
 def test_create_harbor_harbor_doesnt_exist(superuser_api_client):
-    variables = {"harborId": to_global_id("BerthNode", uuid.uuid4())}
+    variables = {"harborId": to_global_id(BerthNode._meta.name, uuid.uuid4())}
 
     assert Pier.objects.count() == 0
 
@@ -950,7 +951,7 @@ mutation DeletePier($input: DeletePierMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_delete_pier(api_client, pier):
-    variables = {"id": to_global_id("PierNode", str(pier.id))}
+    variables = {"id": to_global_id(PierNode._meta.name, str(pier.id))}
 
     assert Pier.objects.count() == 1
 
@@ -967,7 +968,7 @@ def test_delete_pier(api_client, pier):
     indirect=True,
 )
 def test_delete_pier_not_enough_permissions(api_client, pier):
-    variables = {"id": to_global_id("PierNode", str(pier.id))}
+    variables = {"id": to_global_id(PierNode._meta.name, str(pier.id))}
 
     assert Pier.objects.count() == 1
 
@@ -978,7 +979,7 @@ def test_delete_pier_not_enough_permissions(api_client, pier):
 
 
 def test_delete_pier_inexistent_pier(superuser_api_client):
-    variables = {"id": to_global_id("PierNode", uuid.uuid4())}
+    variables = {"id": to_global_id(PierNode._meta.name, uuid.uuid4())}
 
     executed = superuser_api_client.execute(DELETE_PIER_MUTATION, input=variables)
 
@@ -1020,8 +1021,8 @@ mutation UpdatePier($input: UpdatePierMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_update_pier(api_client, pier, harbor, boat_type):
-    global_id = to_global_id("PierNode", str(pier.id))
-    harbor_id = to_global_id("HarborNode", str(harbor.id))
+    global_id = to_global_id(PierNode._meta.name, str(pier.id))
+    harbor_id = to_global_id(HarborNode._meta.name, str(harbor.id))
     boat_types = [boat_type.id]
 
     variables = {
@@ -1084,7 +1085,7 @@ def test_update_pier_no_id(superuser_api_client, pier):
     indirect=True,
 )
 def test_update_pier_not_enough_permissions(api_client, pier):
-    variables = {"id": to_global_id("PierNode", str(pier.id))}
+    variables = {"id": to_global_id(PierNode._meta.name, str(pier.id))}
     assert Pier.objects.count() == 1
 
     executed = api_client.execute(UPDATE_PIER_MUTATION, input=variables)
@@ -1094,7 +1095,7 @@ def test_update_pier_not_enough_permissions(api_client, pier):
 
 
 def test_update_pier_empty_boat_type_list(superuser_api_client, pier):
-    global_id = to_global_id("PierNode", pier.id)
+    global_id = to_global_id(PierNode._meta.name, pier.id)
     variables = {"id": global_id, "suitableBoatTypes": []}
 
     assert Pier.objects.count() == 1
@@ -1111,8 +1112,8 @@ def test_update_pier_empty_boat_type_list(superuser_api_client, pier):
 
 def test_update_pier_harbor_doesnt_exist(superuser_api_client, pier):
     variables = {
-        "id": to_global_id("PierNode", pier.id),
-        "harborId": to_global_id("HarborNode", uuid.uuid4()),
+        "id": to_global_id(PierNode._meta.name, pier.id),
+        "harborId": to_global_id(HarborNode._meta.name, uuid.uuid4()),
     }
 
     assert Pier.objects.count() == 1

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -3,11 +3,14 @@ import json
 import pytest
 from graphql_relay import to_global_id
 
+from applications.new_schema import BerthApplicationNode
 from berth_reservations.tests.utils import (
     assert_in_errors,
     assert_not_enough_permissions,
 )
+from leases.schema import BerthLeaseNode
 from leases.tests.factories import BerthLeaseFactory
+from resources.schema import BerthNode, PierNode
 
 
 def test_get_boat_type(api_client, boat_type):
@@ -137,13 +140,19 @@ def test_get_berth_with_leases(api_client, berth):
             }
         }
     """ % to_global_id(
-        "BerthNode", berth.id
+        BerthNode._meta.name, berth.id
     )
     executed = api_client.execute(query)
 
     assert executed["data"]["berth"] == {
         "leases": {
-            "edges": [{"node": {"id": to_global_id("BerthLeaseNode", berth_lease.id)}}]
+            "edges": [
+                {
+                    "node": {
+                        "id": to_global_id(BerthLeaseNode._meta.name, berth_lease.id)
+                    }
+                }
+            ]
         }
     }
 
@@ -167,7 +176,7 @@ def test_get_berth_with_leases_not_enough_permissions(api_client, berth):
             }
         }
     """ % to_global_id(
-        "BerthNode", berth.id
+        BerthNode._meta.name, berth.id
     )
     executed = api_client.execute(query)
     assert_not_enough_permissions(executed)
@@ -292,7 +301,7 @@ def test_get_piers_filter_by_application(api_client, berth_application, berth):
             }
         }
     """ % to_global_id(
-        "BerthApplicationNode", berth_application.id
+        BerthApplicationNode._meta.name, berth_application.id
     )
 
     executed = api_client.execute(query)
@@ -318,7 +327,7 @@ def test_get_piers_filter_by_application(api_client, berth_application, berth):
             "edges": [
                 {
                     "node": {
-                        "id": to_global_id("PierNode", berth.pier.id),
+                        "id": to_global_id(PierNode._meta.name, berth.pier.id),
                         "properties": {"berths": {"edges": expected_berths}},
                     }
                 }
@@ -353,7 +362,7 @@ def test_get_piers_filter_error_both_filters(api_client, berth_application, bert
             }
         }
     """ % to_global_id(
-        "BerthApplicationNode", berth_application.id
+        BerthApplicationNode._meta.name, berth_application.id
     )
 
     executed = api_client.execute(query)
@@ -390,7 +399,7 @@ def test_get_piers_filter_by_application_not_enough_permissions(
             }
         }
     """ % to_global_id(
-        "BerthApplicationNode", berth_application.id
+        BerthApplicationNode._meta.name, berth_application.id
     )
 
     executed = api_client.execute(query)


### PR DESCRIPTION
## Description :sparkles:
Replace hard-coded GQL class names with the real class name taken from `Model._meta`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-523](https://helsinkisolutionoffice.atlassian.net/browse/VEN-523)**: Use GQL classes to generate global IDs

### Related :handshake:
**[VEN-509](https://helsinkisolutionoffice.atlassian.net/browse/VEN-509)**: Decoding global IDs has potential problems

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```