### PR TITLE
VEN-510 | Specify errors to be ignored by Sentry

### DIFF
--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -90,6 +90,7 @@ sentry_sdk.init(
     environment=env("SENTRY_ENVIRONMENT"),
     integrations=[DjangoIntegration()],
 )
+sentry_sdk.integrations.logging.ignore_logger("graphql.execution.utils")
 
 MEDIA_ROOT = env("MEDIA_ROOT")
 STATIC_ROOT = env("STATIC_ROOT")

--- a/berth_reservations/views.py
+++ b/berth_reservations/views.py
@@ -1,7 +1,16 @@
 import sentry_sdk
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from graphene_file_upload.django import FileUploadGraphQLView
+from graphql_jwt.exceptions import PermissionDenied as JwtPermissionDenied
 
 from .exceptions import VenepaikkaGraphQLError
+
+sentry_ignored_errors = (
+    VenepaikkaGraphQLError,
+    ObjectDoesNotExist,
+    JwtPermissionDenied,
+    PermissionDenied,
+)
 
 
 class SentryGraphQLView(FileUploadGraphQLView):
@@ -17,7 +26,7 @@ class SentryGraphQLView(FileUploadGraphQLView):
                 e
                 for e in result.errors
                 if not isinstance(
-                    getattr(e, "original_error", None), VenepaikkaGraphQLError
+                    getattr(e, "original_error", None), sentry_ignored_errors
                 )
             ]
             if errors:


### PR DESCRIPTION
## Description :sparkles:
- Add more ignores that should be ignored

## Issues :bug:
### Closes :no_good_woman:
**[VEN-510](https://helsinkisolutionoffice.atlassian.net/browse/VEN-510)**: PermissionDenied error is sent to sentry

## Testing :alembic:
### Manual testing :construction_worker_man:
1. Add a print statement to [berth_reservations/views.py#L42](https://github.com/City-of-Helsinki/berth-reservations/blob/9ade74aade04c8c8db232214bc3c991536afad75/berth_reservations/views.py#L42)
2. Execute a restricted query (i.e. `BerthApplications`) from Incognito Mode
3. The print shouldn't be printed
4. Success 👍 

## Additional notes :spiral_notepad:
Follows the [OpenCityProfile!130](https://github.com/City-of-Helsinki/open-city-profile/pull/130)

