### PR TITLE
Allow JWT tokens to be valid for 1 hour

### DIFF
--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -191,6 +191,8 @@ OIDC_API_TOKEN_AUTH = {
     "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": env.bool("TOKEN_AUTH_REQUIRE_SCOPE_PREFIX"),
 }
 
+OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
+
 GRAPHENE = {
     "SCHEMA": "berth_reservations.schema.schema",
     "MIDDLEWARE": ["graphql_jwt.middleware.JSONWebTokenMiddleware"],


### PR DESCRIPTION
## Description :sparkles:

This will allow us using JWT's `exp` value for up to 60 mins 
in the future. Default `OIDC_LEEWAY` considers them invalid
after 15 mins.