### PR TITLE
VEN-509 | Safely decode GQL global ids

### DIFF
--- a/applications/schema.py
+++ b/applications/schema.py
@@ -1,8 +1,8 @@
 import graphene
 from graphene_django.types import DjangoObjectType
-from graphql_relay.node.node import from_global_id
 
-from harbors.models import WinterStorageArea
+from harbors.schema import HarborType, WinterStorageAreaType
+from utils.relay import get_node_from_global_id
 
 from .enums import WinterStorageMethod
 from .models import (
@@ -10,7 +10,6 @@ from .models import (
     BerthSwitch,
     BerthSwitchReason,
     BoatType,
-    Harbor,
     HarborChoice,
     WinterStorageApplication,
     WinterStorageAreaChoice,
@@ -136,8 +135,9 @@ class CreateBerthApplication(graphene.Mutation):
 
         switch_data = kwargs.pop("berth_switch", None)
         if switch_data:
-            harbor_id = from_global_id(switch_data.get("harbor_id"))[1]
-            old_harbor = Harbor.objects.get(id=harbor_id)
+            old_harbor = get_node_from_global_id(
+                info, switch_data.get("harbor_id"), only_type=HarborType
+            )
             reason_id = switch_data.get("reason")
             reason = BerthSwitchReason.objects.get(id=reason_id) if reason_id else None
             berth_switch = BerthSwitch.objects.create(
@@ -153,8 +153,9 @@ class CreateBerthApplication(graphene.Mutation):
         application = BerthApplication.objects.create(**application_data)
 
         for choice in choices:
-            harbor_id = from_global_id(choice.get("harbor_id"))[1]
-            harbor = Harbor.objects.get(id=harbor_id)
+            harbor = get_node_from_global_id(
+                info, choice.get("harbor_id"), only_type=HarborType
+            )
             HarborChoice.objects.get_or_create(
                 harbor=harbor, priority=choice.get("priority"), application=application
             )
@@ -185,8 +186,9 @@ class CreateWinterStorageApplication(graphene.Mutation):
         application = WinterStorageApplication.objects.create(**application_data)
 
         for choice in chosen_areas:
-            winter_area_id = from_global_id(choice.get("winter_area_id"))[1]
-            winter_storage_area = WinterStorageArea.objects.get(id=winter_area_id)
+            winter_storage_area = get_node_from_global_id(
+                info, choice.get("winter_area_id"), only_type=WinterStorageAreaType
+            )
             WinterStorageAreaChoice.objects.get_or_create(
                 winter_storage_area=winter_storage_area,
                 priority=choice.get("priority"),

--- a/customers/schema.py
+++ b/customers/schema.py
@@ -14,6 +14,7 @@ from leases.models import BerthLease
 from leases.schema import BerthLeaseNode
 from users.decorators import view_permission_required
 from users.utils import user_has_view_permission
+from utils.relay import get_node_from_global_id
 
 from .enums import InvoicingType
 from .models import Boat, Company, CustomerProfile
@@ -87,7 +88,7 @@ class ProfileNode(BaseProfileFieldsMixin, DjangoObjectType):
     @login_required
     def __resolve_reference(self, info, **kwargs):
         user = info.context.user
-        profile = relay.Node.get_node_from_global_id(info, self.id)
+        profile = get_node_from_global_id(info, self.id, only_type=ProfileNode)
         if not profile:
             return None
 

--- a/resources/tests/test_resources_mutations.py
+++ b/resources/tests/test_resources_mutations.py
@@ -971,8 +971,8 @@ def test_create_pier_not_enough_permissions(api_client):
     assert_not_enough_permissions(executed)
 
 
-def test_create_harbor_harbor_doesnt_exist(superuser_api_client):
-    variables = {"harborId": to_global_id(BerthNode._meta.name, uuid.uuid4())}
+def test_create_pier_harbor_doesnt_exist(superuser_api_client):
+    variables = {"harborId": to_global_id(HarborNode._meta.name, uuid.uuid4())}
 
     assert Pier.objects.count() == 0
 

--- a/utils/relay.py
+++ b/utils/relay.py
@@ -1,0 +1,21 @@
+from graphene import relay
+
+from berth_reservations.exceptions import VenepaikkaGraphQLError
+
+
+def get_node_from_global_id(info, global_id, only_type):
+    """
+    Utilise relay's get_node_from_global_id to handle errors decoding invalid global ids.
+    Returns the instance found or raises an error if none was found (also the case if the ID is invalid)
+    """
+    instance = relay.Node.get_node_from_global_id(info, global_id, only_type=only_type)
+    model = only_type._meta.model
+
+    if not instance:
+        raise VenepaikkaGraphQLError(
+            model.DoesNotExist(
+                f"{model._meta.object_name} matching query does not exist."
+            )
+        )
+
+    return instance


### PR DESCRIPTION
## Description :sparkles:
- Add a util function to safely decode global GQL ids
- Update mutations to use safe decode of global ids

## Issues :bug:
### Closes :no_good_woman:
**[VEN-509](https://helsinkisolutionoffice.atlassian.net/browse/VEN-509):** Decoding global IDs has potential problems.

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```

### Manual testing :construction_worker_man:
Execute a mutation that requires decoding an ID.
```graphql
mutation HARBOR {
  updateHarbor(input: { id: "clearly_an_invalid_id" }) {
    harbor {
      id
    }
  }
}
```
It should return an error: `"Harbor matching query does not exist."`.