### PR TITLE
Hotfix: add distinct to places count

### DIFF
--- a/resources/models.py
+++ b/resources/models.py
@@ -97,7 +97,7 @@ class HarborManager(AbstractAreaManager):
             .get_queryset()
             .annotate(
                 max_depth=Max(self.max_depth_lookup),
-                number_of_places=Count("piers__berths"),
+                number_of_places=Count("piers__berths", distinct=True),
             )
         )
 
@@ -110,7 +110,7 @@ class WinterStorageAreaManager(AbstractAreaManager):
         return (
             super()
             .get_queryset()
-            .annotate(number_of_marked_places=Count("sections__places"))
+            .annotate(number_of_marked_places=Count("sections__places", distinct=True))
         )
 
 


### PR DESCRIPTION
## Description :sparkles:
Add the `distinct=True` flag to the number of places `Count` to get the actual number of places.

## Testing :alembic:
### Manual testing :construction_worker_man:
Run the Harbors query:
```graphql
query HARBORS {
  harbors {
    edges {
      node {
        properties {
          name
          maxWidth
          maxDepth
          maxLength
          numberOfPlaces
        }
      }
    }
  }
}
```
the `numberOfPlaces` should seem like reasonable numbers (between 0-250)

## Screenshots :camera_flash:
**Before**
<img width="621" alt="image" src="https://user-images.githubusercontent.com/15201480/78264931-761eaa80-750c-11ea-8369-6068552875a8.png">

**After**
<img width="730" alt="image" src="https://user-images.githubusercontent.com/15201480/78264980-859df380-750c-11ea-98f7-59debdd30e55.png">
