### PR TITLE
VEN-490 | VEN-559 | Replace BerthProfileNode for ProfileNode

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -67,6 +67,7 @@ class BerthApplicationNode(DjangoObjectType):
     boat_type = graphene.String()
     harbor_choices = graphene.List(HarborChoiceType)
     status = ApplicationStatusEnum(required=True)
+    customer = graphene.Field("customers.schema.ProfileNode")
 
     class Meta:
         model = BerthApplication
@@ -105,13 +106,13 @@ class UpdateBerthApplication(graphene.ClientIDMutation):
     @change_permission_required(BerthApplication)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        from customers.schema import BerthProfileNode
+        from customers.schema import ProfileNode
 
         application = get_node_from_global_id(
             info, input.pop("id"), only_type=BerthApplicationNode
         )
         customer = get_node_from_global_id(
-            info, input.pop("customer_id"), only_type=BerthProfileNode
+            info, input.pop("customer_id"), only_type=ProfileNode
         )
 
         application.customer = customer

--- a/applications/tests/test_applications_new_schema_mutations.py
+++ b/applications/tests/test_applications_new_schema_mutations.py
@@ -6,7 +6,7 @@ from berth_reservations.tests.utils import (
     assert_field_missing,
     assert_not_enough_permissions,
 )
-from customers.schema import BerthProfileNode
+from customers.schema import ProfileNode
 
 UPDATE_BERTH_APPLICATION_MUTATION = """
 mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
@@ -30,7 +30,7 @@ def test_update_berth_application(api_client, berth_application, customer_profil
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, str(berth_application.id)
     )
-    customer_id = to_global_id(BerthProfileNode._meta.name, str(customer_profile.id))
+    customer_id = to_global_id(ProfileNode._meta.name, str(customer_profile.id))
 
     variables = {
         "id": berth_application_id,
@@ -61,9 +61,7 @@ def test_update_berth_application(api_client, berth_application, customer_profil
 )
 def test_update_berth_application_no_application_id(api_client, customer_profile):
     variables = {
-        "customerId": to_global_id(
-            BerthProfileNode._meta.name, str(customer_profile.id)
-        ),
+        "customerId": to_global_id(ProfileNode._meta.name, str(customer_profile.id)),
     }
 
     executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
@@ -95,7 +93,7 @@ def test_update_berth_application_not_enough_permissions(
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, str(berth_application.id)
     )
-    customer_id = to_global_id(BerthProfileNode._meta.name, str(customer_profile.id))
+    customer_id = to_global_id(ProfileNode._meta.name, str(customer_profile.id))
 
     variables = {
         "id": berth_application_id,

--- a/customers/schema.py
+++ b/customers/schema.py
@@ -23,12 +23,16 @@ InvoicingTypeEnum = graphene.Enum.from_enum(InvoicingType)
 
 
 class BoatNode(DjangoObjectType):
+    owner = graphene.Field("customers.schema.ProfileNode", required=True)
+
     class Meta:
         model = Boat
         interfaces = (relay.Node,)
 
 
 class CompanyType(DjangoObjectType):
+    customer = graphene.Field("customers.schema.ProfileNode", required=True)
+
     class Meta:
         model = Company
         fields = ("business_id", "name", "address", "postal_code", "city")

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -37,6 +37,7 @@ class BerthLeaseNodeFilter(django_filters.FilterSet):
 class BerthLeaseNode(DjangoObjectType):
     berth = graphene.Field(BerthNode, required=True)
     status = LeaseStatusEnum(required=True)
+    customer = graphene.Field("customers.schema.ProfileNode", required=True)
 
     class Meta:
         model = BerthLease

--- a/leases/tests/test_lease_mutations.py
+++ b/leases/tests/test_lease_mutations.py
@@ -13,7 +13,7 @@ from berth_reservations.tests.utils import (
     assert_in_errors,
     assert_not_enough_permissions,
 )
-from customers.schema import BerthProfileNode, BoatNode
+from customers.schema import BoatNode, ProfileNode
 from leases.enums import LeaseStatus
 from leases.models import BerthLease
 from leases.schema import BerthLeaseNode
@@ -77,9 +77,7 @@ def test_create_berth_lease(api_client, berth_application, berth, customer_profi
         "comment": "",
         "boat": None,
         "customer": {
-            "id": to_global_id(
-                BerthProfileNode._meta.name, berth_application.customer.id
-            )
+            "id": to_global_id(ProfileNode._meta.name, berth_application.customer.id)
         },
         "application": {
             "id": variables.get("applicationId"),
@@ -126,9 +124,7 @@ def test_create_berth_lease_all_arguments(
         "comment": variables.get("comment"),
         "boat": {"id": variables.get("boatId")},
         "customer": {
-            "id": to_global_id(
-                BerthProfileNode._meta.name, berth_application.customer.id
-            )
+            "id": to_global_id(ProfileNode._meta.name, berth_application.customer.id)
         },
         "application": {
             "id": variables.get("applicationId"),

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -5,7 +5,7 @@ from graphql_relay import to_global_id
 
 from applications.new_schema import BerthApplicationNode
 from berth_reservations.tests.utils import assert_not_enough_permissions
-from customers.schema import BerthProfileNode, BoatNode
+from customers.schema import BoatNode, ProfileNode
 from leases.schema import BerthLeaseNode
 from leases.tests.factories import BerthLeaseFactory
 from resources.schema import BerthNode, BerthTypeNode
@@ -73,7 +73,7 @@ def test_query_berth_leases(api_client, berth_lease, berth_application):
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, berth_application.id
     )
-    customer_id = to_global_id(BerthProfileNode._meta.name, berth_lease.customer.id)
+    customer_id = to_global_id(ProfileNode._meta.name, berth_lease.customer.id)
     boat_id = to_global_id(BoatNode._meta.name, berth_lease.boat.id)
 
     assert executed["data"]["berthLeases"]["edges"][0]["node"] == {
@@ -166,7 +166,7 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, berth_application.id
     )
-    customer_id = to_global_id(BerthProfileNode._meta.name, berth_lease.customer.id)
+    customer_id = to_global_id(ProfileNode._meta.name, berth_lease.customer.id)
     boat_id = to_global_id(BoatNode._meta.name, berth_lease.boat.id)
 
     assert executed["data"]["berthLease"] == {


### PR DESCRIPTION
## Description :sparkles:
- Replace `BerthProfileNode` for `ProfileNode`
- Update corresponding tests

## Issues :bug:
### Closes :no_good_woman:
**[VEN-490](https://helsinkisolutionoffice.atlassian.net/browse/VEN-490):** Graph branches point to BerthProfileNode instead of ProfileNode
**[VEN-559](https://helsinkisolutionoffice.atlassian.net/browse/VEN-559):** Decode correct CustomerProfile ID

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```

### Manual testing :construction_worker_man:
On `Voyager` check that the only branches pointing at `BerthProfileNode` are the explicit queries, otherwise, you should see:
```
BerthLease.customer: ProfileNode!
BerthApplication.customer: ProfileNode
BoatNode.owner: ProfileNode!
ProfileNode.company: CompanyType
```