### PR TITLE
Add nullable option to get node util

### DIFF
--- a/leases/schema.py
+++ b/leases/schema.py
@@ -78,10 +78,13 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
         application = get_node_from_global_id(
-            info, input.pop("application_id"), only_type=BerthApplicationNode
+            info,
+            input.pop("application_id"),
+            only_type=BerthApplicationNode,
+            nullable=False,
         )
         berth = get_node_from_global_id(
-            info, input.pop("berth_id"), only_type=BerthNode
+            info, input.pop("berth_id"), only_type=BerthNode, nullable=False,
         )
 
         if not application.customer:
@@ -97,7 +100,7 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
             from customers.schema import BoatNode
 
             boat = get_node_from_global_id(
-                info, input.pop("boat_id"), only_type=BoatNode
+                info, input.pop("boat_id"), only_type=BoatNode, nullable=False,
             )
 
             if boat.owner.id != input["customer"].id:
@@ -126,7 +129,9 @@ class DeleteBerthLeaseMutation(graphene.ClientIDMutation):
     @delete_permission_required(BerthLease)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        lease = get_node_from_global_id(info, input.pop("id"), only_type=BerthLeaseNode)
+        lease = get_node_from_global_id(
+            info, input.pop("id"), only_type=BerthLeaseNode, nullable=False,
+        )
 
         if lease.status != LeaseStatus.DRAFTED:
             raise VenepaikkaGraphQLError(

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -416,10 +416,10 @@ class CreateBerthMutation(graphene.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
         input["pier"] = get_node_from_global_id(
-            info, input.pop("pier_id"), only_type=PierNode
+            info, input.pop("pier_id"), only_type=PierNode, nullable=False,
         )
         input["berth_type"] = get_node_from_global_id(
-            info, input.pop("berth_type_id"), only_type=BerthTypeNode
+            info, input.pop("berth_type_id"), only_type=BerthTypeNode, nullable=False,
         )
 
         berth = Berth.objects.create(**input)
@@ -439,16 +439,21 @@ class UpdateBerthMutation(graphene.ClientIDMutation):
     @change_permission_required(Berth)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        berth = get_node_from_global_id(info, input.pop("id"), only_type=BerthNode)
+        berth = get_node_from_global_id(
+            info, input.pop("id"), only_type=BerthNode, nullable=False,
+        )
 
         if input.get("pier_id"):
             input["pier"] = get_node_from_global_id(
-                info, input.pop("pier_id"), only_type=PierNode
+                info, input.pop("pier_id"), only_type=PierNode, nullable=False,
             )
 
         if input.get("berth_type_id"):
             input["berth_type"] = get_node_from_global_id(
-                info, input.pop("berth_type_id"), only_type=BerthTypeNode
+                info,
+                input.pop("berth_type_id"),
+                only_type=BerthTypeNode,
+                nullable=False,
             )
 
         update_object(berth, input)
@@ -464,7 +469,9 @@ class DeleteBerthMutation(graphene.ClientIDMutation):
     @delete_permission_required(Berth)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        berth = get_node_from_global_id(info, input.get("id"), only_type=BerthNode)
+        berth = get_node_from_global_id(
+            info, input.get("id"), only_type=BerthNode, nullable=False,
+        )
 
         delete_inactive_leases(Q(berth=berth), "Berth")
 
@@ -505,7 +512,7 @@ class UpdateBerthTypeMutation(graphene.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
         berth_type = get_node_from_global_id(
-            info, input.pop("id"), only_type=BerthTypeNode
+            info, input.pop("id"), only_type=BerthTypeNode, nullable=False,
         )
 
         update_object(berth_type, input)
@@ -522,7 +529,7 @@ class DeleteBerthTypeMutation(graphene.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
         berth_type = get_node_from_global_id(
-            info, input.pop("id"), only_type=BerthTypeNode
+            info, input.pop("id"), only_type=BerthTypeNode, nullable=False,
         )
 
         berth_type.delete()
@@ -604,7 +611,9 @@ class UpdateHarborMutation(graphene.ClientIDMutation):
     @change_permission_required(Harbor)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        harbor = get_node_from_global_id(info, input.pop("id"), only_type=HarborNode)
+        harbor = get_node_from_global_id(
+            info, input.pop("id"), only_type=HarborNode, nullable=False,
+        )
 
         try:
             availability_level_id = input.pop("availability_level_id", None)
@@ -634,7 +643,9 @@ class DeleteHarborMutation(graphene.ClientIDMutation):
     @delete_permission_required(Harbor)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        harbor = get_node_from_global_id(info, input.pop("id"), only_type=HarborNode)
+        harbor = get_node_from_global_id(
+            info, input.pop("id"), only_type=HarborNode, nullable=False,
+        )
 
         delete_inactive_leases(Q(berth__pier__harbor=harbor), "Harbor")
 
@@ -665,7 +676,7 @@ class CreatePierMutation(graphene.ClientIDMutation):
 
         if input.get("harbor_id"):
             harbor = get_node_from_global_id(
-                info, input.pop("harbor_id"), only_type=HarborNode
+                info, input.pop("harbor_id"), only_type=HarborNode, nullable=False,
             )
             input["harbor"] = harbor
 
@@ -696,11 +707,13 @@ class UpdatePierMutation(graphene.ClientIDMutation):
     @change_permission_required(Pier)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        pier = get_node_from_global_id(info, input.pop("id"), only_type=PierNode)
+        pier = get_node_from_global_id(
+            info, input.pop("id"), only_type=PierNode, nullable=False,
+        )
 
         if input.get("harbor_id"):
             harbor = get_node_from_global_id(
-                info, input.pop("harbor_id"), only_type=HarborNode
+                info, input.pop("harbor_id"), only_type=HarborNode, nullable=False,
             )
             input["harbor"] = harbor
 
@@ -729,7 +742,9 @@ class DeletePierMutation(graphene.ClientIDMutation):
     @delete_permission_required(Pier)
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        pier = get_node_from_global_id(info, input.pop("id"), only_type=PierNode)
+        pier = get_node_from_global_id(
+            info, input.pop("id"), only_type=PierNode, nullable=False,
+        )
 
         delete_inactive_leases(Q(berth__pier=pier), "Pier")
 

--- a/utils/relay.py
+++ b/utils/relay.py
@@ -3,15 +3,18 @@ from graphene import relay
 from berth_reservations.exceptions import VenepaikkaGraphQLError
 
 
-def get_node_from_global_id(info, global_id, only_type):
+def get_node_from_global_id(info, global_id, only_type, nullable=True):
     """
     Utilise relay's get_node_from_global_id to handle errors decoding invalid global ids.
     Returns the instance found or raises an error if none was found (also the case if the ID is invalid)
+
+    The nullable allows to explicitly ignore the DoesNotExist error and return None instead. This helps
+    hide information that shouldn't be returned to the client. The default value is True for tighter security.
     """
     instance = relay.Node.get_node_from_global_id(info, global_id, only_type=only_type)
     model = only_type._meta.model
 
-    if not instance:
+    if not instance and not nullable:
         raise VenepaikkaGraphQLError(
             model.DoesNotExist(
                 f"{model._meta.object_name} matching query does not exist."


### PR DESCRIPTION
## Description :sparkles:
* Add a `nullable` option to the `get_node_from_global_id` util. This allows to have better control on when to raise an error that might return sensitive information to the client
* Update the schemas to pass the tests

## Issues :bug:
### Closes :no_good_woman:
**[VEN-562](https://helsinkisolutionoffice.atlassian.net/browse/VEN-562):** Node resolver util should sometimes just return null

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```