### PR TITLE
VEN-558 | Validate that BerthLease season occurs during the same year

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -115,6 +115,13 @@ class BerthLease(AbstractLease):
         verbose_name_plural = _("berth leases")
         default_related_name = "berth_leases"
 
+    def clean(self):
+        if self.start_date.year != self.end_date.year:
+            raise ValidationError(
+                _("BerthLease start and end year have to be the same")
+            )
+        super().clean()
+
     def __str__(self):
         return " {} > {} - {} ({})".format(
             self.berth, self.start_date, self.end_date, self.status

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 import django_filters
 import graphene
 from django.core.exceptions import ValidationError
@@ -113,7 +115,9 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
         try:
             lease = BerthLease.objects.create(**input)
         except ValidationError as e:
-            raise VenepaikkaGraphQLError(e)
+            # Flatten all the error messages on a single list
+            errors = reduce(sum, e.message_dict.values(), [])
+            raise VenepaikkaGraphQLError(errors)
 
         application.status = ApplicationStatus.OFFER_GENERATED
         application.save()

--- a/leases/tests/test_lease_models.py
+++ b/leases/tests/test_lease_models.py
@@ -102,3 +102,15 @@ def test_lease_should_have_boat_owner_as_customer():
     another_customers_boat = BoatFactory()
     with pytest.raises(ValidationError):
         BerthLeaseFactory(boat=another_customers_boat)
+
+
+@freeze_time("2020-11-11T08:00:00Z")
+def test_lease_should_be_the_same_year():
+    start_date = calculate_berth_lease_start_date()
+    start_date = start_date.replace(year=start_date.year - 1)
+    end_date = calculate_berth_lease_end_date()
+
+    with pytest.raises(ValidationError) as exception:
+        BerthLeaseFactory(start_date=start_date, end_date=end_date)
+
+    assert "BerthLease start and end year have to be the same" in str(exception.value)


### PR DESCRIPTION
## Description :sparkles:
- Add a validation for `BerthLease` years

## Issues :bug:
### Closes :no_good_woman:
**[VEN-558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-558):** Validate that BerthLease season occurs during the same year

### Related :handshake:
#188 

## Testing :alembic:
### Automated tests :gear:️
```shell
$  pytest leases/tests/test_lease_models.py::test_lease_should_be_the_same_year
```

## Screenshots 📸 
**Error returned on GraphQL**
<img width="602" alt="image" src="https://user-images.githubusercontent.com/15201480/78789003-3a289100-79b5-11ea-8c5c-3e0157d1b530.png">
