### PR TITLE
VEN-569 | Avoid leases changing places

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -100,6 +100,11 @@ class BerthLease(AbstractLease):
         )
         creating = self._state.adding
         if not creating:
+            # If the berth is being changed
+            if not BerthLease.objects.filter(id=self.id, berth=self.berth).exists():
+                raise ValidationError(
+                    _("Cannot change the berth assigned to this lease")
+                )
             leases_for_given_period = leases_for_given_period.exclude(pk=self.pk)
         if leases_for_given_period.exists():
             raise ValidationError(_("Berth already has a lease"))
@@ -142,6 +147,13 @@ class WinterStorageLease(AbstractLease):
         )
         creating = self._state.adding
         if not creating:
+            # If the place is being changed
+            if not WinterStorageLease.objects.filter(
+                id=self.id, place=self.place
+            ).exists():
+                raise ValidationError(
+                    _("Cannot change the place assigned to this lease")
+                )
             existing_leases = existing_leases.exclude(pk=self.pk)
         if existing_leases.exists():
             raise ValidationError(_("WinterStoragePlace already has a lease"))

--- a/leases/tests/test_lease_models.py
+++ b/leases/tests/test_lease_models.py
@@ -187,18 +187,6 @@ def test_berth_lease_inactive_berth_raises_error(berth):
     assert "Selected berth is not active" in str(exception.value)
 
 
-def test_berth_lease_inactive_berth_updating(berth_lease, berth):
-    berth.is_active = False
-    berth.save()
-
-    assert BerthLease.objects.get(id=berth_lease.id).berth != berth
-
-    berth_lease.berth = berth
-    berth_lease.save()
-
-    assert BerthLease.objects.get(id=berth_lease.id).berth == berth
-
-
 def test_winter_storage_lease_inactive_winter_storage_raises_error(
     winter_storage_place,
 ):
@@ -211,21 +199,26 @@ def test_winter_storage_lease_inactive_winter_storage_raises_error(
     assert "Selected place is not active" in str(exception.value)
 
 
-def test_winter_storage_lease_inactive_winter_storage_updating(
+def test_berth_lease_cannot_update_berth(berth_lease, berth):
+    assert BerthLease.objects.get(id=berth_lease.id).berth != berth
+
+    with pytest.raises(ValidationError) as exception:
+        berth_lease.berth = berth
+        berth_lease.save()
+
+    assert "Cannot change the berth assigned to this lease" in str(exception.value)
+
+
+def test_winter_storage_lease_cannot_update_place(
     winter_storage_lease, winter_storage_place
 ):
-    winter_storage_place.is_active = False
-    winter_storage_place.save()
-
     assert (
         WinterStorageLease.objects.get(id=winter_storage_lease.id).place
         != winter_storage_place
     )
 
-    winter_storage_lease.place = winter_storage_place
-    winter_storage_lease.save()
+    with pytest.raises(ValidationError) as exception:
+        winter_storage_lease.place = winter_storage_place
+        winter_storage_lease.save()
 
-    assert (
-        WinterStorageLease.objects.get(id=winter_storage_lease.id).place
-        == winter_storage_place
-    )
+    assert "Cannot change the place assigned to this lease" in str(exception.value)


### PR DESCRIPTION
## Description :sparkles:
- Raise an error when the `berth/place` is being changed on a lease

## Issues :bug:
### Closes :no_good_woman:
**[VEN-569](https://helsinkisolutionoffice.atlassian.net/browse/VEN-569):** Lease shouldn't allow switching to a new place

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest  leases/tests/test_lease_models.py::test_berth_lease_cannot_update_berth
$ pytest  leases/tests/test_lease_models.py::test_winter_storage_lease_cannot_update_place
```

### Manual testing :construction_worker_man:
1. Go to the Lease page on the admin
2. Try to change the `berth/place` assigned to the lease
3. An error should be raised

## Screenshots :camera_flash:
**Error raised on admin**
<img width="341" alt="image" src="https://user-images.githubusercontent.com/15201480/79457220-88164800-7ff8-11ea-96f5-0135e3d288b9.png">