### PR TITLE
VEN-477 | Delete applications

### DIFF
--- a/applications/tests/test_applications_new_schema_mutations.py
+++ b/applications/tests/test_applications_new_schema_mutations.py
@@ -1,8 +1,12 @@
+import random
+
 import pytest
 from graphql_relay import to_global_id
 
+from applications.models import BerthApplication
 from applications.new_schema import BerthApplicationNode
 from berth_reservations.tests.utils import (
+    assert_doesnt_exist,
     assert_field_missing,
     assert_not_enough_permissions,
 )
@@ -104,3 +108,57 @@ def test_update_berth_application_not_enough_permissions(
 
     assert berth_application.customer is None
     assert_not_enough_permissions(executed)
+
+
+DELETE_BERTH_APPLICATION_MUTATION = """
+mutation DeleteBerthApplication($input: DeleteBerthApplicationMutationInput!) {
+    deleteBerthApplication(input: $input) {
+        __typename
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+def test_delete_berth_application(api_client, berth_application, customer_profile):
+    variables = {
+        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
+    }
+
+    assert BerthApplication.objects.count() == 1
+
+    api_client.execute(DELETE_BERTH_APPLICATION_MUTATION, input=variables)
+
+    assert BerthApplication.objects.count() == 0
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["api_client", "user", "berth_supervisor", "berth_handler"],
+    indirect=True,
+)
+def test_delete_berth_not_enough_permissions(api_client, berth_application):
+    variables = {
+        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
+    }
+
+    assert BerthApplication.objects.count() == 1
+
+    executed = api_client.execute(DELETE_BERTH_APPLICATION_MUTATION, input=variables)
+
+    assert BerthApplication.objects.count() == 1
+    assert_not_enough_permissions(executed)
+
+
+def test_delete_berth_inexistent_berth(superuser_api_client):
+    variables = {
+        "id": to_global_id(BerthApplicationNode._meta.name, random.randint(0, 100)),
+    }
+
+    executed = superuser_api_client.execute(
+        DELETE_BERTH_APPLICATION_MUTATION, input=variables
+    )
+
+    assert_doesnt_exist("BerthApplication", executed)


### PR DESCRIPTION
## Description :sparkles:
- Add a mutation to delete `BerthApplications`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-477](https://helsinkisolutionoffice.atlassian.net/browse/VEN-477):** Mutation to delete an application

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest applications/tests/test_applications_new_schema_mutations.py
```

### Manual testing :construction_worker_man:
```graphql
mutation DeleteBerthApplication($input: DeleteBerthApplicationMutationInput!) {
    deleteBerthApplication(input: $input) {
        __typename
    }
}
```

## Screenshots 📸 
<img width="323" alt="image" src="https://user-images.githubusercontent.com/15201480/79550373-eac31e80-80a0-11ea-8b80-2dfdb8318691.png">
