### PR TITLE
VEN-548 | Update Lease mutation

### DIFF
--- a/leases/schema.py
+++ b/leases/schema.py
@@ -1,5 +1,3 @@
-from functools import reduce
-
 import django_filters
 import graphene
 from django.core.exceptions import ValidationError
@@ -14,9 +12,10 @@ from applications.models import BerthApplication
 from applications.new_schema import BerthApplicationNode
 from berth_reservations.exceptions import VenepaikkaGraphQLError
 from customers.models import CustomerProfile
-from resources.schema import BerthNode
+from resources.schema import BerthNode, update_object
 from users.decorators import (
     add_permission_required,
+    change_permission_required,
     delete_permission_required,
     view_permission_required,
 )
@@ -63,14 +62,17 @@ class BerthLeaseNode(DjangoObjectType):
             )
 
 
+class BerthLeaseInput:
+    boat_id = graphene.ID()
+    start_date = graphene.Date()
+    end_date = graphene.Date()
+    comment = graphene.String()
+
+
 class CreateBerthLeaseMutation(graphene.ClientIDMutation):
-    class Input:
+    class Input(BerthLeaseInput):
         application_id = graphene.ID(required=True)
         berth_id = graphene.ID(required=True)
-        boat_id = graphene.ID()
-        start_date = graphene.Date()
-        end_date = graphene.Date()
-        comment = graphene.String()
 
     berth_lease = graphene.Field(BerthLeaseNode)
 
@@ -85,14 +87,15 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
             only_type=BerthApplicationNode,
             nullable=False,
         )
-        berth = get_node_from_global_id(
-            info, input.pop("berth_id"), only_type=BerthNode, nullable=False,
-        )
 
         if not application.customer:
             raise VenepaikkaGraphQLError(
                 _("Application must be connected to an existing customer first")
             )
+
+        berth = get_node_from_global_id(
+            info, input.pop("berth_id"), only_type=BerthNode, nullable=False,
+        )
 
         input["application"] = application
         input["berth"] = berth
@@ -116,13 +119,65 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
             lease = BerthLease.objects.create(**input)
         except ValidationError as e:
             # Flatten all the error messages on a single list
-            errors = reduce(sum, e.message_dict.values(), [])
+            errors = sum(e.message_dict.values(), [])
             raise VenepaikkaGraphQLError(errors)
 
         application.status = ApplicationStatus.OFFER_GENERATED
         application.save()
 
         return CreateBerthLeaseMutation(berth_lease=lease)
+
+
+class UpdateBerthLeaseMutation(graphene.ClientIDMutation):
+    class Input(BerthLeaseInput):
+        id = graphene.ID(required=True)
+        application_id = graphene.ID()
+
+    berth_lease = graphene.Field(BerthLeaseNode)
+
+    @classmethod
+    @change_permission_required(BerthLease)
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **input):
+        lease = get_node_from_global_id(
+            info, input.pop("id"), only_type=BerthLeaseNode, nullable=False,
+        )
+        application_id = input.get("application_id")
+
+        if application_id:
+            # If the application id was passed, raise an error if it doesn't exist
+            application = get_node_from_global_id(
+                info, application_id, only_type=BerthApplicationNode, nullable=False,
+            )
+            if not application.customer:
+                raise VenepaikkaGraphQLError(
+                    _("Application must be connected to an existing customer first")
+                )
+            input["application"] = application
+            input["customer"] = application.customer
+
+        if input.get("boat_id", False):
+            from customers.schema import BoatNode
+
+            boat = get_node_from_global_id(
+                info, input.pop("boat_id"), only_type=BoatNode, nullable=False,
+            )
+
+            if boat.owner.id != input["customer"].id:
+                raise VenepaikkaGraphQLError(
+                    _("Boat does not belong to the same customer as the Application")
+                )
+
+            input["boat"] = boat
+
+        try:
+            update_object(lease, input)
+        except ValidationError as e:
+            # Flatten all the error messages on a single list
+            errors = sum(e.message_dict.values(), [])
+            raise VenepaikkaGraphQLError(errors)
+
+        return UpdateBerthLeaseMutation(berth_lease=lease)
 
 
 class DeleteBerthLeaseMutation(graphene.ClientIDMutation):
@@ -183,6 +238,14 @@ class Mutation:
         "then the dates are in the same year. If the object is being created between those dates, "
         "then the start date is the date of creation and end date is 14.9 of the same year. "
         "If the object is being created after 14.9, then the dates are from next year."
+        "\n\nErrors:"
+        "\n* An application without a customer associated is passed"
+        "\n* A boat is passed and the owner of the boat differs from the owner of the application"
+    )
+
+    update_berth_lease = UpdateBerthLeaseMutation.Field(
+        description="Updates a `BerthLease` object."
+        "\n\n**Requires permissions** to edit leases."
         "\n\nErrors:"
         "\n* An application without a customer associated is passed"
         "\n* A boat is passed and the owner of the boat differs from the owner of the application"


### PR DESCRIPTION
## Description :sparkles:
- Add extra validation for leases changing application
  - Check that they belong to the same owner
  - WSApplication doesn't have a `customer` field, so it can't be checked atm
- Add the `UpdateBerthLeaseMutation`
- Create a separate `BerthLeaseInput` class to share the common input fields between mutations
- Minor changes to `CreateBerthLeaseMutation` to fail faster when the application has no customer

## Issues :bug:
### Closes :no_good_woman:
**[VEN-548](https://helsinkisolutionoffice.atlassian.net/browse/VEN-548):** 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_mutations.py
```

### Manual testing :construction_worker_man:
```graphql
mutation UpdateBerthLease($input: UpdateBerthLeaseMutationInput!) {
    updateBerthLease(input:$input){
        berthLease {
            id
            startDate
            endDate
            comment
            boat {
                id
            }
            application {
                id
                customer {
                    id
                }
            }
        }
    }
}
```

```json
{
  "id": "<BerthLeaseID>",
  "startDate": "2019-01-01",
  "endDate": "2020-09-04",
  "comment": "Such updated, very wow",
  "boatId": "<OPTIONAL>",
  "applicationId": "<OPTIONAL>",
}
```

## Screenshots :camera_flash:
**GraphQL schema**
<img width="333" alt="image" src="https://user-images.githubusercontent.com/15201480/79859636-fb91ce00-83d9-11ea-93b0-02494ec4552e.png">