### PR TITLE
VEN-589 | Add depth to berth input

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -439,8 +439,9 @@ class BerthInput(AbstractBoatPlaceInput):
     comment = graphene.String()
     is_accessible = graphene.Boolean()
     berth_type_id = graphene.ID()
-    width = graphene.Float()
-    length = graphene.Float()
+    width = graphene.Float(description=_("width (m)"))
+    length = graphene.Float(description=_("length (m)"))
+    depth = graphene.Float(description=_("depth (m)"))
     mooring_type = BerthMooringTypeEnum()
 
 
@@ -449,8 +450,9 @@ def get_berth_type(info, input):
     berth_type_id = input.pop("berth_type_id", None)
     width = input.pop("width", None)
     length = input.pop("length", None)
+    depth = input.pop("depth", None)
     mooring_type = input.pop("mooring_type", None)
-    berth_type_params = [width, length, mooring_type]
+    berth_type_params = [width, length, depth, mooring_type]
 
     # Cannot have both fields at the same time
     if berth_type_id and any(berth_type_params):
@@ -463,7 +465,7 @@ def get_berth_type(info, input):
     elif any(berth_type_params):
         if all(berth_type_params):
             berth_type, created = BerthType.objects.get_or_create(
-                width=width, length=length, mooring_type=mooring_type
+                width=width, length=length, depth=depth, mooring_type=mooring_type
             )
         else:
             raise VenepaikkaGraphQLError(_("Missing fields to associate a BerthType"))
@@ -502,7 +504,12 @@ class UpdateBerthMutation(graphene.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **input):
         # Check if the field should be updated
         if input.get("berth_type_id") or any(
-            [input.get("width"), input.get("depth"), input.get("mooring_type")]
+            [
+                input.get("width"),
+                input.get("length"),
+                input.get("depth"),
+                input.get("mooring_type"),
+            ]
         ):
             input["berth_type"] = get_berth_type(info, input)
 

--- a/resources/tests/test_resources_mutations.py
+++ b/resources/tests/test_resources_mutations.py
@@ -39,6 +39,7 @@ mutation CreateBerth($input: CreateBerthMutationInput!) {
                  id
                  width
                  length
+                 depth
                  mooringType
             }
         }
@@ -76,6 +77,7 @@ def test_create_berth(pier, berth_type, api_client):
             "id": berth_type_id,
             "width": float(berth_type.width),
             "length": float(berth_type.length),
+            "depth": float(berth_type.depth),
             "mooringType": berth_type.mooring_type.name,
         },
     }
@@ -92,6 +94,7 @@ def test_create_berth_new_berth_type(pier, api_client):
         "isActive": False,
         "width": round(random.uniform(1.5, 99.0), 2),
         "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
         "mooringType": random.choice(list(BerthMooringType)).name,
     }
 
@@ -111,6 +114,7 @@ def test_create_berth_new_berth_type(pier, api_client):
         "berthType": {
             "width": variables["width"],
             "length": variables["length"],
+            "depth": variables["depth"],
             "mooringType": variables["mooringType"],
         },
     }
@@ -127,6 +131,7 @@ def test_create_berth_existing_berth_type(pier, api_client, berth_type):
         "isActive": False,
         "width": float(berth_type.width),
         "length": float(berth_type.length),
+        "depth": float(berth_type.depth),
         "mooringType": berth_type.mooring_type.name,
     }
 
@@ -149,6 +154,7 @@ def test_create_berth_existing_berth_type(pier, api_client, berth_type):
             "id": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
             "width": variables["width"],
             "length": variables["length"],
+            "depth": variables["depth"],
             "mooringType": variables["mooringType"],
         },
     }
@@ -199,6 +205,7 @@ def test_create_berth_berth_type_id_and_params(api_client, pier, berth_type):
         "berthTypeId": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
         "width": round(random.uniform(1.5, 99.0), 2),
         "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
         "mooringType": random.choice(list(BerthMooringType)).name,
     }
 
@@ -323,6 +330,7 @@ mutation UpdateBerth($input: UpdateBerthMutationInput!) {
                 id
                  width
                  length
+                 depth
                  mooringType
             }
         }
@@ -363,6 +371,7 @@ def test_update_berth(berth, pier, api_client):
             "id": to_global_id(BerthTypeNode._meta.name, berth.berth_type.id),
             "width": float(berth.berth_type.width),
             "length": float(berth.berth_type.length),
+            "depth": float(berth.berth_type.depth),
             "mooringType": berth.berth_type.mooring_type.name,
         },
     }
@@ -400,6 +409,7 @@ def test_update_berth_existing_berth_type(berth, pier, berth_type, api_client):
             "id": variables["berthTypeId"],
             "width": float(berth_type.width),
             "length": float(berth_type.length),
+            "depth": float(berth_type.depth),
             "mooringType": berth_type.mooring_type.name,
         },
     }
@@ -415,6 +425,7 @@ def test_update_berth_new_berth_type(berth, pier, api_client):
         "id": global_id,
         "width": round(random.uniform(1.5, 99.0), 2),
         "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
         "mooringType": random.choice(list(BerthMooringType)).name,
     }
 
@@ -442,6 +453,7 @@ def test_update_berth_new_berth_type(berth, pier, api_client):
         "berthType": {
             "width": variables["width"],
             "length": variables["length"],
+            "depth": variables["depth"],
             "mooringType": variables["mooringType"],
         },
     }
@@ -498,6 +510,7 @@ def test_update_berth_berth_type_id_and_params(api_client, berth, berth_type):
         "berthTypeId": to_global_id(BerthTypeNode._meta.name, str(berth_type.id)),
         "width": round(random.uniform(1.5, 99.0), 2),
         "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
         "mooringType": random.choice(list(BerthMooringType)).name,
     }
 
@@ -519,6 +532,7 @@ def test_update_berth_missing_berth_type_params(api_client, berth):
         "id": to_global_id(BerthNode._meta.name, str(berth.id)),
         "width": round(random.uniform(1, 9.99), 2),
         "length": round(random.uniform(1, 9.99), 2),
+        "depth": round(random.uniform(1, 9.99), 2),
     }
 
     assert Berth.objects.count() == 1
@@ -550,26 +564,25 @@ mutation CreateBerthTypeMutation($input: CreateBerthTypeMutationInput!) {
     "api_client", ["harbor_services", "berth_services"], indirect=True,
 )
 def test_create_berth_type(api_client):
-    variables = {"mooringType": "DINGHY_PLACE", "width": 66.6, "length": 33.3}
+    variables = {
+        "mooringType": "DINGHY_PLACE",
+        "width": round(random.uniform(1.5, 99.0), 2),
+        "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
+    }
 
     assert BerthType.objects.count() == 0
 
     executed = api_client.execute(CREATE_BERTH_TYPE_MUTATION, input=variables)
 
     assert BerthType.objects.count() == 1
-    assert executed["data"]["createBerthType"]["berthType"]["id"] is not None
-    assert (
-        executed["data"]["createBerthType"]["berthType"]["mooringType"]
-        == variables["mooringType"]
-    )
-    assert (
-        executed["data"]["createBerthType"]["berthType"]["width"] == variables["width"]
-    )
-    assert (
-        executed["data"]["createBerthType"]["berthType"]["length"]
-        == variables["length"]
-    )
-    assert executed["data"]["createBerthType"]["berthType"]["depth"] is None
+    assert executed["data"]["createBerthType"]["berthType"].pop("id") is not None
+    assert executed["data"]["createBerthType"]["berthType"] == {
+        "mooringType": variables["mooringType"],
+        "width": variables["width"],
+        "length": variables["length"],
+        "depth": variables["depth"],
+    }
 
 
 @pytest.mark.parametrize(
@@ -578,7 +591,12 @@ def test_create_berth_type(api_client):
     indirect=True,
 )
 def test_create_berth_type_not_enough_permissions(api_client):
-    variables = {"mooringType": "DINGHY_PLACE", "width": 66.6, "length": 33.3}
+    variables = {
+        "mooringType": "DINGHY_PLACE",
+        "width": round(random.uniform(1.5, 99.0), 2),
+        "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
+    }
 
     assert BerthType.objects.count() == 0
 
@@ -589,7 +607,12 @@ def test_create_berth_type_not_enough_permissions(api_client):
 
 
 def test_create_berth_type_invalid_mooring(superuser_api_client):
-    variables = {"mooringType": "INVALID_VALUE", "width": 666, "length": 333}
+    variables = {
+        "mooringType": "INVALID_VALUE",
+        "width": round(random.uniform(1.5, 99.0), 2),
+        "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
+    }
 
     assert BerthType.objects.count() == 0
 
@@ -675,9 +698,9 @@ def test_update_berth_type(berth_type, api_client):
 
     variables = {
         "id": global_id,
-        "width": 99.9,
-        "length": 99.9,
-        "depth": 99.9,
+        "width": round(random.uniform(1.5, 99.0), 2),
+        "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
         "mooringType": "QUAYSIDE_MOORING",
     }
 
@@ -705,8 +728,9 @@ def test_update_berth_type(berth_type, api_client):
 
 def test_update_berth_type_no_id(superuser_api_client, berth_type):
     variables = {
-        "width": 999,
-        "length": 999,
+        "width": round(random.uniform(1.5, 99.0), 2),
+        "length": round(random.uniform(1.5, 99.0), 2),
+        "depth": round(random.uniform(1.5, 99.0), 2),
     }
 
     assert BerthType.objects.count() == 1


### PR DESCRIPTION
## Description :sparkles:
- Add `depth` to `BerthInput` for `create/udpate` mutations
- Update the test

## Issues :bug:
### Closes :no_good_woman:
**[VEN-589](https://helsinkisolutionoffice.atlassian.net/browse/VEN-589):** Add depth to berth mutations

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest resources/tests/test_resources_mutations.py
```

### Manual testing :construction_worker_man:
```graphql
mutation UPDATE_BERTH($input: UpdateBerthMutationInput!) {
  updateBerth(input: $input) {
    berth {
      id
      berthType {
        id
        width
        length
        depth
        mooringType
      }
    }
  }
}
```

```json
{
  "input": {
    "id":"QmVydGhOb2RlOjMzNDU5NTJhLTNiYzItNDE1NC1hOGJiLWQ5Yjg0NDlmMGI3Mg==",
    "mooringType": "STERN_BUOY_PLACE",
    "width": 6.66,
    "length": 3.33,
    "depth": 9.99,
  }
}
```


## Screenshots :camera_flash:
**UpdateBerthMutationInput:**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/15201480/80363760-5d947c80-888d-11ea-9bde-c9d286ee59e0.png">

**CreateBerthMutationInput:**
<img width="351" alt="image" src="https://user-images.githubusercontent.com/15201480/80363826-756c0080-888d-11ea-8412-23a2b405535f.png">
