### PR TITLE
VEN-585 | CountConnection

### DIFF
--- a/applications/new_schema.py
+++ b/applications/new_schema.py
@@ -12,6 +12,7 @@ from users.decorators import (
     view_permission_required,
 )
 from utils.relay import get_node_from_global_id
+from utils.schema import CountConnection
 
 from .enums import ApplicationStatus
 from .models import BerthApplication, BerthSwitch, HarborChoice
@@ -77,6 +78,7 @@ class BerthApplicationNode(DjangoObjectType):
         model = BerthApplication
         interfaces = (graphene.relay.Node,)
         exclude = ("chosen_harbors", "harborchoice_set")
+        connection_class = CountConnection
 
     def resolve_boat_type(self, info, **kwargs):
         if self.boat_type:

--- a/customers/schema.py
+++ b/customers/schema.py
@@ -24,6 +24,7 @@ from users.decorators import (
 )
 from users.utils import user_has_view_permission
 from utils.relay import get_node_from_global_id
+from utils.schema import CountConnection
 
 from .enums import BoatCertificateType, InvoicingType, OrganizationType
 from .models import Boat, BoatCertificate, CustomerProfile, Organization
@@ -39,6 +40,7 @@ class BoatCertificateNode(DjangoObjectType):
     class Meta:
         model = BoatCertificate
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
     def resolve_file(self, info, **kwargs):
         return info.context.build_absolute_uri(self.file.url) if self.file else None
@@ -51,6 +53,7 @@ class BoatNode(DjangoObjectType):
     class Meta:
         model = Boat
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
     def resolve_certificates(self, info):
         return self.certificates.all()
@@ -70,6 +73,7 @@ class OrganizationNode(DjangoObjectType):
             "postal_code",
             "city",
         )
+        connection_class = CountConnection
 
 
 PROFILE_NODE_FIELDS = (
@@ -150,6 +154,7 @@ class BerthProfileNode(BaseProfileFieldsMixin, DjangoObjectType):
         filter_fields = ("invoicing_type",)
         fields = PROFILE_NODE_FIELDS
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
     @classmethod
     @login_required

--- a/leases/schema.py
+++ b/leases/schema.py
@@ -21,6 +21,7 @@ from users.decorators import (
 )
 from users.utils import user_has_view_permission
 from utils.relay import get_node_from_global_id
+from utils.schema import CountConnection
 
 from .enums import LeaseStatus
 from .models import BerthLease
@@ -43,6 +44,7 @@ class BerthLeaseNode(DjangoObjectType):
     class Meta:
         model = BerthLease
         interfaces = (graphene.relay.Node,)
+        connection_class = CountConnection
 
     @classmethod
     @login_required

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 from dateutil.parser import isoparse
 from freezegun import freeze_time
@@ -291,3 +293,21 @@ def test_query_berth_leases_order_by_created_at_default(api_client):
     )
 
     assert first_date < second_date
+
+
+def test_query_berth_lease_count(superuser_api_client):
+    count = random.randint(1, 10)
+    for _i in range(count):
+        BerthLeaseFactory()
+
+    query = """
+        {
+            berthLeases {
+                count
+                totalCount
+            }
+        }
+    """
+
+    executed = superuser_api_client.execute(query)
+    assert executed["data"] == {"berthLeases": {"count": count, "totalCount": count}}

--- a/resources/schema.py
+++ b/resources/schema.py
@@ -26,6 +26,7 @@ from users.decorators import (
 )
 from users.utils import user_has_view_permission
 from utils.relay import get_node_from_global_id
+from utils.schema import CountConnection
 
 from .enums import BerthMooringType
 from .models import (
@@ -170,6 +171,7 @@ class PierNode(graphql_geojson.GeoJSONType):
         ]
         geojson_field = "location"
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
 
 class BerthTypeNode(DjangoObjectType):
@@ -219,6 +221,7 @@ class BerthNode(DjangoObjectType):
         )
         interfaces = (relay.Node,)
         filterset_class = BerthNodeFilterSet
+        connection_class = CountConnection
 
     @view_permission_required(BerthLease, BerthApplication, CustomerProfile)
     def resolve_leases(self, info, **kwargs):
@@ -273,6 +276,7 @@ class HarborNode(graphql_geojson.GeoJSONType):
         geojson_field = "location"
         interfaces = (relay.Node,)
         filterset_class = HarborFilter
+        connection_class = CountConnection
 
     name = graphene.String()
     street_address = graphene.String()
@@ -334,6 +338,7 @@ class WinterStoragePlaceTypeNode(DjangoObjectType):
     class Meta:
         model = WinterStoragePlaceType
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
     width = graphene.Float(description=_("width (m)"), required=True)
     length = graphene.Float(description=_("length (m)"), required=True)
@@ -351,6 +356,7 @@ class WinterStoragePlaceNode(DjangoObjectType):
             "modified_at",
         )
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
 
 class WinterStorageSectionNode(graphql_geojson.GeoJSONType):
@@ -366,6 +372,7 @@ class WinterStorageSectionNode(graphql_geojson.GeoJSONType):
         ]
         geojson_field = "location"
         interfaces = (relay.Node,)
+        connection_class = CountConnection
 
 
 class WinterStorageAreaFilter(django_filters.FilterSet):
@@ -391,6 +398,7 @@ class WinterStorageAreaNode(graphql_geojson.GeoJSONType):
         geojson_field = "location"
         interfaces = (relay.Node,)
         filterset_class = WinterStorageAreaFilter
+        connection_class = CountConnection
 
     name = graphene.String()
     street_address = graphene.String()

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -1,0 +1,21 @@
+import graphene
+
+
+class CountConnection(graphene.Connection):
+    class Meta:
+        abstract = True
+
+    count = graphene.Int(
+        description="Count of nodes on this connection with filters applied",
+        required=True,
+    )
+    total_count = graphene.Int(
+        description="Total count of nodes on this connection regardless of filters",
+        required=True,
+    )
+
+    def resolve_count(self, info):
+        return self.iterable.distinct().count()
+
+    def resolve_total_count(self, info, **kwargs):
+        return self.iterable.model.objects.count()


### PR DESCRIPTION
## Description :sparkles:
* Add `CountConnection` to expose the entity count on GQL connection fields
* Add tests for the connections using it

## Issues :bug:
### Closes :no_good_woman:
**[VEN-585](https://helsinkisolutionoffice.atlassian.net/browse/VEN-585):** Add custom connection with count attribute

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```

### Manual testing :construction_worker_man:
All the objects exposed as connections extend this class, so you can test with any resource
```graphql
query CONNECTION_TEST {
  allHarbors:harbors {
    count
    totalCount
  }
  harborsElectricity:harbors(piers_Electricity: true) {
    count
    totalCount
  }
  harborsNoElectricity:harbors(piers_Electricity: false) {
    count
    totalCount
  }
}
```
**Result:**
```json
{
  "data": {
    "allHarbors": {
      "count": 42,
      "totalCount": 42
    },
    "harborsElectricity": {
      "count": 28,
      "totalCount": 42
    },
    "harborsNoElectricity": {
      "count": 16,
      "totalCount": 42
    }
  }
}
```

## Screenshots :camera_flash:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/15201480/80470702-08b73b80-894b-11ea-8c6d-ddfa29a41b44.png">

## Additional notes :spiral_notepad:
Some of the `Node`s don't expose a query, so they cannot be tested. However, the base `connection_class` was added for consistency among nodes.