### PR TITLE
VEN-590 | Change berth number from string

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -430,7 +430,7 @@ class AbstractAreaSectionInput:
 
 
 class AbstractBoatPlaceInput:
-    number = graphene.String()
+    number = graphene.Int()
     is_active = graphene.Boolean()
 
 
@@ -475,7 +475,7 @@ def get_berth_type(info, input):
 
 class CreateBerthMutation(graphene.ClientIDMutation):
     class Input(BerthInput):
-        number = graphene.String(required=True)
+        number = graphene.Int(required=True)
         pier_id = graphene.ID(required=True)
 
     berth = graphene.Field(BerthNode)


### PR DESCRIPTION
## Description :sparkles:
- Change the input type of Berth `number` from `String` to `Int`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-590](https://helsinkisolutionoffice.atlassian.net/browse/VEN-590):** AbstractBoatPlaceInput number type is string

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```

## Screenshots :camera_flash:
**Create berth mutation**
<img width="352" alt="image" src="https://user-images.githubusercontent.com/15201480/80483178-3e195480-895e-11ea-9802-49c35d794e56.png">

**Update berth mutation**
<img width="351" alt="image" src="https://user-images.githubusercontent.com/15201480/80483234-5d17e680-895e-11ea-93f1-1000729b5d3c.png">
