### PR TITLE
VEN-591 | Hide BerthType from client

### DIFF
--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -10,7 +10,7 @@ from berth_reservations.tests.utils import assert_not_enough_permissions
 from customers.schema import BoatNode, ProfileNode
 from leases.schema import BerthLeaseNode
 from leases.tests.factories import BerthLeaseFactory
-from resources.schema import BerthNode, BerthTypeNode
+from resources.schema import BerthNode
 
 QUERY_BERTH_LEASES = """
 query GetBerthLeases {
@@ -45,9 +45,6 @@ query GetBerthLeases {
                 berth {
                     id
                     number
-                    berthType {
-                        id
-                    }
                 }
             }
         }
@@ -69,9 +66,6 @@ def test_query_berth_leases(api_client, berth_lease, berth_application):
 
     executed = api_client.execute(QUERY_BERTH_LEASES)
 
-    berth_type_id = to_global_id(
-        BerthTypeNode._meta.name, berth_lease.berth.berth_type.id
-    )
     berth_lease_id = to_global_id(BerthLeaseNode._meta.name, berth_lease.id)
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, berth_application.id
@@ -95,7 +89,6 @@ def test_query_berth_leases(api_client, berth_lease, berth_application):
         "berth": {
             "id": to_global_id(BerthNode._meta.name, berth_lease.berth.id),
             "number": berth_lease.berth.number,
-            "berthType": {"id": berth_type_id},
         },
     }
 
@@ -139,9 +132,6 @@ query GetBerthLease {
         berth {
             id
             number
-            berthType {
-                id
-            }
         }
     }
 }
@@ -164,9 +154,6 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
     query = QUERY_BERTH_LEASE % berth_lease_id
     executed = api_client.execute(query)
 
-    berth_type_id = to_global_id(
-        BerthTypeNode._meta.name, berth_lease.berth.berth_type.id
-    )
     berth_application_id = to_global_id(
         BerthApplicationNode._meta.name, berth_application.id
     )
@@ -188,7 +175,6 @@ def test_query_berth_lease(api_client, berth_lease, berth_application):
         "berth": {
             "id": to_global_id(BerthNode._meta.name, berth_lease.berth.id),
             "number": berth_lease.berth.number,
-            "berthType": {"id": berth_type_id},
         },
     }
 

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -365,10 +365,8 @@ def test_get_piers_filter_by_application(api_client, berth_application, berth):
                             berths {
                                 edges {
                                     node {
-                                        berthType {
-                                            width
-                                            length
-                                        }
+                                        width
+                                        length
                                     }
                                 }
                             }
@@ -391,10 +389,8 @@ def test_get_piers_filter_by_application(api_client, berth_application, berth):
         expected_berths = [
             {
                 "node": {
-                    "berthType": {
-                        "width": float(berth.berth_type.width),
-                        "length": float(berth.berth_type.length),
-                    }
+                    "width": float(berth.berth_type.width),
+                    "length": float(berth.berth_type.length),
                 }
             }
         ]


### PR DESCRIPTION
## Description :sparkles:
Hide the `BerthType` logic from the client by exposing the dimensions + mooring type directly on the `BerthNode` rather than having a nested field. When creating or updating a `berth`, only the dimensions and mooring type are expected, not the `berth_type_id` anymore.

When a berth is being created, a `BerthType` with the passed properties will try to be fetched from the DB, if it doesn't exist, a new one will be created and immediately associated with the new `berth`.

When a berth is being updated, a `BerthType` will try to be fetched _with the new properties_ combined with the old ones for the props not provided, if there's no matching `type`, a new one will be created and associated.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-591](https://helsinkisolutionoffice.atlassian.net/browse/VEN-591):** Hide BerthType from client

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest resources/tests/test_resources_mutations.py
```

### Manual testing :construction_worker_man:
**Query:**
```graphql
query BERTHS {
  berths(first: 5) {
    edges {
      node {
        id
        width
        length
        depth
        mooringType
      }
    }
  }
}
```

**Create:**
```graphql
mutation CREATE_BERTH($input: CreateBerthMutationInput!) {
    createBerth(input: $input) {
        berth {
            id
            width
            length
            depth
            mooringType
        }
    }
}
```
Input:
```json
{
    "number": 666,
    "pierId": "<PIER_ID>",
    "width": 3.33,
    "length": 11.1,
    "depth": 5.55,
    "mooringType": "STERN_BUOY_PLACE"
}
```

**Update:**
```graphql
mutation UPDATE_BERTH($input: UpdateBerthMutationInput!) {
    updateBerth(input: $input) {
        berth {
            id
            width
            length
            depth
            mooringType
        }
    }
}
```
Input:
```json
{
    "id": "<BERTH_ID>",
    "width": 6.66
}
```

## Screenshots :camera_flash:
**Berth node exposes the dimensions directly:**
<img width="349" alt="image" src="https://user-images.githubusercontent.com/15201480/80579461-be998d00-8a12-11ea-9340-a8a71a59b000.png">

**Create berth mutation input (no more berth_type_id):**
<img width="349" alt="image" src="https://user-images.githubusercontent.com/15201480/80579058-1a174b00-8a12-11ea-9dc6-8527cdf1e4d9.png">

**Update berth mutation input (no more berth_type_id):**
<img width="348" alt="image" src="https://user-images.githubusercontent.com/15201480/80579136-32876580-8a12-11ea-984c-423332ee445c.png">
