### PR TITLE
VEN-581 | Annotate active leases

### DIFF
--- a/leases/schema.py
+++ b/leases/schema.py
@@ -40,6 +40,14 @@ class BerthLeaseNode(DjangoObjectType):
     berth = graphene.Field(BerthNode, required=True)
     status = LeaseStatusEnum(required=True)
     customer = graphene.Field("customers.schema.ProfileNode", required=True)
+    is_active = graphene.Boolean(
+        required=True,
+        description="For a Lease to be active, it has to have `status == PAID`. "
+        "\n\nIf the present date is before the season starts (10.6.2020), "
+        "a lease will be active if it starts at the same date as the season. "
+        "If the present date is during the season, a lease will be active if the "
+        "dates `start date < today < end date`.",
+    )
 
     class Meta:
         model = BerthLease


### PR DESCRIPTION
## Description :sparkles:
* Annotate leases that are active
  * _Only_ `PAID` leases are active
  * Starting at the beginning of the season (if today is before the season starts)
  * Start date < today < end date (if today is during the season)

## Issues :bug:
### Closes :no_good_woman:
**[VEN-581](https://helsinkisolutionoffice.atlassian.net/browse/VEN-581):** Annotate active leases at the GQL API

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_models.py
```

### Manual testing :construction_worker_man:
```graphql
query LEASE {
  berthLeases {
    edges {
      node {
        id
        isActive
        startDate
        endDate
        status
      }
    }
  }
}
```

## Screenshots :camera_flash:
**Berth lease node:**
<img width="345" alt="image" src="https://user-images.githubusercontent.com/15201480/80946224-39d5b700-8df6-11ea-8190-cc08edcfb582.png">
