### PR TITLE
Hotfix: rename Service enum to avoid naming conflicts

### DIFF
--- a/payments/enums.py
+++ b/payments/enums.py
@@ -2,7 +2,7 @@ from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum
 
 
-class ServiceType(Enum):
+class ProductServiceType(Enum):
     # Fixed services
     ELECTRICITY = "electricity"
     WATER = "water"
@@ -32,21 +32,21 @@ class ServiceType(Enum):
     @staticmethod
     def FIXED_SERVICES():
         return [
-            ServiceType.ELECTRICITY,
-            ServiceType.WATER,
-            ServiceType.GATE,
-            ServiceType.MOORING,
-            ServiceType.WASTE_COLLECTION,
-            ServiceType.LIGHTING,
+            ProductServiceType.ELECTRICITY,
+            ProductServiceType.WATER,
+            ProductServiceType.GATE,
+            ProductServiceType.MOORING,
+            ProductServiceType.WASTE_COLLECTION,
+            ProductServiceType.LIGHTING,
         ]
 
     @staticmethod
     def OPTIONAL_SERVICES():
         return [
-            ServiceType.SUMMER_STORAGE_FOR_DOCKING_EQUIPMENT,
-            ServiceType.SUMMER_STORAGE_FOR_TRAILERS,
-            ServiceType.PARKING_PERMIT,
-            ServiceType.DINGHY_PLACE,
+            ProductServiceType.SUMMER_STORAGE_FOR_DOCKING_EQUIPMENT,
+            ProductServiceType.SUMMER_STORAGE_FOR_TRAILERS,
+            ProductServiceType.PARKING_PERMIT,
+            ProductServiceType.DINGHY_PLACE,
         ]
 
     def is_fixed_service(self):

--- a/payments/migrations/0001_initial.py
+++ b/payments/migrations/0001_initial.py
@@ -73,7 +73,7 @@ class Migration(migrations.Migration):
                 (
                     "service",
                     enumfields.fields.EnumField(
-                        enum=payments.enums.ServiceType,
+                        enum=payments.enums.ProductServiceType,
                         max_length=40,
                         verbose_name="service",
                     ),
@@ -246,12 +246,14 @@ class Migration(migrations.Migration):
             constraint=models.UniqueConstraint(
                 condition=models.Q(
                     service__in=[
-                        payments.enums.ServiceType(
+                        payments.enums.ProductServiceType(
                             "summer_storage_for_docking_equipment"
                         ),
-                        payments.enums.ServiceType("summer_storage_for_trailers"),
-                        payments.enums.ServiceType("parking_permit"),
-                        payments.enums.ServiceType("dinghy_place"),
+                        payments.enums.ProductServiceType(
+                            "summer_storage_for_trailers"
+                        ),
+                        payments.enums.ProductServiceType("parking_permit"),
+                        payments.enums.ProductServiceType("dinghy_place"),
                     ]
                 ),
                 fields=("service", "period"),

--- a/payments/models.py
+++ b/payments/models.py
@@ -7,7 +7,12 @@ from django.db.models import Q, UniqueConstraint
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
 
-from payments.enums import AdditionalProductType, PeriodType, PriceUnits, ServiceType
+from payments.enums import (
+    AdditionalProductType,
+    PeriodType,
+    PriceUnits,
+    ProductServiceType,
+)
 from utils.models import TimeStampedModel, UUIDModel
 
 PLACE_PRODUCT_TAX_PERCENTAGES = [Decimal(x) for x in ("24.00",)]
@@ -108,7 +113,7 @@ class WinterStorageProduct(AbstractPlaceProduct):
 
 
 class AdditionalProduct(AbstractBaseProduct):
-    service = EnumField(ServiceType, verbose_name=_("service"), max_length=40)
+    service = EnumField(ProductServiceType, verbose_name=_("service"), max_length=40)
     period = EnumField(PeriodType, max_length=8)
     tax_percentage = models.DecimalField(
         verbose_name=_("tax percentage"),
@@ -130,7 +135,7 @@ class AdditionalProduct(AbstractBaseProduct):
         constraints = [
             UniqueConstraint(
                 fields=["service", "period"],
-                condition=Q(service__in=ServiceType.OPTIONAL_SERVICES()),
+                condition=Q(service__in=ProductServiceType.OPTIONAL_SERVICES()),
                 name="optional_services_per_period",
             ),
         ]

--- a/payments/schema/__init__.py
+++ b/payments/schema/__init__.py
@@ -9,7 +9,7 @@ from .types import (
     PeriodTypeEnum,
     PlaceProductTaxEnum,
     PriceUnitsEnum,
-    ServiceTypeEnum,
+    ProductServiceTypeEnum,
     WinterStorageProductNode,
 )
 
@@ -24,6 +24,6 @@ __all__ = [
     "PlaceProductTaxEnum",
     "PriceUnitsEnum",
     "Query",
-    "ServiceTypeEnum",
+    "ProductServiceTypeEnum",
     "WinterStorageProductNode",
 ]

--- a/payments/schema/mutations.py
+++ b/payments/schema/mutations.py
@@ -20,7 +20,7 @@ from .types import (
     BerthProductNode,
     PeriodTypeEnum,
     PriceUnitsEnum,
-    ServiceTypeEnum,
+    ProductServiceTypeEnum,
     WinterStorageProductNode,
 )
 
@@ -178,7 +178,7 @@ class DeleteWinterStorageProductMutation(graphene.ClientIDMutation):
 
 
 class AdditionalProductInput:
-    service = ServiceTypeEnum()
+    service = ProductServiceTypeEnum()
     period = PeriodTypeEnum()
     price_value = graphene.Decimal()
     price_unit = PriceUnitsEnum()
@@ -187,7 +187,7 @@ class AdditionalProductInput:
 
 class CreateAdditionalProductMutation(graphene.ClientIDMutation):
     class Input(AdditionalProductInput):
-        service = ServiceTypeEnum(required=True)
+        service = ProductServiceTypeEnum(required=True)
         period = PeriodTypeEnum(required=True)
         price_value = graphene.Decimal(required=True)
 

--- a/payments/schema/queries.py
+++ b/payments/schema/queries.py
@@ -1,7 +1,7 @@
 from graphene import List, Node
 from graphene_django import DjangoConnectionField
 
-from payments.enums import AdditionalProductType, ServiceType
+from payments.enums import AdditionalProductType, ProductServiceType
 from payments.models import AdditionalProduct
 
 from .types import (
@@ -57,25 +57,25 @@ class Query:
             product_type = AdditionalProductType(product_type)
             if product_type == AdditionalProductType.FIXED_SERVICE:
                 return AdditionalProduct.objects.filter(
-                    service__in=ServiceType.FIXED_SERVICES()
+                    service__in=ProductServiceType.FIXED_SERVICES()
                 )
             elif product_type == AdditionalProductType.OPTIONAL_SERVICE:
                 return AdditionalProduct.objects.filter(
-                    service__in=ServiceType.OPTIONAL_SERVICES()
+                    service__in=ProductServiceType.OPTIONAL_SERVICES()
                 )
 
         return AdditionalProduct.objects.all()
 
     def resolve_additional_product_services(self, info, **kwargs):
-        service_list = list(ServiceType)
+        service_list = list(ProductServiceType)
         product_type = kwargs.get("product_type")
 
         if product_type:
             product_type = AdditionalProductType(product_type)
             if product_type == AdditionalProductType.FIXED_SERVICE:
-                service_list = ServiceType.FIXED_SERVICES()
+                service_list = ProductServiceType.FIXED_SERVICES()
             elif product_type == AdditionalProductType.OPTIONAL_SERVICE:
-                service_list = ServiceType.OPTIONAL_SERVICES()
+                service_list = ProductServiceType.OPTIONAL_SERVICES()
 
         return [
             AdditionalProductServiceNode(service=service) for service in service_list

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -1,7 +1,12 @@
 import graphene
 from graphene_django import DjangoConnectionField, DjangoObjectType
 
-from payments.enums import AdditionalProductType, PeriodType, PriceUnits, ServiceType
+from payments.enums import (
+    AdditionalProductType,
+    PeriodType,
+    PriceUnits,
+    ProductServiceType,
+)
 from users.decorators import view_permission_required
 from utils.enum import graphene_enum
 from utils.schema import CountConnection
@@ -19,7 +24,7 @@ PriceUnitsEnum = graphene_enum(PriceUnits)
 
 AdditionalProductTypeEnum = graphene_enum(AdditionalProductType)
 
-ServiceTypeEnum = graphene_enum(ServiceType)
+ProductServiceTypeEnum = graphene_enum(ProductServiceType)
 
 PeriodTypeEnum = graphene_enum(PeriodType)
 
@@ -101,7 +106,7 @@ class WinterStorageProductNode(DjangoObjectType, AbstractPlaceProductNode):
 
 
 class AdditionalProductNode(DjangoObjectType):
-    service = ServiceTypeEnum(required=True)
+    service = ProductServiceTypeEnum(required=True)
     period = PeriodTypeEnum(required=True)
     price_value = graphene.Decimal(required=True)
     price_unit = PriceUnitsEnum(required=True)
@@ -120,7 +125,7 @@ class AdditionalProductNode(DjangoObjectType):
 
 
 class AdditionalProductServiceNode(graphene.ObjectType):
-    service = ServiceTypeEnum(required=True)
+    service = ProductServiceTypeEnum(required=True)
     product_type = AdditionalProductTypeEnum(required=True)
 
     class Meta:

--- a/payments/tests/factories.py
+++ b/payments/tests/factories.py
@@ -5,7 +5,7 @@ import factory
 
 from resources.tests.factories import HarborFactory, WinterStorageAreaFactory
 
-from ..enums import PeriodType, PriceUnits, ServiceType
+from ..enums import PeriodType, PriceUnits, ProductServiceType
 from ..models import (
     AbstractBaseProduct,
     ADDITIONAL_PRODUCT_TAX_PERCENTAGES,
@@ -58,7 +58,7 @@ class WinterStorageProductFactory(AbstractPlaceProductFactory):
 
 
 class AdditionalProductFactory(AbstractBaseProductFactory):
-    service = factory.Faker("random_element", elements=list(ServiceType))
+    service = factory.Faker("random_element", elements=list(ProductServiceType))
     period = factory.LazyFunction(lambda: PeriodType.SEASON)
     tax_percentage = factory.LazyFunction(lambda: DEFAULT_TAX_PERCENTAGE)
 

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -5,7 +5,12 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
-from payments.enums import AdditionalProductType, PeriodType, PriceUnits, ServiceType
+from payments.enums import (
+    AdditionalProductType,
+    PeriodType,
+    PriceUnits,
+    ProductServiceType,
+)
 from payments.models import DEFAULT_TAX_PERCENTAGE
 from payments.tests.factories import (
     AdditionalProductFactory,
@@ -52,7 +57,7 @@ def test_winter_storage_product_invalid_tax():
 
 def test_additional_product_product_type_fixed():
     product = AdditionalProductFactory(
-        service=ServiceType.ELECTRICITY,
+        service=ProductServiceType.ELECTRICITY,
         tax_percentage=DEFAULT_TAX_PERCENTAGE,
         period=PeriodType.SEASON,
     )
@@ -60,12 +65,12 @@ def test_additional_product_product_type_fixed():
 
 
 def test_additional_product_product_type_optional():
-    product = AdditionalProductFactory(service=ServiceType.DINGHY_PLACE)
+    product = AdditionalProductFactory(service=ProductServiceType.DINGHY_PLACE)
     assert product.product_type == AdditionalProductType.OPTIONAL_SERVICE
 
 
 def test_additional_product_one_service_per_period():
-    service = random.choice(ServiceType.OPTIONAL_SERVICES())
+    service = random.choice(ProductServiceType.OPTIONAL_SERVICES())
     period = random.choice(list(PeriodType))
 
     AdditionalProductFactory(service=service, period=period)
@@ -84,7 +89,7 @@ def test_additional_product_one_service_per_period():
 def test_additional_product_no_season(period):
     with pytest.raises(ValidationError) as exception:
         AdditionalProductFactory(
-            service=ServiceType.ELECTRICITY,
+            service=ProductServiceType.ELECTRICITY,
             tax_percentage=DEFAULT_TAX_PERCENTAGE,
             period=period,
         )
@@ -96,7 +101,7 @@ def test_additional_product_no_season(period):
 def test_additional_product_fixed_service_tax_value():
     with pytest.raises(ValidationError) as exception:
         AdditionalProductFactory(
-            service=random.choice(ServiceType.FIXED_SERVICES()),
+            service=random.choice(ProductServiceType.FIXED_SERVICES()),
             tax_percentage=Decimal("10.00"),
         )
 

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -8,7 +8,12 @@ from berth_reservations.tests.utils import (
     assert_field_missing,
     assert_not_enough_permissions,
 )
-from payments.enums import AdditionalProductType, PeriodType, PriceUnits, ServiceType
+from payments.enums import (
+    AdditionalProductType,
+    PeriodType,
+    PriceUnits,
+    ProductServiceType,
+)
 from resources.schema import HarborNode, WinterStorageAreaNode
 from utils.relay import to_global_id
 
@@ -498,7 +503,7 @@ mutation CREATE_ADDITIONAL_PRODUCT($input: CreateAdditionalProductMutationInput!
     "api_client", ["berth_services"], indirect=True,
 )
 def test_create_additional_product(api_client):
-    service = random.choice(list(ServiceType))
+    service = random.choice(list(ProductServiceType))
     period = (
         PeriodType.SEASON
         if service.is_fixed_service()
@@ -552,7 +557,7 @@ def test_create_additional_product(api_client):
 )
 def test_create_additional_product_not_enough_permissions(api_client):
     variables = {
-        "service": random.choice(list(ServiceType)).name,
+        "service": random.choice(list(ProductServiceType)).name,
         "period": random.choice(list(PeriodType)).name,
         "priceValue": "1.00",
     }
@@ -632,7 +637,7 @@ mutation UPDATE_ADDITIONAL_PRODUCT($input: UpdateAdditionalProductMutationInput!
 )
 def test_update_additional_product(api_client, additional_product):
     product_global_id = to_global_id(AdditionalProductNode, additional_product.id)
-    service = random.choice(list(ServiceType))
+    service = random.choice(list(ProductServiceType))
     period = (
         PeriodType.SEASON
         if service.is_fixed_service()

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -3,7 +3,7 @@ import random
 import pytest
 
 from berth_reservations.tests.utils import assert_not_enough_permissions
-from payments.enums import ServiceType
+from payments.enums import ProductServiceType
 from payments.tests.factories import AdditionalProductFactory, BerthProductFactory
 from resources.schema import HarborNode, WinterStorageAreaNode
 from utils.relay import to_global_id
@@ -432,10 +432,10 @@ query ADDITIONAL_PRODUCTS {
 @pytest.mark.parametrize("filter", ["FIXED_SERVICE", "OPTIONAL_SERVICE"])
 def test_get_additional_products_filtered(superuser_api_client, filter):
     fixed = AdditionalProductFactory(
-        service=random.choice(ServiceType.FIXED_SERVICES())
+        service=random.choice(ProductServiceType.FIXED_SERVICES())
     )
     optional = AdditionalProductFactory(
-        service=random.choice(ServiceType.OPTIONAL_SERVICES())
+        service=random.choice(ProductServiceType.OPTIONAL_SERVICES())
     )
 
     executed = superuser_api_client.execute(ADDITIONAL_PRODUCTS_FILTERED_QUERY % filter)


### PR DESCRIPTION
## Description :sparkles:
Rename `ServiceType` to `ProductServiceType` to avoid naming conflicts with the Federated service (Helsinki Profile also has a `ServiceType` enum)