### PR TITLE
[Hotfix] Season date calculation

### DIFF
--- a/leases/utils.py
+++ b/leases/utils.py
@@ -1,28 +1,38 @@
 from datetime import date
 
 
-# If a lease object is being created before 10.6, then the dates are in the same year.
-# If the object is being created between those dates, then the start date is
-# the date of creation and end date is 14.9 of the same year.
-# If the object is being created after 14.9, then the dates are from next year.
-def calculate_berth_lease_start_date():
-    # Leases always start on 10.6 the earliest
+def calculate_season_start_date(lease_start: date = None) -> date:
+    """Return the date when the summer season starts
+
+    If the current date is after the season end date,
+    it returns next year's default start date.
+
+    Leases always start on 10.6 the earliest
+    """
     today = date.today()
     default = date(day=10, month=6, year=today.year)
+
+    if lease_start:
+        return default.replace(year=lease_start.year)
 
     # If today is gte than the date when all the leases end,
     # return the default start date for the next year
     if today >= date(day=14, month=9, year=today.year):
         return default.replace(year=today.year + 1)
 
-    # Otherwise, return the latest date between the default start date or today
-    return max(default, today)
+    return default
 
 
-def calculate_berth_lease_end_date():
-    # Leases always end on 14.9
+def calculate_season_end_date(lease_end: date = None) -> date:
+    """Return the date when the summer season ends
+
+    Leases always end on 14.9, the year depends on the current year
+    """
     today = date.today()
     default = date(day=14, month=9, year=today.year)
+
+    if lease_end:
+        return default.replace(year=lease_end.year)
 
     # If today is gte than the day when all leases end,
     # return the default end date for the next year
@@ -31,3 +41,25 @@ def calculate_berth_lease_end_date():
 
     # Otherwise, return the default end date for the current year
     return default
+
+
+def calculate_berth_lease_start_date() -> date:
+    """
+    Return the date when the lease season should start
+
+    If a lease object is being created before 10.6, then the dates are in the same year.
+    If the object is being created between those dates, then the start date is
+    the date of creation and end date is 14.9 of the same year.
+    If the object is being created after 14.9, then the dates are from next year.
+    """
+
+    # Otherwise, return the latest date between the default start date or today
+    return max(calculate_season_start_date(), date.today())
+
+
+def calculate_berth_lease_end_date() -> date:
+    """Return the date when the lease season should end
+
+    Leases always end on 14.9, the year depends on the current year
+    """
+    return calculate_season_end_date()

--- a/payments/models.py
+++ b/payments/models.py
@@ -10,10 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
 
 from leases.models import BerthLease, WinterStorageLease
-from leases.utils import (
-    calculate_berth_lease_end_date,
-    calculate_berth_lease_start_date,
-)
+from leases.utils import calculate_season_end_date, calculate_season_start_date
 from payments.enums import (
     AdditionalProductType,
     OrderStatus,
@@ -344,9 +341,10 @@ class Order(UUIDModel, TimeStampedModel):
             self._check_same_lease(old_instance)
 
     def is_full_season(self):
-        return (
-            self.lease.start_date == calculate_berth_lease_start_date()
-            and self.lease.end_date == calculate_berth_lease_end_date()
+        return self.lease.start_date == calculate_season_start_date(
+            lease_start=self.lease.start_date
+        ) and self.lease.end_date == calculate_season_end_date(
+            lease_end=self.lease.end_date
         )
 
     def _create_order_lines(self, section):

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -363,7 +363,12 @@ def test_order_berth_lease_right_price_for_full_season(harbor):
             order_line = OrderLine.objects.filter(
                 order=order, product__service=ProductServiceType(service)
             ).first()
-            product_price = order_line.product.price_value
+            product_price = calculate_product_partial_season_price(
+                order_line.product.price_value,
+                order.lease.start_date,
+                order.lease.end_date,
+                summer_season=True,
+            )
             order_price = order_line.price
             assert product_price == order_price
 
@@ -771,6 +776,8 @@ def test_order_line_product_price(period):
     assert order_line.tax_percentage == product.tax_percentage
 
 
+# Freezing time to avoid season price miscalculation
+@freeze_time("2020-01-01T08:00:00Z")
 def test_order_line_percentage_price():
     product = AdditionalProductFactory(price_unit=PriceUnits.PERCENTAGE)
     order_line = OrderLineFactory(

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -13,6 +13,8 @@ from berth_reservations.tests.utils import (
 from customers.schema import ProfileNode
 from leases.models import BerthLease
 from leases.schema import BerthLeaseNode
+from leases.tests.factories import BerthLeaseFactory
+from leases.utils import calculate_season_start_date
 from resources.schema import HarborNode, WinterStorageAreaNode
 from utils.relay import to_global_id
 
@@ -753,7 +755,10 @@ mutation CREATE_ORDER($input: CreateOrderMutationInput!) {
 @pytest.mark.parametrize(
     "api_client", ["berth_services"], indirect=True,
 )
-def test_create_order_berth_product(api_client, berth_product, berth_lease):
+# Freezing time to avoid season price miscalculation
+@freeze_time("2020-01-01T08:00:00Z")
+def test_create_order_berth_product(api_client, berth_product):
+    berth_lease = BerthLeaseFactory(start_date=calculate_season_start_date())
     customer_id = to_global_id(ProfileNode, berth_lease.customer.id)
     product_id = to_global_id(BerthProductNode, berth_product.id)
     lease_id = to_global_id(BerthLeaseNode, berth_lease.id)

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -7,10 +7,7 @@ from typing import Callable
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule
 
-from leases.utils import (
-    calculate_berth_lease_end_date,
-    calculate_berth_lease_start_date,
-)
+from leases.utils import calculate_season_end_date, calculate_season_start_date
 
 
 def round_price(price):
@@ -116,7 +113,7 @@ def calculate_product_partial_season_price(
     base_price: Decimal, start_date: date, end_date: date, summer_season: bool = True
 ) -> Decimal:
     # If it's the "normal" (summer) season, calculate with the normal dates
-    season_days = calculate_berth_lease_end_date() - calculate_berth_lease_start_date()
+    season_days = calculate_season_end_date() - calculate_season_start_date()
     # If it's for the opposite season ("winter season"), calculate the inverse
     if not summer_season:
         # Calculate the amount of days in the year, in case it's a leap year


### PR DESCRIPTION
## Description :sparkles:
The function that was being used to calculate the beginning of the season was used both for determine the lease start date but also to just calculate the season start. However, the default start date for a lease should be `today` if `season start < today < season end`, so there were some miscalculations by using the same function.

By adding a `use_default_date` param to the function, we can decide whether to use `today` (given the conditions) or the computed `default` start date.

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```
