### PR TITLE
VEN-703 | numberOfMarkedPlaces crashes WS areas' queries

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -399,7 +399,7 @@ class WinterStorageAreaNode(graphql_geojson.GeoJSONType):
     maps = graphene.List(WinterStorageAreaMapType, required=True)
     max_width = graphene.Float()
     max_length = graphene.Float()
-    number_of_marked_places = graphene.Int(required=True)
+    number_of_marked_places = graphene.Int()
     product = graphene.Field("payments.schema.WinterStorageProductNode")
 
     def resolve_image_file(self, info, **kwargs):


### PR DESCRIPTION
## Description :sparkles:
- Define number_of_marked_places as optional
## Issues :bug:
### Closes :no_good_woman:
[VEN-703](https://helsinkisolutionoffice.atlassian.net/browse/VEN-703)

## Testing :alembic:
### Automated tests :gear:️
None
### Manual testing :construction_worker_man:
Execute following query, it should not return error anymore:
```
query {
  winterStorageAreas {
    edges {
      node {
        id
        properties {
          numberOfMarkedPlaces
          sections {
            edges {
              node {
                id
                properties {
                  electricity
                  gate
                  summerStorageForDockingEquipment
                  summerStorageForTrailers
                  water
                  __typename
                }
                __typename
              }
              __typename
            }
            __typename
          }
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
}
```
