### PR TITLE
VEN-573 | Fix: add customer to WinterStorageApplicationAdmin

### DIFF
--- a/applications/admin.py
+++ b/applications/admin.py
@@ -241,6 +241,7 @@ class WinterStorageApplicationAdmin(admin.ModelAdmin):
                 "fields": [
                     "created_at",
                     "status",
+                    "customer",
                     "storage_method",
                     "trailer_registration_number",
                 ]


### PR DESCRIPTION
## Description :sparkles:
- Add customer to WinterStorageApplicationAdmin
## Issues :bug:
### Closes :no_good_woman:
[VEN-573](https://helsinkisolutionoffice.atlassian.net/browse/VEN-573)

## Testing :alembic:

### Manual testing :construction_worker_man:
Land to `http://localhost:8000/admin/applications/winterstorageapplication/add/`
Customer should be selectable there.


