### PR TITLE
VEN-726 | Update/Delete mutations for WSApplications

### DIFF
--- a/applications/new_schema/mutations.py
+++ b/applications/new_schema/mutations.py
@@ -1,17 +1,18 @@
 import graphene
 from django.db import transaction
 
-from applications.models import BerthApplication
+from applications.models import BerthApplication, WinterStorageApplication
 from customers.models import CustomerProfile
-from leases.models import BerthLease
+from leases.models import BerthLease, WinterStorageLease
 from users.decorators import (
     change_permission_required,
     delete_permission_required,
     view_permission_required,
 )
 from utils.relay import get_node_from_global_id
+from utils.schema import update_object
 
-from .types import BerthApplicationNode
+from .types import BerthApplicationNode, WinterStorageApplicationNode
 
 
 class BerthApplicationInput:
@@ -35,12 +36,11 @@ class UpdateBerthApplication(graphene.ClientIDMutation):
         application = get_node_from_global_id(
             info, input.pop("id"), only_type=BerthApplicationNode
         )
-        customer = get_node_from_global_id(
+        input["customer"] = get_node_from_global_id(
             info, input.pop("customer_id"), only_type=ProfileNode
         )
 
-        application.customer = customer
-        application.save()
+        update_object(application, input)
 
         return UpdateBerthApplication(berth_application=application)
 
@@ -62,8 +62,72 @@ class DeleteBerthApplicationMutation(graphene.ClientIDMutation):
         return DeleteBerthApplicationMutation()
 
 
+class WinterStorageApplicationInput:
+    # TODO: the required has to be removed once more fields are added
+    customer_id = graphene.ID(required=True)
+
+
+class UpdateWinterStorageApplication(graphene.ClientIDMutation):
+    class Input(WinterStorageApplicationInput):
+        id = graphene.ID(required=True)
+
+    winter_storage_application = graphene.Field(WinterStorageApplicationNode)
+
+    @classmethod
+    @view_permission_required(CustomerProfile, WinterStorageLease)
+    @change_permission_required(WinterStorageApplication)
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **input):
+        from customers.schema import ProfileNode
+
+        application = get_node_from_global_id(
+            info, input.pop("id"), only_type=WinterStorageApplicationNode
+        )
+        input["customer"] = get_node_from_global_id(
+            info, input.pop("customer_id"), only_type=ProfileNode
+        )
+
+        update_object(application, input)
+
+        return UpdateWinterStorageApplication(winter_storage_application=application)
+
+
+class DeleteWinterStorageApplicationMutation(graphene.ClientIDMutation):
+    class Input:
+        id = graphene.ID(required=True)
+
+    @classmethod
+    @delete_permission_required(WinterStorageApplication)
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **input):
+        application = get_node_from_global_id(
+            info,
+            input.get("id"),
+            only_type=WinterStorageApplicationNode,
+            nullable=False,
+        )
+
+        application.delete()
+
+        return DeleteBerthApplicationMutation()
+
+
 class Mutation:
     update_berth_application = UpdateBerthApplication.Field()
     delete_berth_application = DeleteBerthApplicationMutation.Field(
         description="**Requires permissions** to delete applications."
+    )
+
+    update_winter_storage_application = UpdateWinterStorageApplication.Field(
+        description="Updates a `WinterStorageApplication`."
+        "\n\n**Requires permissions** to update applications."
+        "\n\nErrors:"
+        "\n* The passed application doesn't exist"
+        "\n* The passed customer doesn't exist"
+    )
+    delete_winter_storage_application = DeleteWinterStorageApplicationMutation.Field(
+        description="Deletes a `WinterStorageApplication`."
+        "\n\n**Requires permissions** to delete applications."
+        "\n\nErrors:"
+        "\n* The passed application doesn't exist"
     )

--- a/applications/tests/test_applications_new_schema_mutations.py
+++ b/applications/tests/test_applications_new_schema_mutations.py
@@ -1,16 +1,17 @@
 import random
 
 import pytest
-from graphql_relay import to_global_id
 
-from applications.models import BerthApplication
+from applications.models import BerthApplication, WinterStorageApplication
 from applications.new_schema import BerthApplicationNode
+from applications.new_schema.types import WinterStorageApplicationNode
 from berth_reservations.tests.utils import (
     assert_doesnt_exist,
     assert_field_missing,
     assert_not_enough_permissions,
 )
 from customers.schema import ProfileNode
+from utils.relay import to_global_id
 
 UPDATE_BERTH_APPLICATION_MUTATION = """
 mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
@@ -31,10 +32,8 @@ mutation UpdateApplication($input: UpdateBerthApplicationInput!) {
     "api_client", ["berth_services"], indirect=True,
 )
 def test_update_berth_application(api_client, berth_application, customer_profile):
-    berth_application_id = to_global_id(
-        BerthApplicationNode._meta.name, str(berth_application.id)
-    )
-    customer_id = to_global_id(ProfileNode._meta.name, str(customer_profile.id))
+    berth_application_id = to_global_id(BerthApplicationNode, berth_application.id)
+    customer_id = to_global_id(ProfileNode, customer_profile.id)
 
     variables = {
         "id": berth_application_id,
@@ -65,7 +64,7 @@ def test_update_berth_application(api_client, berth_application, customer_profil
 )
 def test_update_berth_application_no_application_id(api_client, customer_profile):
     variables = {
-        "customerId": to_global_id(ProfileNode._meta.name, str(customer_profile.id)),
+        "customerId": to_global_id(ProfileNode, customer_profile.id),
     }
 
     executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
@@ -78,7 +77,7 @@ def test_update_berth_application_no_application_id(api_client, customer_profile
 )
 def test_update_berth_application_no_customer_id(api_client, berth_application):
     variables = {
-        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
+        "id": to_global_id(BerthApplicationNode, berth_application.id),
     }
 
     executed = api_client.execute(UPDATE_BERTH_APPLICATION_MUTATION, input=variables)
@@ -94,10 +93,8 @@ def test_update_berth_application_no_customer_id(api_client, berth_application):
 def test_update_berth_application_not_enough_permissions(
     api_client, berth_application, customer_profile
 ):
-    berth_application_id = to_global_id(
-        BerthApplicationNode._meta.name, str(berth_application.id)
-    )
-    customer_id = to_global_id(ProfileNode._meta.name, str(customer_profile.id))
+    berth_application_id = to_global_id(BerthApplicationNode, berth_application.id)
+    customer_id = to_global_id(ProfileNode, customer_profile.id)
 
     variables = {
         "id": berth_application_id,
@@ -124,7 +121,7 @@ mutation DeleteBerthApplication($input: DeleteBerthApplicationMutationInput!) {
 )
 def test_delete_berth_application(api_client, berth_application, customer_profile):
     variables = {
-        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
+        "id": to_global_id(BerthApplicationNode, berth_application.id),
     }
 
     assert BerthApplication.objects.count() == 1
@@ -141,7 +138,7 @@ def test_delete_berth_application(api_client, berth_application, customer_profil
 )
 def test_delete_berth_not_enough_permissions(api_client, berth_application):
     variables = {
-        "id": to_global_id(BerthApplicationNode._meta.name, str(berth_application.id)),
+        "id": to_global_id(BerthApplicationNode, berth_application.id),
     }
 
     assert BerthApplication.objects.count() == 1
@@ -152,9 +149,9 @@ def test_delete_berth_not_enough_permissions(api_client, berth_application):
     assert_not_enough_permissions(executed)
 
 
-def test_delete_berth_inexistent_berth(superuser_api_client):
+def test_delete_berth_application_inexistent_application(superuser_api_client):
     variables = {
-        "id": to_global_id(BerthApplicationNode._meta.name, random.randint(0, 100)),
+        "id": to_global_id(BerthApplicationNode, random.randint(0, 100)),
     }
 
     executed = superuser_api_client.execute(
@@ -162,3 +159,173 @@ def test_delete_berth_inexistent_berth(superuser_api_client):
     )
 
     assert_doesnt_exist("BerthApplication", executed)
+
+
+UPDATE_WINTER_STORAGE_APPLICATION_MUTATION = """
+mutation UpdateApplication($input: UpdateWinterStorageApplicationInput!) {
+    updateWinterStorageApplication(input: $input) {
+        winterStorageApplication {
+            id
+            customer {
+                id
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+def test_update_winter_storage_application(
+    api_client, winter_storage_application, customer_profile
+):
+    application_id = to_global_id(
+        WinterStorageApplicationNode, winter_storage_application.id
+    )
+    customer_id = to_global_id(ProfileNode, customer_profile.id)
+
+    variables = {
+        "id": application_id,
+        "customerId": customer_id,
+    }
+
+    assert winter_storage_application.customer is None
+
+    executed = api_client.execute(
+        UPDATE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert executed == {
+        "data": {
+            "updateWinterStorageApplication": {
+                "winterStorageApplication": {
+                    "id": application_id,
+                    "customer": {"id": customer_id},
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+def test_update_winter_storage_application_no_application_id(
+    api_client, customer_profile
+):
+    variables = {
+        "customerId": to_global_id(ProfileNode, customer_profile.id),
+    }
+
+    executed = api_client.execute(
+        UPDATE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert_field_missing("id", executed)
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+def test_update_winter_storage_application_no_customer_id(
+    api_client, winter_storage_application
+):
+    variables = {
+        "id": to_global_id(WinterStorageApplicationNode, winter_storage_application.id),
+    }
+
+    executed = api_client.execute(
+        UPDATE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert_field_missing("customerId", executed)
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["api_client", "berth_handler", "berth_supervisor", "harbor_services", "user"],
+    indirect=True,
+)
+def test_update_winter_storage_application_not_enough_permissions(
+    api_client, winter_storage_application, customer_profile
+):
+    winter_storage_application_id = to_global_id(
+        WinterStorageApplicationNode, winter_storage_application.id
+    )
+    customer_id = to_global_id(ProfileNode, customer_profile.id)
+
+    variables = {
+        "id": winter_storage_application_id,
+        "customerId": customer_id,
+    }
+
+    executed = api_client.execute(
+        UPDATE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert winter_storage_application.customer is None
+    assert_not_enough_permissions(executed)
+
+
+DELETE_WINTER_STORAGE_APPLICATION_MUTATION = """
+mutation DeleteWinterStorageApplication($input: DeleteWinterStorageApplicationMutationInput!) {
+    deleteWinterStorageApplication(input: $input) {
+        __typename
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+def test_delete_winter_storage_application(
+    api_client, winter_storage_application, customer_profile
+):
+    variables = {
+        "id": to_global_id(WinterStorageApplicationNode, winter_storage_application.id),
+    }
+
+    assert WinterStorageApplication.objects.count() == 1
+
+    api_client.execute(DELETE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables)
+
+    assert WinterStorageApplication.objects.count() == 0
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["api_client", "user", "berth_supervisor", "berth_handler"],
+    indirect=True,
+)
+def test_delete_winter_storage_application_not_enough_permissions(
+    api_client, winter_storage_application
+):
+    variables = {
+        "id": to_global_id(WinterStorageApplicationNode, winter_storage_application.id),
+    }
+
+    assert WinterStorageApplication.objects.count() == 1
+
+    executed = api_client.execute(
+        DELETE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert WinterStorageApplication.objects.count() == 1
+    assert_not_enough_permissions(executed)
+
+
+def test_delete_winter_storage_application_inexistent_application(
+    superuser_api_client,
+):
+    variables = {
+        "id": to_global_id(WinterStorageApplicationNode, random.randint(0, 100)),
+    }
+
+    executed = superuser_api_client.execute(
+        DELETE_WINTER_STORAGE_APPLICATION_MUTATION, input=variables
+    )
+
+    assert_doesnt_exist("WinterStorageApplication", executed)


### PR DESCRIPTION
## Description :sparkles:
- Add `updateWinterStorageApplication` and `deleteWinterStorageApplication` mutations and tests
- Replace the `to_global_id` being used in the test file to the simplified util function
- Minor function renamings

## Issues :bug:
### Closes :no_good_woman:
**[VEN-726](https://helsinkisolutionoffice.atlassian.net/browse/VEN-726):** Schema for winter storage applications
**[VEN-735](https://helsinkisolutionoffice.atlassian.net/browse/VEN-735):** Update WS application
**[VEN-736](https://helsinkisolutionoffice.atlassian.net/browse/VEN-736):** Delete WS application

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest applications/tests/test_applications_new_schema_mutations.py
```

## Screenshots :camera_flash:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/15201480/87294075-e1184e00-c50b-11ea-9672-573a7ac8f4d3.png">

