### PR TITLE
VEN-674 | Add django-ilmoitin queries to API

### DIFF
--- a/berth_reservations/new_schema.py
+++ b/berth_reservations/new_schema.py
@@ -1,4 +1,6 @@
+import django_ilmoitin.api.schema as django_ilmoitin_schema
 import graphene
+from django_ilmoitin.models import NotificationTemplate
 from graphene_federation import build_schema
 
 import applications.new_schema
@@ -6,6 +8,7 @@ import customers.schema
 import leases.schema
 import payments.schema
 import resources.schema
+from users.decorators import view_permission_required
 
 # =====================================================
 # New GraphQL API for the new 'resources' app
@@ -21,9 +24,15 @@ class Query(
     leases.schema.Query,
     resources.schema.Query,
     payments.schema.Query,
+    django_ilmoitin_schema.Query,
     graphene.ObjectType,
 ):
-    pass
+    @staticmethod
+    @view_permission_required(NotificationTemplate)
+    def resolve_notification_templates(parent, info, **kwargs):
+        return django_ilmoitin_schema.Query.resolve_notification_templates(
+            parent, info, **kwargs
+        )
 
 
 class Mutation(

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-filter==2.2.0      # via -r requirements.in
 django-graphql-geojson==0.1.4  # via -r requirements.in
 django-graphql-jwt==0.2.2  # via -r requirements.in
 django-helusers==0.5.2    # via -r requirements.in
-django-ilmoitin==0.2.0    # via -r requirements.in
+django-ilmoitin==0.5.2    # via -r requirements.in
 django-js-asset==1.2.2    # via django-mptt
 django-mailer==2.0        # via -r requirements.in, django-ilmoitin
 django-mptt==0.10.0       # via django-munigeo

--- a/users/management/commands/set_group_model_permissions.py
+++ b/users/management/commands/set_group_model_permissions.py
@@ -258,6 +258,14 @@ DEFAULT_MODELS_PERMS = {
             HARBOR_SERVICES: None,
         },
     },
+    "django_ilmoitin": {
+        "notificationtemplate": {
+            BERTH_SERVICES: ("view", "add", "change", "delete",),
+            BERTH_HANDLER: ("view",),
+            BERTH_SUPERVISOR: None,
+            HARBOR_SERVICES: ("view",),
+        },
+    },
 }
 
 


### PR DESCRIPTION
## Description :sparkles:
* Update the `django-ilmoitin` version to the latest
* Add the `notificationTemplates` query to the API

## Issues :bug:
### Closes :no_good_woman:
**[VEN-674](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** Existing notification templates could be queried via GQL API

## Testing :alembic:
### Manual testing :construction_worker_man:
```graphql
query Notifications {
  notificationTemplates {
    edges {
      node {
        id
        preview
        translations {
          subject
          languageCode
          preview
          bodyText
        }
      }
    }
  }
}
```