### PR TITLE
VEN-757 | Update boat type

### DIFF
--- a/customers/schema/mutations.py
+++ b/customers/schema/mutations.py
@@ -131,11 +131,6 @@ class UpdateBoatMutation(graphene.ClientIDMutation):
         boat = get_node_from_global_id(
             info, input.pop("id"), only_type=BoatNode, nullable=False
         )
-        if "boat_type_id" in input:
-            boat_type = get_node_from_global_id(
-                info, input.pop("boat_type_id"), only_type=BoatNode, nullable=True
-            )
-            input["boat_type"] = boat_type
 
         add_certificates = input.pop("add_boat_certificates", [])
         update_certificates = input.pop("update_boat_certificates", [])


### PR DESCRIPTION
## Description :sparkles:
* Fix the `updateBoat` mutation: The received `boat_type_id` was tried to be parsed as a `BoatNode.ID` which was causing the API to fail

## Issues :bug:
### Closes :no_good_woman:
**[VEN-757](https://helsinkisolutionoffice.atlassian.net/browse/VEN-757):** Updating boat type fails

## Testing :alembic:
### Manual testing :construction_worker_man:
Test the mutation with the following input:
```json
{
  "id": "Qm9hdE5vZGU6NDMzMjQ2YTQtOGU2NS00YjZlLWIxYTQtMDhiMmM1OWU5MTcx",
  "boatTypeId": "6",
  "registrationNumber": "VEN-101",
  "width": 2.5,
  "length": 7,
  "draught": null,
  "weight": null,
  "name": "Boaty McBerth",
  "model": ""
}
```