### PR TITLE
VEN-732 | Calculate correct price for WS orders

### DIFF
--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -42,6 +42,7 @@ from resources.tests.factories import (
     WinterStoragePlaceFactory,
     WinterStorageSectionFactory,
 )
+from utils.numbers import rounded
 
 
 def test_berth_product_invalid_price_unit():
@@ -208,8 +209,21 @@ def test_order_retrieves_winter_storage_lease(
         customer=customer_profile,
         product=winter_storage_product,
     )
+    sqm = (
+        winter_storage_lease.place.place_type.width
+        * winter_storage_lease.place.place_type.length
+    )
+    expected_price = calculate_product_partial_season_price(
+        winter_storage_product.price_value,
+        winter_storage_lease.start_date,
+        winter_storage_lease.end_date,
+        summer_season=False,
+    )
+    expected_price = rounded(expected_price * sqm, decimals=2)
+
     assert order.lease.id == winter_storage_lease.id
     assert order._lease_content_type.name == winter_storage_lease._meta.verbose_name
+    assert order.price == expected_price
 
 
 def test_order_berth_product_price(berth_product, customer_profile):

--- a/resources/tests/factories.py
+++ b/resources/tests/factories.py
@@ -87,10 +87,10 @@ class WinterStorageSectionFactory(AbstractAreaSectionFactory):
 
 class AbstractPlaceTypeFactory(factory.django.DjangoModelFactory):
     length = factory.Faker(
-        "pydecimal", min_value=0, max_value=999, right_digits=2, positive=True
+        "pydecimal", min_value=0, max_value=99, right_digits=2, positive=True
     )
     width = factory.Faker(
-        "pydecimal", min_value=0, max_value=999, right_digits=2, positive=True
+        "pydecimal", min_value=0, max_value=99, right_digits=2, positive=True
     )
 
 


### PR DESCRIPTION
## Description :sparkles:
* Multiply the WSProduct price for the dimensions of the WSPlace _if_ the Order has an associated lease

## Issues :bug:
### Closes :no_good_woman:
**[VEN-732](https://helsinkisolutionoffice.atlassian.net/browse/VEN-732):** WS orders do not get proper price calculated

WS products have price per square meter. When generating an Order based on WS product AND WS lease, we should take the dimensions (square meters) of the WS place related to the lease and multiply it by the price.

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_retrieves_winter_storage_lease
```