### PR TITLE
VEN-381 | Refactor profiles' queries

### DIFF
--- a/customers/schema/__init__.py
+++ b/customers/schema/__init__.py
@@ -1,7 +1,6 @@
 from .mutations import Mutation
 from .queries import Query
 from .types import (
-    BerthProfileNode,
     BoatCertificateNode,
     BoatCertificateTypeEnum,
     BoatNode,
@@ -12,7 +11,6 @@ from .types import (
 )
 
 __all__ = [
-    "BerthProfileNode",
     "BoatCertificateNode",
     "BoatCertificateTypeEnum",
     "BoatNode",

--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -6,12 +6,12 @@ from leases.models import BerthLease
 from users.decorators import view_permission_required
 
 from ..models import CustomerProfile
-from .types import BerthProfileNode
+from .types import ProfileNode
 
 
 class Query:
-    berth_profile = graphene.relay.Node.Field(BerthProfileNode)
-    berth_profiles = DjangoFilterConnectionField(BerthProfileNode)
+    berth_profile = graphene.relay.Node.Field(ProfileNode)
+    berth_profiles = DjangoFilterConnectionField(ProfileNode)
 
     @view_permission_required(CustomerProfile, BerthApplication, BerthLease)
     def resolve_berth_profiles(self, info, **kwargs):

--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -6,13 +6,37 @@ from leases.models import BerthLease
 from users.decorators import view_permission_required
 
 from ..models import CustomerProfile
-from .types import ProfileNode
+from .types import InvoicingTypeEnum, ProfileFilterSet, ProfileNode
 
 
 class Query:
     berth_profile = graphene.relay.Node.Field(ProfileNode)
-    berth_profiles = DjangoFilterConnectionField(ProfileNode)
+    berth_profiles = DjangoFilterConnectionField(
+        ProfileNode,
+        filterset_class=ProfileFilterSet,
+        invoicing_types=graphene.List(InvoicingTypeEnum),
+        description="The `invoicingTypes` filter takes a list of `InvoicingType` values "
+        "representing the desired invoicing types of the customers. If an empty list is "
+        "passed, no filter will be applied and all the results will be returned."
+        "\n\n**Requires permissions** to access customer profiles."
+        "\n\nErrors:"
+        "\n* A value passed is not a valid invoicing type",
+    )
 
     @view_permission_required(CustomerProfile, BerthApplication, BerthLease)
     def resolve_berth_profiles(self, info, **kwargs):
-        return CustomerProfile.objects.all()
+        invoicing_types = kwargs.pop("invoicing_types", [])
+
+        qs = CustomerProfile.objects
+
+        if invoicing_types:
+            qs = qs.filter(invoicing_type__in=invoicing_types)
+
+        return qs.select_related("organization").prefetch_related(
+            "boats",
+            "berth_applications",
+            "berth_leases",
+            "winter_storage_applications",
+            "winter_storage_leases",
+            "orders",
+        )

--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -6,7 +6,7 @@ from leases.models import BerthLease
 from users.decorators import view_permission_required
 
 from ..models import CustomerProfile
-from .types import InvoicingTypeEnum, ProfileFilterSet, ProfileNode
+from .types import CustomerGroupEnum, InvoicingTypeEnum, ProfileFilterSet, ProfileNode
 
 
 class Query:
@@ -15,22 +15,30 @@ class Query:
         ProfileNode,
         filterset_class=ProfileFilterSet,
         invoicing_types=graphene.List(InvoicingTypeEnum),
+        customer_groups=graphene.List(CustomerGroupEnum),
         description="The `invoicingTypes` filter takes a list of `InvoicingType` values "
         "representing the desired invoicing types of the customers. If an empty list is "
         "passed, no filter will be applied and all the results will be returned."
+        "\n\nThe `customerGroups` filter takes a list of `CustomerGroup` values "
+        "representing the desired groups of the customers. If an empty list is "
+        "passed, no filter will be applied and all the results will be returned."
         "\n\n**Requires permissions** to access customer profiles."
         "\n\nErrors:"
-        "\n* A value passed is not a valid invoicing type",
+        "\n* A value passed is not a valid invoicing type"
+        "\n* A value passed is not a valid customer group",
     )
 
     @view_permission_required(CustomerProfile, BerthApplication, BerthLease)
     def resolve_berth_profiles(self, info, **kwargs):
         invoicing_types = kwargs.pop("invoicing_types", [])
+        customer_groups = kwargs.pop("customer_groups", [])
 
         qs = CustomerProfile.objects
 
         if invoicing_types:
             qs = qs.filter(invoicing_type__in=invoicing_types)
+        if customer_groups:
+            qs = qs.filter(customer_group__in=customer_groups)
 
         return qs.select_related("organization").prefetch_related(
             "boats",

--- a/customers/schema/types.py
+++ b/customers/schema/types.py
@@ -21,6 +21,11 @@ InvoicingTypeEnum = graphene_enum(InvoicingType)
 OrganizationTypeEnum = graphene_enum(OrganizationType)
 BoatCertificateTypeEnum = graphene_enum(BoatCertificateType)
 
+CustomerGroupEnum = graphene.Enum(
+    "CustomerGroup",
+    [("PRIVATE", "private")] + [(enum.name, enum.value) for enum in OrganizationType],
+)
+
 
 class BoatCertificateNode(DjangoObjectType):
     certificate_type = BoatCertificateTypeEnum(required=True)
@@ -112,6 +117,7 @@ class ProfileNode(DjangoObjectType):
     # object in our database.
     invoicing_type = InvoicingTypeEnum()
     comment = graphene.String()
+    customer_group = CustomerGroupEnum()
     organization = graphene.Field(OrganizationNode)
     boats = DjangoConnectionField(BoatNode)
     berth_applications = DjangoFilterConnectionField(

--- a/customers/schema/types.py
+++ b/customers/schema/types.py
@@ -125,12 +125,9 @@ class ProfileNode(BaseProfileFieldsMixin, DjangoObjectType):
 
     # explicitly mark shadowed ID field as external
     # otherwise, graphene-federation cannot catch it.
-    id = external(relay.GlobalID())
     # TODO: maybe later investigate other approaches for this?
-    # there is also this bug: if we include this ProfileNode
-    # in some Query fields (e.g. profile = graphene.Field(ProfileNode))
-    # graphene will also mark ID fields as "@external" on some
-    # other random Node types (e.g. WinterStorageAreaNode)
+    #  This one might or might not be the right one.
+    id = external(relay.GlobalID())
 
     @login_required
     def __resolve_reference(self, info, **kwargs):

--- a/customers/schema/types.py
+++ b/customers/schema/types.py
@@ -69,6 +69,14 @@ class BerthApplicationFilter(django_filters.FilterSet):
     )
 
 
+class ProfileFilterSet(django_filters.FilterSet):
+    class Meta:
+        model = CustomerProfile
+        fields = ("comment",)
+
+    comment = django_filters.CharFilter(lookup_expr="icontains")
+
+
 @extend(fields="id")
 class ProfileNode(DjangoObjectType):
     """
@@ -87,7 +95,6 @@ class ProfileNode(DjangoObjectType):
             "berth_leases",
             "orders",
         )
-        filter_fields = ("comment",)
         interfaces = (relay.Node,)
         connection_class = CountConnection
 

--- a/customers/tests/test_customers_queries.py
+++ b/customers/tests/test_customers_queries.py
@@ -30,9 +30,8 @@ FEDERATED_SCHEMA_QUERY = """
 def test_profile_node_gets_extended_properly(api_client):
     executed = api_client.execute(FEDERATED_SCHEMA_QUERY)
     assert (
-        # TODO: remove the second "@key" when/if graphene-federartion fixes itself
-        'extend type ProfileNode  implements Node  @key(fields: "id") '
-        ' @key(fields: "id") {   id: ID! @external'
+        "extend type ProfileNode  implements Node "
+        ' @key(fields: "id") {   id: ID! @external '
         in executed["data"]["_service"]["sdl"]
     )
 

--- a/customers/tests/test_customers_queries.py
+++ b/customers/tests/test_customers_queries.py
@@ -15,7 +15,7 @@ from leases.schema import BerthLeaseNode
 from leases.tests.factories import BerthLeaseFactory
 from utils.relay import to_global_id
 
-from ..schema import BerthProfileNode, BoatCertificateNode, BoatNode, ProfileNode
+from ..schema import BoatCertificateNode, BoatNode, ProfileNode
 from ..tests.factories import BoatFactory, OrganizationFactory
 
 FEDERATED_SCHEMA_QUERY = """
@@ -244,7 +244,7 @@ def test_query_berth_profiles(api_client, customer_profile):
 
     executed = api_client.execute(QUERY_BERTH_PROFILES)
 
-    customer_id = to_global_id(BerthProfileNode, customer_profile.id)
+    customer_id = to_global_id(ProfileNode, customer_profile.id)
     boat_id = to_global_id(BoatNode, boat.id)
     berth_application_id = to_global_id(BerthApplicationNode, berth_application.id)
     berth_lease_id = to_global_id(BerthLeaseNode, berth_lease.id)
@@ -314,7 +314,7 @@ query GetBerthProfile {
     indirect=True,
 )
 def test_query_berth_profile(api_client, customer_profile):
-    berth_profile_id = to_global_id(BerthProfileNode, customer_profile.id)
+    berth_profile_id = to_global_id(ProfileNode, customer_profile.id)
 
     berth_application = BerthApplicationFactory(customer=customer_profile)
     berth_lease = BerthLeaseFactory(customer=customer_profile)
@@ -344,7 +344,7 @@ def test_query_berth_profile(api_client, customer_profile):
 
 
 def test_query_berth_profile_self_user(customer_profile):
-    berth_profile_id = to_global_id(BerthProfileNode, customer_profile.id)
+    berth_profile_id = to_global_id(ProfileNode, customer_profile.id)
 
     berth_application = BerthApplicationFactory(customer=customer_profile)
     berth_lease = BerthLeaseFactory(customer=customer_profile)
@@ -380,7 +380,7 @@ def test_query_berth_profile_self_user(customer_profile):
 def test_query_berth_profile_not_enough_permissions_valid_id(
     api_client, customer_profile
 ):
-    berth_profile_id = to_global_id(BerthProfileNode, customer_profile.id)
+    berth_profile_id = to_global_id(ProfileNode, customer_profile.id)
 
     query = QUERY_BERTH_PROFILE % berth_profile_id
 
@@ -411,7 +411,7 @@ query BOATS_CERTIFICATES {
 def test_query_boat_certificates(superuser_api_client, boat_certificate):
     certificate_id = to_global_id(BoatCertificateNode, boat_certificate.id)
     boat_id = to_global_id(BoatNode, boat_certificate.boat.id)
-    customer_id = to_global_id(BerthProfileNode, boat_certificate.boat.owner.id)
+    customer_id = to_global_id(ProfileNode, boat_certificate.boat.owner.id)
 
     query = QUERY_BOAT_CERTIFICATES % customer_id
 
@@ -442,7 +442,7 @@ def test_query_customer_boat_count(superuser_api_client, customer_profile):
             }
         }
     """ % to_global_id(
-        BerthProfileNode, customer_profile.id
+        ProfileNode, customer_profile.id
     )
 
     executed = superuser_api_client.execute(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ factory-boy==2.12.0       # via -r requirements.in
 faker==2.0.3              # via factory-boy
 future==0.18.1            # via pyjwkest, python-jose
 graphene-django==2.6.0    # via -r requirements.in, django-graphql-geojson, django-graphql-jwt
-graphene-federation==0.0.4  # via -r requirements.in
+graphene-federation==0.1.0  # via -r requirements.in
 graphene-file-upload==1.2.2  # via -r requirements.in
 graphene==2.1.8           # via graphene-django, graphene-federation
 graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay

--- a/utils/relay.py
+++ b/utils/relay.py
@@ -1,3 +1,4 @@
+from django.utils.translation import ugettext_lazy as _
 from graphene import relay
 from graphql_relay import (
     from_global_id as relay_from_global_id,
@@ -5,6 +6,7 @@ from graphql_relay import (
 )
 
 from berth_reservations.exceptions import VenepaikkaGraphQLError
+from users.utils import user_has_view_permission
 
 
 def get_node_from_global_id(info, global_id, only_type, nullable=True):
@@ -55,3 +57,41 @@ def from_global_id(global_id, node_type=None):
             _type == node_type._meta.name
         ), f"Must receive a {node_type._meta.name} id."
     return _id
+
+
+def return_node_if_user_has_permissions(node, user, *models):
+    """
+    Checks whether the user has permissions to access this node / model.
+
+    1. If the passed node is falsy, we return None.
+    2. Otherwise we try to get to the user this node belongs to,
+       either directly by node.user or through CustomerProfile,
+       i.e. by doing node.customer.user
+    3. If the node belongs to the user making the request,
+       the node / model is returned.
+    4. If the node does not belong to the user, but the user has
+       permissions to view the necessary models, the node / model
+       is still returned.
+    5. If the node does not belong to the user and the user has no
+       permissions to view it, an error is raised.
+
+    :param node: Graphene Node or Django Model being accessed
+    :param user: the user from the current request / session
+    :param models: Django models that user has to have permissions to
+    :return: None | Django Model or Graphene Node | Exception raised
+    """
+    if not node:
+        return None
+
+    node_user = None
+    if hasattr(node, "user"):
+        node_user = node.user
+    elif hasattr(node, "customer") and hasattr(node.customer, "user"):
+        node_user = node.customer.user
+
+    if (node_user and node_user == user) or user_has_view_permission(user, *models):
+        return node
+    else:
+        raise VenepaikkaGraphQLError(
+            _("You do not have permission to perform this action.")
+        )


### PR DESCRIPTION
## Description :sparkles:

1. Upgrade graphene-federation dependency
Newest version of graphene-federation has some bugs fixed,
including the one that caused duplicate "@key" directive
injections into the generated schema.

2. Return federated ProfileNode in our profiles' queries
BerthProfileNode had no connection to the federated ProfileNode
and contained only those CustomerProfile's fields that are stored
in our backend. If we return ProfileNode instead, clients will be
able to get the entire profile object federated across the two
backends. This will also allow the client to use our backend's
profile fields as filters / search fields, when executing the
`berthProfiles` query.

3. Modify filters for berthProfiles query
   1. Loosen up the "comment" field filter to check if comment field
   contains the passed value (now it checks if the entire comment
   is equal to the one passed to the filter).
   2. Allow filtering by invoicing types.
   In order to allow passing enums to this filtering, the logic
   had to be implemented separately in the query resolver.

4. Add customerGroup filter to berthProfiles
   1. Annotate customer's group on CustomerProfile objects.
   2. If customer is an organization, then the organizations' type
   is used as customer group, otherwise customer is considered
   to be a "private" customer.
   3. Add a filter on the `berthProfiles` query that accepts a list
   of desired `CustomerGroup` enum values.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-381](https://helsinkisolutionoffice.atlassian.net/browse/VEN-381):** Add customer type filter to the profiles query

## Testing :alembic:
### Automated tests :gear:️

```bash
pytest -ra -vv customers/tests/test_customers_queries.py
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

![Screenshot 2020-07-15 at 16 46 55](https://user-images.githubusercontent.com/24206160/87552819-dc45cc80-c6ba-11ea-83f8-343b35a2ee4f.png)
![Screenshot 2020-07-15 at 16 47 14](https://user-images.githubusercontent.com/24206160/87552825-de0f9000-c6ba-11ea-88b7-fbb9cc92e394.png)

