### PR TITLE
Upgrade django-ilmoitin's version to 0.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-filter==2.2.0      # via -r requirements.in
 django-graphql-geojson==0.1.4  # via -r requirements.in
 django-graphql-jwt==0.2.2  # via -r requirements.in
 django-helusers==0.5.2    # via -r requirements.in
-django-ilmoitin==0.5.2    # via -r requirements.in
+django-ilmoitin==0.5.3    # via -r requirements.in
 django-js-asset==1.2.2    # via django-mptt
 django-mailer==2.0        # via -r requirements.in, django-ilmoitin
 django-mptt==0.10.0       # via django-munigeo


### PR DESCRIPTION
## Description :sparkles:

The new version includes a hotfix, that changes the name of the
language enum to a prefixed one - `NotificationTemplateLanguage`.
With this hotfix, our schema will not clash anymore with the
profile's schema and federation gateway will generate the combined
schema successfully.
