### PR TITLE
VEN-762 | Add number of unavailable places to piers

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -143,6 +143,7 @@ class BoatTypeType(DjangoObjectType):
 
 class PierNode(graphql_geojson.GeoJSONType):
     number_of_free_places = graphene.Int(required=True)
+    number_of_inactive_places = graphene.Int(required=True)
     number_of_places = graphene.Int(required=True)
     max_width = graphene.Float()
     max_length = graphene.Float()
@@ -282,6 +283,7 @@ class HarborNode(graphql_geojson.GeoJSONType):
     max_depth = graphene.Float()
     number_of_places = graphene.Int(required=True)
     number_of_free_places = graphene.Int(required=True)
+    number_of_inactive_places = graphene.Int(required=True)
     piers = DjangoFilterConnectionField(
         PierNode,
         min_berth_width=graphene.Float(),
@@ -323,6 +325,9 @@ class HarborNode(graphql_geojson.GeoJSONType):
 
     def resolve_number_of_free_places(self, info, **kwargs):
         return sum([pier.number_of_free_places or 0 for pier in self.piers.all()])
+
+    def resolve_number_of_inactive_places(self, info, **kwargs):
+        return sum([pier.number_of_inactive_places or 0 for pier in self.piers.all()])
 
     def resolve_number_of_places(self, info, **kwargs):
         return sum([pier.number_of_places or 0 for pier in self.piers.all()])

--- a/resources/tests/test_resources_models.py
+++ b/resources/tests/test_resources_models.py
@@ -21,10 +21,11 @@ from resources.models import (
     get_winter_area_media_folder,
     Harbor,
     HarborMap,
+    Pier,
     WinterStorageArea,
     WinterStorageAreaMap,
 )
-from resources.tests.factories import BerthTypeFactory
+from resources.tests.factories import BerthFactory, BerthTypeFactory, PierFactory
 
 
 def test_harbor_map_file_path(harbor):
@@ -461,3 +462,20 @@ def test_berth_type_is_assigned_existing_price_group():
     berth_type = BerthTypeFactory(width=width)
 
     assert BerthType.objects.get(id=berth_type.id).price_group == price_group
+
+
+def test_pier_number_of_places():
+    pier = PierFactory()
+    free_berths = random.randint(1, 10)
+    inactive_berths = random.randint(1, 10)
+
+    for _berth in range(0, free_berths):
+        BerthFactory(pier=pier, is_active=True)
+
+    for _berth in range(0, inactive_berths):
+        BerthFactory(pier=pier, is_active=False)
+
+    pier = Pier.objects.get(pk=pier.pk)
+    assert pier.number_of_free_places == free_berths
+    assert pier.number_of_inactive_places == inactive_berths
+    assert pier.number_of_places == free_berths + inactive_berths

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -35,8 +35,18 @@ def test_get_boat_type(api_client, boat_type):
     assert executed["data"] == {"boatTypes": [{"name": boat_type.name}]}
 
 
-def test_get_harbors(api_client, berth):
-    harbor = berth.pier.harbor
+def test_get_harbors(api_client, pier):
+    harbor = pier.harbor
+    big_berth = BerthFactory(
+        pier=pier,
+        berth_type=BerthTypeFactory(width=10, length=10, depth=10),
+        is_active=True,
+    )
+    BerthFactory(
+        pier=pier,
+        berth_type=BerthTypeFactory(width=1, length=1, depth=1),
+        is_active=False,
+    )
 
     query = """
         {
@@ -55,6 +65,7 @@ def test_get_harbors(api_client, berth):
                             maxDepth
                             numberOfPlaces
                             numberOfFreePlaces
+                            numberOfInactivePlaces
                             createdAt
                             modifiedAt
                         }
@@ -73,11 +84,12 @@ def test_get_harbors(api_client, berth):
                         "properties": {
                             "name": harbor.name,
                             "zipCode": harbor.zip_code,
-                            "maxWidth": float(berth.berth_type.width),
-                            "maxLength": float(berth.berth_type.length),
-                            "maxDepth": float(berth.berth_type.depth),
-                            "numberOfPlaces": 1,
+                            "maxWidth": float(big_berth.berth_type.width),
+                            "maxLength": float(big_berth.berth_type.length),
+                            "maxDepth": float(big_berth.berth_type.depth),
+                            "numberOfPlaces": 2,
                             "numberOfFreePlaces": 1,
+                            "numberOfInactivePlaces": 1,
                             "createdAt": harbor.created_at.isoformat(),
                             "modifiedAt": harbor.modified_at.isoformat(),
                         },


### PR DESCRIPTION
## Description :sparkles:
* Annotate number of unavailable places on piers

## Issues :bug:
### Closes :no_good_woman:
**[VEN-762](https://helsinkisolutionoffice.atlassian.net/browse/VEN-762)** 

### Related :handshake:
**[VEN-729](https://helsinkisolutionoffice.atlassian.net/browse/VEN-729)** 
The number of unavailable `winter storage places` will be added on 729 altogether with number of free and total places

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest resources/tests/test_resources_queries.py::test_get_harbors
$ pytest resources/tests/test_resources_models.py::test_pier_number_of_places
```

### Manual testing :construction_worker_man:
```graphql
query Pier {
  piers {
    edges {
      node {
        id
        properties {
          numberOfPlaces
          numberOfFreePlaces
          numberOfUnavailablePlaces
        }
      }
    }
  }
}
```

## Additional notes :spiral_notepad:
The number of unavailable `winter storage places` will be added on [VEN-729](https://helsinkisolutionoffice.atlassian.net/browse/VEN-729) altogether with number of free and total places