### PR TITLE
Fix piers and ws sections in django admin

### DIFF
--- a/resources/admin.py
+++ b/resources/admin.py
@@ -83,6 +83,11 @@ class HarborAdmin(CustomTranslatableAdmin, admin.OSMGeoAdmin):
 class PierAdmin(admin.OSMGeoAdmin):
     filter_horizontal = ("suitable_boat_types",)
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "harbor":
+            kwargs["queryset"] = Harbor.objects.all()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 class WinterStorageAreaAdmin(CustomTranslatableAdmin, admin.OSMGeoAdmin):
     ordering = ("translations__name",)
@@ -112,7 +117,10 @@ class WinterStorageAreaAdmin(CustomTranslatableAdmin, admin.OSMGeoAdmin):
 
 
 class WinterStorageSectionAdmin(admin.OSMGeoAdmin):
-    pass
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "area":
+            kwargs["queryset"] = WinterStorageArea.objects.all()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 admin.site.register(AvailabilityLevel, AvailabilityLevelAdmin)

--- a/resources/models.py
+++ b/resources/models.py
@@ -401,9 +401,7 @@ class Pier(AbstractAreaSection):
         unique_together = (("identifier", "harbor"),)
 
     def __str__(self):
-        if self.identifier:
-            return "{} ({})".format(self.harbor, self.identifier)
-        return self.harbor
+        return "{} ({})".format(self.harbor, self.identifier or "-")
 
 
 class WinterStorageSection(AbstractAreaSection):
@@ -435,9 +433,7 @@ class WinterStorageSection(AbstractAreaSection):
         unique_together = (("area", "identifier"),)
 
     def __str__(self):
-        if self.identifier:
-            return "{} ({})".format(self.area, self.identifier)
-        return self.area
+        return "{} ({})".format(self.area, self.identifier or "-")
 
 
 class AbstractPlaceType(TimeStampedModel, UUIDModel):


### PR DESCRIPTION
## Description :sparkles:

1. Refactor __str__ logic for WS sections and piers 
Since identifier is blankable, if no identifier is passed str
function will fail, as it would return the WS area or harbor
object. With this change we ensure that the return value is
always a string.

2. Use explicit querysets for harbor / ws area in django admin
Django's own querysets result in duplicated results, as each of
the translated object becomes its own choice. Using these basic
querysets gets rid of the duplicated choices.

## Testing :alembic:
### Manual testing :construction_worker_man:

Go to http://localhost:8040/admin/resources/pier/add/ and check `Harbor` field, it should not have any duplicates.

## Screenshots :camera_flash:
![Screenshot 2020-07-20 at 17 32 19](https://user-images.githubusercontent.com/24206160/87949656-fc0c3480-caae-11ea-8cd3-a4683afdfc5c.png)

