### PR TITLE
VEN-766 | Fix tax percentage calculation

### DIFF
--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -807,3 +807,24 @@ def test_order_line_pretax_price(order_line):
     assert order_line.pretax_price == round(
         order_line.price / (1 + (order_line.tax_percentage / 100)), 2
     )
+
+
+def test_order_tax_percentage():
+    # Hard-code the base price. Base tax percentage currently is always 24%
+    o = OrderFactory(price=Decimal("100.00"))
+
+    # Create a product for an optional service
+    ap = AdditionalProductFactory(
+        service=ProductServiceType.PARKING_PERMIT,
+        price_unit=PriceUnits.AMOUNT,
+        tax_percentage=Decimal("10.00"),
+    )
+
+    # Hard-code the price of additional product to override model's save method
+    OrderLineFactory(order=o, product=ap, price=Decimal("88.70"))
+
+    # Calculations:
+    # base product: pretax = 80.65, tax = 24.0%, tax amount = 19.35
+    # order line: pretax = 80.64, tax = 10.0%, tax amount = 8.06
+    # total tax should be: (24.0 + 10.0) / 2 == 17.0
+    assert o.total_tax_percentage == Decimal("17.00")

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -17,6 +17,7 @@ from leases.schema import BerthLeaseNode, WinterStorageLeaseNode
 from leases.tests.factories import BerthLeaseFactory
 from leases.utils import calculate_season_start_date
 from resources.schema import HarborNode, WinterStorageAreaNode
+from utils.numbers import rounded
 from utils.relay import to_global_id
 
 from ..enums import (
@@ -51,7 +52,6 @@ from ..utils import (
     calculate_product_partial_year_price,
     calculate_product_percentage_price,
     convert_aftertax_to_pretax,
-    round_price,
 )
 from .factories import OrderFactory
 
@@ -1088,7 +1088,12 @@ def test_create_order_line(api_client, order, additional_product):
     assert executed["data"]["createOrderLine"] == {
         "orderLine": {
             "price": str(expected_price),
-            "taxPercentage": str(round_price(additional_product.tax_percentage)),
+            "taxPercentage": rounded(
+                additional_product.tax_percentage,
+                decimals=2,
+                round_to_nearest=0.05,
+                as_string=True,
+            ),
             "pretaxPrice": str(
                 convert_aftertax_to_pretax(
                     expected_price, additional_product.tax_percentage,

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -1,6 +1,6 @@
 import calendar
 from datetime import date, timedelta
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal
 from functools import wraps
 from typing import Callable
 
@@ -8,10 +8,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule
 
 from leases.utils import calculate_season_end_date, calculate_season_start_date
-
-
-def round_price(price):
-    return price.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+from utils.numbers import rounded as rounded_decimal
 
 
 def rounded(func):
@@ -22,13 +19,13 @@ def rounded(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
         value = func(*args, **kwargs)
-        return round_price(value)
+        return rounded_decimal(value)
 
     return wrapped
 
 
 def currency_format(value):
-    return f"{round_price(value)}€"
+    return f"{rounded_decimal(value)}€"
 
 
 def currency(func):
@@ -41,7 +38,7 @@ def currency(func):
 
 
 def percentage_format(value):
-    return f"{round_price(value)}%"
+    return f"{rounded_decimal(value)}%"
 
 
 def percentage(func):

--- a/utils/numbers.py
+++ b/utils/numbers.py
@@ -6,7 +6,10 @@ DecimalString = Union[Decimal, str]
 
 
 def rounded(
-    value: Union[Decimal, int, float, str], decimals: int = 2, as_string: bool = False
+    value: Union[Decimal, int, float, str],
+    decimals: int = 2,
+    as_string: bool = False,
+    round_to_nearest: Union[Decimal, float] = None,
 ) -> DecimalString:
     """
     Round a decimal to a given amount of decimals and return it as either Decimal or String
@@ -15,11 +18,20 @@ def rounded(
     :param decimals: The amount of decimals to round value
     :param as_string: Whether the value should be returned as Decimal or string.
     For testing, it's useful to be able to parse the Decimal value directly to string.
+    :param round_to_nearest: Rounds the value to the nearest decimal passed.
+    I.e. the nearest 0.05 of 3.1416 -> 3.15
     :return: A rounded Decimal number
     """
-    number = round(Decimal(value), decimals)
+    if round_to_nearest:
+        correction = Decimal(0.5 if value >= 0 else -0.5)
+        value = Decimal(
+            int(value / Decimal(round_to_nearest) + correction)
+            * Decimal(round_to_nearest)
+        )
 
-    return str(number) if as_string else number
+    value = round(Decimal(value), decimals)
+
+    return str(value) if as_string else value
 
 
 def random_decimal(


### PR DESCRIPTION
## Description :sparkles:
* The tax percentage is now calculated properly and is rounded to the nearest 0.05-decimal
* Add a "round to nearest decimal" option to `utils.numbers.rounded`
* Add a test to explicitly test for order's tax percentage
* Tidy up rounding functions and reuse code

## Issues :bug:
### Closes :no_good_woman:
**[VEN-766](https://helsinkisolutionoffice.atlassian.net/browse/VEN-766):** total tax percentage on orders gets wrong value

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_tax_percentage
```