### PR TITLE
Hotfix | Pretax price breaking Admin page

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -103,7 +103,7 @@ class OrderAdmin(admin.ModelAdmin):
 
     @currency
     def total_price(self, obj):
-        return obj.total_price
+        return obj.total_price if obj.price and obj.tax_percentage else None
 
     @currency
     def total_pretax_price(self, obj):
@@ -111,7 +111,7 @@ class OrderAdmin(admin.ModelAdmin):
 
     @percentage
     def total_tax_percentage(self, obj):
-        return obj.total_tax_percentage
+        return obj.total_tax_percentage if obj.price and obj.tax_percentage else None
 
     pretax_price.short_description = _("Pretax price")
     pretax_price.admin_order_field = "pretax_price"

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -25,7 +25,7 @@ def rounded(func):
 
 
 def currency_format(value):
-    return f"{rounded_decimal(value)}€"
+    return f"{rounded_decimal(value)}€" if value else "-"
 
 
 def currency(func):
@@ -38,7 +38,7 @@ def currency(func):
 
 
 def percentage_format(value):
-    return f"{rounded_decimal(value)}%"
+    return f"{rounded_decimal(value)}%" if value else "-"
 
 
 def percentage(func):


### PR DESCRIPTION
## Description :sparkles:
* Check if the value being formatted exists, otherwise return a placeholder value
* Add checks for `total_price` and `total_tax_percentage` on the `payments/admin` to avoid `None` values passed

## Testing :alembic:
### Manual testing :construction_worker_man:
Go to `admin/payments/order/{order_id}/change/` and `admin/payments/order/add/`, both should work fine