### PR TITLE
VEN-729 | Add annotated fields to WinterStorageSectionNode

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -367,6 +367,12 @@ class WinterStoragePlaceNode(DjangoObjectType):
 
 
 class WinterStorageSectionNode(graphql_geojson.GeoJSONType):
+    max_width = graphene.Float()
+    max_length = graphene.Float()
+    number_of_places = graphene.Int(required=True)
+    number_of_free_places = graphene.Int(required=True)
+    number_of_inactive_places = graphene.Int(required=True)
+
     class Meta:
         model = WinterStorageSection
         filter_fields = [

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -316,6 +316,16 @@ def test_get_winter_storage_areas(api_client, winter_storage_section):
 
 
 def test_get_winter_storage_sections(api_client, winter_storage_section):
+    big_place = WinterStoragePlaceFactory(
+        winter_storage_section=winter_storage_section,
+        place_type=WinterStoragePlaceTypeFactory(width=10, length=10),
+        is_active=True,
+    )
+    WinterStoragePlaceFactory(
+        winter_storage_section=winter_storage_section,
+        place_type=WinterStoragePlaceTypeFactory(width=1, length=1),
+        is_active=False,
+    )
     query = """
         {
             winterStorageSections {
@@ -329,6 +339,11 @@ def test_get_winter_storage_sections(api_client, winter_storage_section):
                             identifier
                             createdAt
                             modifiedAt
+                            maxWidth
+                            maxLength
+                            numberOfPlaces
+                            numberOfFreePlaces
+                            numberOfInactivePlaces
                         }
                     }
                 }
@@ -346,6 +361,11 @@ def test_get_winter_storage_sections(api_client, winter_storage_section):
                             "identifier": winter_storage_section.identifier,
                             "createdAt": winter_storage_section.created_at.isoformat(),
                             "modifiedAt": winter_storage_section.modified_at.isoformat(),
+                            "maxWidth": float(big_place.place_type.width),
+                            "maxLength": float(big_place.place_type.length),
+                            "numberOfPlaces": 2,
+                            "numberOfFreePlaces": 1,
+                            "numberOfInactivePlaces": 1,
                         },
                     }
                 }


### PR DESCRIPTION
## Description :sparkles:
* `WinterStoragePlace`s were missing the newly annotated fields (number of places) that were already available on `WinterStorageArea`

## Issues :bug:
### Related :handshake:
**[VEN-729](https://helsinkisolutionoffice.atlassian.net/browse/VEN-729):** #239 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ resources/tests/test_resources_queries.py::test_get_winter_storage_sections
```

### Manual testing :construction_worker_man:
```graphql
query WS {
  winterStorageSections {
    edges {
      node {
        id
        properties {
          numberOfPlaces
          numberOfFreePlaces
          numberOfInactivePlaces
          maxWidth
          maxLength
        }
      }
    }
  }
}
```