### PR TITLE
VEN-730 | Profile mutations

### DIFF
--- a/customers/schema/mutations.py
+++ b/customers/schema/mutations.py
@@ -269,6 +269,23 @@ class UpdateBerthServicesProfileMutation(graphene.ClientIDMutation):
         return UpdateBerthServicesProfileMutation(profile=profile)
 
 
+class DeleteBerthServicesProfileMutation(graphene.ClientIDMutation):
+    class Input:
+        id = graphene.ID(required=True)
+
+    @classmethod
+    @delete_permission_required(CustomerProfile, Organization)
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, **input):
+        profile = get_node_from_global_id(
+            info, input.pop("id"), only_type=ProfileNode, nullable=False
+        )
+
+        profile.delete()
+
+        return DeleteBoatMutation()
+
+
 class Mutation:
     create_boat = CreateBoatMutation.Field(
         description="Creates a `Boat` associated with the `ProfileNode` passed."
@@ -287,6 +304,7 @@ class Mutation:
     )
     delete_boat = DeleteBoatMutation.Field(
         description="Deletes a `Boat` object."
+        "\n\n**Requires permissions** to delete boats."
         "\n\nErrors:"
         "\n* The passed boat doesn't exist"
     )
@@ -307,4 +325,10 @@ class Mutation:
         "\n\nErrors:"
         "\n* No customer `GlobalID` is provided"
         "\n* Both `organization` and `deleteOrganization: true` are passed"
+    )
+    delete_berth_services_profile = DeleteBerthServicesProfileMutation.Field(
+        description="Deletes a `ProfileNode` object."
+        "\n\n**Requires permissions** to delete profiles."
+        "\n\nErrors:"
+        "\n* The passed profile doesn't exist"
     )

--- a/customers/tests/conftest.py
+++ b/customers/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from berth_reservations.tests.conftest import *  # noqa
 from resources.tests.conftest import boat_type  # noqa
 
-from .factories import BoatCertificateFactory, BoatFactory
+from .factories import BoatCertificateFactory, BoatFactory, OrganizationFactory
 
 
 @pytest.fixture
@@ -16,3 +16,9 @@ def boat():
 def boat_certificate():
     boat_certificate = BoatCertificateFactory()
     return boat_certificate
+
+
+@pytest.fixture
+def organization():
+    organization = OrganizationFactory()
+    return organization

--- a/users/management/commands/set_group_model_permissions.py
+++ b/users/management/commands/set_group_model_permissions.py
@@ -69,7 +69,7 @@ DEFAULT_MODELS_PERMS = {
             BERTH_SUPERVISOR: ("view",),
             HARBOR_SERVICES: None,
         },
-        "company": {
+        "organization": {
             BERTH_SERVICES: ("view", "add", "change", "delete",),
             BERTH_HANDLER: ("view",),
             BERTH_SUPERVISOR: ("view",),


### PR DESCRIPTION
## Description :sparkles:
* Add `CUD` mutations for `ProfileNode`
* Minor fixes for some errors left on `BoatNode` mutations

## Issues :bug:
### Closes :no_good_woman:
**[VEN-730](https://helsinkisolutionoffice.atlassian.net/browse/VEN-730):** add CRUD mutations for CustomerProfile

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest customers/tests/test_customers_mutations.py
```

### Manual testing :construction_worker_man:
You can find examples on `customers/tests/test_customers_mutations.py`

## Screenshots :camera_flash:
**createBerthServicesProfile**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/15201480/88375725-c57f3400-cda4-11ea-870a-a9da11c8d58d.png">

**updateBerthServicesProfile**
<img width="351" alt="image" src="https://user-images.githubusercontent.com/15201480/88375772-dcbe2180-cda4-11ea-8e83-045420a984ca.png">

**deleteBerthServicesProfile**
<img width="351" alt="image" src="https://user-images.githubusercontent.com/15201480/88375783-e21b6c00-cda4-11ea-89e6-2faa59e3b772.png">

## Additional notes :spiral_notepad:
The `deleteBerthServicesProfile` mutation takes a `deleteOrganization: boolean` input. The mutation will raise an error if it's passed as `true` and the `profile` does not have an organization or if both `deleteOrganization: true` and `organization: {}` inputs are passed.
