### PR TITLE
Hotfix | Fix winter storage product season and price calculation

### DIFF
--- a/leases/utils.py
+++ b/leases/utils.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from dateutil.relativedelta import relativedelta
+
 
 def calculate_season_start_date(lease_start: date = None) -> date:
     """Return the date when the summer season starts
@@ -43,6 +45,58 @@ def calculate_season_end_date(lease_end: date = None) -> date:
     return default
 
 
+def calculate_winter_season_start_date(lease_start: date = None) -> date:
+    """Return the date when the winter season starts
+
+    If the current date is after the season end date,
+    it returns next year's default start date.
+
+    Winter Storage Leases always start on 15.9 the earliest
+    """
+    today = date.today()
+    default = date(day=15, month=9, year=today.year)
+
+    if lease_start:
+        lease_date = default.replace(year=lease_start.year)
+        # If the lease started between 1.1 and 10.6, that means
+        # the season began the previous year
+        if lease_start <= date(day=10, month=6, year=lease_start.year):
+            lease_date -= relativedelta(years=1)
+        return lease_date
+
+    # If the current day is before the winter season ends,
+    # the start day will be on the previous year
+    if today <= date(day=10, month=6, year=today.year):
+        default -= relativedelta(years=1)
+
+    return default
+
+
+def calculate_winter_season_end_date(lease_end: date = None) -> date:
+    """Return the date when the winter season ends
+
+    Winter Storage Leases always end on 10.6, the year depends on the current year
+    """
+    today = date.today()
+    default = date(day=10, month=6, year=today.year)
+
+    if lease_end:
+        lease_date = default.replace(year=lease_end.year)
+        # If the lease ended between 15.9 and 31.12, that means
+        # the season ends the following year.
+        if lease_end >= date(day=15, month=9, year=lease_end.year):
+            lease_date = default.replace(year=lease_end.year + 1)
+        return lease_date
+
+    # If today is gte than the day when all leases end,
+    # return the default end date for the next year
+    if today > default:
+        return default.replace(year=today.year + 1)
+
+    # Otherwise, return the default end date for the current year
+    return default
+
+
 def calculate_berth_lease_start_date() -> date:
     """
     Return the date when the lease season should start
@@ -73,13 +127,7 @@ def calculate_winter_storage_lease_start_date() -> date:
     """
 
     # Return the earliest date between the default start date or today
-    today = date.today()
-    default = max(date(day=15, month=9, year=today.year), today)
-
-    if today < date(day=10, month=6, year=today.year):
-        return today
-
-    return default
+    return max(calculate_winter_season_start_date(), date.today())
 
 
 def calculate_winter_storage_lease_end_date() -> date:
@@ -87,10 +135,4 @@ def calculate_winter_storage_lease_end_date() -> date:
 
     The season should end by default on 10.6 on the following year
     """
-    today = date.today()
-    default = date(day=10, month=6, year=today.year + 1)
-
-    if today.month <= default.month and today.day < default.day:
-        default = default.replace(year=today.year)
-
-    return default
+    return calculate_winter_season_end_date()

--- a/payments/tests/factories.py
+++ b/payments/tests/factories.py
@@ -28,7 +28,7 @@ class AbstractBaseProductFactory(factory.django.DjangoModelFactory):
     price_value = factory.LazyAttribute(
         lambda o: random_price()
         if o.price_unit == PriceUnits.AMOUNT
-        else random_price(0, 100, decimals=0)
+        else random_price(1, 100, decimals=0)
     )
 
     class Meta:

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -7,7 +7,12 @@ from typing import Callable
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule
 
-from leases.utils import calculate_season_end_date, calculate_season_start_date
+from leases.utils import (
+    calculate_season_end_date,
+    calculate_season_start_date,
+    calculate_winter_season_end_date,
+    calculate_winter_season_start_date,
+)
 from utils.numbers import rounded as rounded_decimal
 
 
@@ -113,9 +118,9 @@ def calculate_product_partial_season_price(
     season_days = calculate_season_end_date() - calculate_season_start_date()
     # If it's for the opposite season ("winter season"), calculate the inverse
     if not summer_season:
-        # Calculate the amount of days in the year, in case it's a leap year
-        days_in_year = (start_date + relativedelta(years=1)) - start_date
-        season_days = days_in_year - season_days
+        season_days = (
+            calculate_winter_season_end_date() - calculate_winter_season_start_date()
+        )
     delta = (end_date - start_date).days
     price = (delta * base_price) / season_days.days
     return price


### PR DESCRIPTION
## Description :sparkles:
There was a miscalculation of the winter season by 1 day. With this new calculation, it's also not necessary to check if the order lasts for the full season (`order.is_full_season()`), since it will always yield the correct result, even when "partially" calculating

## Issues :bug:
### Related :handshake:
**[VEN-759](https://helsinkisolutionoffice.atlassian.net/browse/VEN-759):** add season logic to winter storage leases

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_winter_storage_lease_right_price_for_full_season
```