### PR TITLE
VEN-695 | Generate order with lease

### DIFF
--- a/payments/management/commands/assign_berth_price_groups.py
+++ b/payments/management/commands/assign_berth_price_groups.py
@@ -15,15 +15,14 @@ class Command(BaseCommand):
         #   get_or_create a BPG with the BT width
         #   Assign the price_group to the recovered BPG
 
-        groups_created = 0
+        start_groups = BerthPriceGroup.objects.count()
         for berth_type in berth_types:
-            group, created = BerthPriceGroup.objects.get_or_create_for_width(
-                berth_type.width
-            )
+            group = BerthPriceGroup.objects.get_or_create_for_width(berth_type.width)
             berth_type.price_group = group
             berth_type.save()
-            groups_created += 1 if created else 0
+        end_groups = BerthPriceGroup.objects.count()
 
+        groups_created = end_groups - start_groups
         self.stdout.write(
             self.style.SUCCESS(
                 f"BerthTypes assigned: {len(berth_types)}\n"

--- a/payments/models.py
+++ b/payments/models.py
@@ -53,9 +53,14 @@ class AbstractBaseProduct(TimeStampedModel, UUIDModel):
 
 
 class BerthPriceGroupManager(models.Manager):
+    def get_for_width(self, width):
+        # One single common way to get a BPG based on the width
+        return self.get(name=f"{width}m")
+
     def get_or_create_for_width(self, width):
         # One single common way to get a BPG based on the width
-        return self.get_or_create(name=f"{width}m")
+        price_group, _created = self.get_or_create(name=f"{rounded_decimal(width)}m")
+        return price_group
 
 
 class BerthPriceGroup(UUIDModel):

--- a/resources/models.py
+++ b/resources/models.py
@@ -554,7 +554,7 @@ class BerthType(AbstractPlaceType):
         from payments.models import BerthPriceGroup
 
         if not self.price_group:
-            self.price_group, created = BerthPriceGroup.objects.get_or_create_for_width(
+            self.price_group = BerthPriceGroup.objects.get_or_create_for_width(
                 self.width
             )
         return super().save(*args, **kwargs)

--- a/resources/tests/test_resources_models.py
+++ b/resources/tests/test_resources_models.py
@@ -35,6 +35,7 @@ from resources.tests.factories import (
     WinterStoragePlaceFactory,
     WinterStorageSectionFactory,
 )
+from utils.numbers import rounded
 
 
 def test_harbor_map_file_path(harbor):
@@ -460,13 +461,16 @@ def test_berth_type_is_assigned_new_price_group():
 
     berth_type = BerthTypeFactory(width=width)
 
-    assert BerthType.objects.get(id=berth_type.id).price_group.name == f"{width}m"
+    assert (
+        BerthType.objects.get(id=berth_type.id).price_group.name
+        == f"{rounded(width, decimals=2)}m"
+    )
     assert BerthPriceGroup.objects.count() == 1
 
 
 def test_berth_type_is_assigned_existing_price_group():
     width = round(random.uniform(1, 999), 2)
-    price_group = BerthPriceGroupFactory(name=f"{width}m")
+    price_group = BerthPriceGroupFactory(name=f"{rounded(width, decimals=2)}m")
 
     berth_type = BerthTypeFactory(width=width)
 


### PR DESCRIPTION
## Description :sparkles:
Generate an `Order` whenever a `winter storage/berth lease` is generated _only_ through the `createXXXLease` mutations.

It will automatically look for a `Berth/WinterStorageProduct` that can be associated to the lease based on the `Harbor/Area` to which the lease place belongs, and a `BerthPriceGroup` for `BerthLease`s.

For `BerthLease`s, it will `get_or_create` the `BerthPriceGroup` every time. In case the price group wouldn't exist, it will be generated, but the `order/lease` creation will fail because of the lack of `BerthProduct`, since there will be no products related to the new price group.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-695](https://helsinkisolutionoffice.atlassian.net/browse/VEN-695):** generate an order (a.k.a "invoice") when generating Lease

## Testing :alembic:
### Automated tests :gear:️
```shell
pytest -k "test_create_berth_lease_with_order or test_create_winter_storage_lease_with_order"
```

### Manual testing :construction_worker_man:
Before executing the mutation, make sure you have an existing `BerthProduct` for the `berth.pier.harbor` you're gonna use.

```graphql
mutation CREATE_LEASE($input: CreateBerthLeaseMutationInput!) {
  createBerthLease(input:$input){
    berthLease {
      id
      startDate
      endDate
      customer {
        id
      }
      boat {
        id
      }
      status
      comment
      berth {
        id
      }
      application {
        id
      }
    }
  }
}
```

**input:**
```json
{
  "input": {
    "applicationId": "",
    "berthId": ""
  }
}
```
## Screenshots :camera_flash:
**Create Berth lease:**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/15201480/88639909-fa052f80-d0c5-11ea-8701-473a00904452.png">

**Create Winter Storage lease:**
<img width="346" alt="image" src="https://user-images.githubusercontent.com/15201480/88639992-16a16780-d0c6-11ea-8d05-6a635555c6df.png">
