### PR TITLE
Add Sequence to factories giving duplicated results

### DIFF
--- a/berth_reservations/tests/factories.py
+++ b/berth_reservations/tests/factories.py
@@ -9,7 +9,9 @@ from customers.models import CustomerProfile
 class UserFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    username = factory.Faker("user_name")
+    username = factory.Sequence(
+        lambda n: factory.Faker("user_name").generate() + f"{n}"
+    )
     email = factory.Faker("email")
 
     class Meta:
@@ -17,7 +19,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
 
 class MunicipalityFactory(factory.django.DjangoModelFactory):
-    id = factory.Faker("word")
+    id = factory.Sequence(lambda n: factory.Faker("word").generate() + f"-{n}")
     name = factory.Faker("city")
 
     class Meta:


### PR DESCRIPTION
## Description :sparkles:
* Ensure that the `UserFactory.username` and `MunicipalityFactory.id` are unique by using `faker.Sequence`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-634](https://helsinkisolutionoffice.atlassian.net/browse/VEN-634):** duplicated municipality key in tests

## Testing :alembic:
### Automated tests :gear:️
```shell
pytest
```

### Manual testing :construction_worker_man:
From a python shell, execute
```python
from berth_reservations.tests.factories import UserFactory, MunicipalityFactory

# Note how the last digit on the username is an increasing unique number
UserFactory().username
UserFactory().username
UserFactory().username

# Same with the id, it will always have a unique -{n}
MunicipalityFactory().id
MunicipalityFactory().id
MunicipalityFactory().id
```
