### PR TITLE
VEN-695 | Hotfix | Add fallback for the default product

### DIFF
--- a/leases/schema/mutations.py
+++ b/leases/schema/mutations.py
@@ -82,9 +82,15 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
             price_group = BerthPriceGroup.objects.get_or_create_for_width(
                 berth.berth_type.width
             )
-            product = BerthProduct.objects.get(
-                harbor=berth.pier.harbor, price_group=price_group
+            price_group_products = BerthProduct.objects.filter(price_group=price_group)
+            harbor_product = price_group_products.filter(harbor=berth.pier.harbor)
+
+            product = (
+                harbor_product.first()
+                if harbor_product
+                else price_group_products.get(harbor__isnull=True)
             )
+
             Order.objects.create(
                 customer=input["customer"], lease=lease, product=product
             )


### PR DESCRIPTION
## Description :sparkles:
* If the product for `harbor, price_group` fails, it tries to use the default product for the `price_gropu`. _ONLY_ works for `BerthProducts` since only those have "default" products.

## Issues :bug:
### Related :handshake:
**[VEN-695](https://helsinkisolutionoffice.atlassian.net/browse/VEN-695):** #248 

## Testing :alembic:
### Automated tests :gear:️
```shell
pytest leases/tests/test_lease_mutations.py::test_create_berth_lease_with_order_default_product
```