### PR TITLE
Expose isActive field on WS place node in GQL API

### DIFF
--- a/resources/schema.py
+++ b/resources/schema.py
@@ -347,6 +347,7 @@ class WinterStoragePlaceNode(DjangoObjectType):
             "id",
             "number",
             "winter_storage_section",
+            "is_active",
             "created_at",
             "modified_at",
         )

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -382,6 +382,7 @@ def test_get_winter_storage_places(api_client, winter_storage_place):
                 edges {
                     node {
                         number
+                        isActive
                         createdAt
                         modifiedAt
                     }
@@ -396,6 +397,7 @@ def test_get_winter_storage_places(api_client, winter_storage_place):
                 {
                     "node": {
                         "number": winter_storage_place.number,
+                        "isActive": winter_storage_place.is_active,
                         "createdAt": winter_storage_place.created_at.isoformat(),
                         "modifiedAt": winter_storage_place.modified_at.isoformat(),
                     }


### PR DESCRIPTION
## Description :sparkles:

Expose isActive field on WS place node in GQL API

## Testing :alembic:
### Automated tests :gear:️

```bash
pytest resources/tests/test_resources_queries.py::test_get_winter_storage_places
```

## Screenshots :camera_flash:

<img width="337" alt="Screenshot 2020-07-31 at 17 13 21" src="https://user-images.githubusercontent.com/24206160/89043467-339d9b00-d351-11ea-8cc7-79270843f0bc.png">

