### PR TITLE
[VEN-771] | Add is_active field to Winter Storage leases

### DIFF
--- a/leases/schema/types.py
+++ b/leases/schema/types.py
@@ -48,6 +48,14 @@ class WinterStorageLeaseNode(DjangoObjectType):
     status = LeaseStatusEnum(required=True)
     customer = graphene.Field("customers.schema.ProfileNode", required=True)
     order = graphene.Field("payments.schema.OrderNode")
+    is_active = graphene.Boolean(
+        required=True,
+        description="For a Lease to be active, it has to have `status == PAID`. "
+        "\n\nIf the present date is before the season starts (15.9.2020), "
+        "a lease will be active if it starts at the same date as the season. "
+        "If the present date is during the season, a lease will be active if the "
+        "dates `start date < today < end date`.",
+    )
 
     class Meta:
         model = WinterStorageLease


### PR DESCRIPTION
## Description :sparkles:
* Add a `is_active` field to WSLeases

## Issues :bug:
### Closes :no_good_woman:
**[VEN-771](https://helsinkisolutionoffice.atlassian.net/browse/VEN-771):**  add "isActive" field to WinterStorageLeaseNode

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_models.py
```

## Screenshots :camera_flash:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/15201480/90637889-3e9f6900-e235-11ea-83da-c79044bfaf4e.png">
