### PR TITLE
VEN-739 | Use application boat dimensions as fallback for price

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -471,10 +471,17 @@ class Order(UUIDModel, TimeStampedModel):
                             self.lease.place.place_type.width
                             * self.lease.place.place_type.length
                         )
-                    else:
+                    elif self.lease.boat:
                         # If the lease is only associated to an area,
                         # calculate the price based on the boat dimensions
                         place_sqm = self.lease.boat.width * self.lease.boat.length
+                    else:
+                        # If the lease is not associated to a boat object,
+                        # take the values set by the user on the application
+                        place_sqm = (
+                            self.lease.application.boat_width
+                            * self.lease.application.boat_length
+                        )
                     price = price * place_sqm
 
             self.price = rounded_decimal(self.price or price)

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -939,3 +939,36 @@ def test_order_winter_storage_lease_with_area_right_price(
     assert order.lease.id == winter_storage_lease.id
     assert order._lease_content_type.name == winter_storage_lease._meta.verbose_name
     assert order.price == expected_price
+
+
+def test_order_winter_storage_lease_without_boat_right_price(
+    winter_storage_area,
+    winter_storage_product,
+    winter_storage_application,
+    customer_profile,
+):
+    winter_storage_lease = WinterStorageLeaseFactory(
+        place=None,
+        area=winter_storage_area,
+        customer=customer_profile,
+        boat=None,
+        application=winter_storage_application,
+    )
+    order = Order.objects.create(
+        _lease_object_id=winter_storage_lease.id,
+        customer=customer_profile,
+        product=winter_storage_product,
+    )
+    sqm = winter_storage_application.boat_width * winter_storage_application.boat_length
+
+    expected_price = calculate_product_partial_season_price(
+        winter_storage_product.price_value,
+        winter_storage_lease.start_date,
+        winter_storage_lease.end_date,
+        summer_season=False,
+    )
+    expected_price = rounded(expected_price * sqm, decimals=2)
+
+    assert order.lease.id == winter_storage_lease.id
+    assert order._lease_content_type.name == winter_storage_lease._meta.verbose_name
+    assert order.price == expected_price


### PR DESCRIPTION
## Description :sparkles:
* Use application boat dimensions as fallback for price: when calculating the price for winter storage orders, if there's no `boat` associated to the `order.lease`, use the `application.boat_width/lenght` since those are required fields

## Issues :bug:
### Closes :no_good_woman:
**[VEN-739](https://helsinkisolutionoffice.atlassian.net/browse/VEN-739):** link WS leases simply to WS area if it has no marked places

### Related :handshake:
#254 
#257 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_winter_storage_lease_without_boat_right_price
```
