### PR TITLE
VEN-326 | Add OrderStatus query

### DIFF
--- a/berth_reservations/schema.py
+++ b/berth_reservations/schema.py
@@ -2,10 +2,12 @@ import graphene
 
 import applications.schema
 import harbors.schema
-from payments.schema import OldAPIMutation
+from payments.schema import OldAPIMutation, OldAPIQuery
 
 
-class Query(harbors.schema.Query, applications.schema.Query, graphene.ObjectType):
+class Query(
+    harbors.schema.Query, applications.schema.Query, OldAPIQuery, graphene.ObjectType
+):
     pass
 
 

--- a/payments/schema/__init__.py
+++ b/payments/schema/__init__.py
@@ -1,5 +1,5 @@
 from .mutations import Mutation, OldAPIMutation
-from .queries import Query
+from .queries import OldAPIQuery, Query
 from .types import (
     AdditionalProductNode,
     AdditionalProductTaxEnum,
@@ -9,6 +9,7 @@ from .types import (
     OrderLineNode,
     OrderLogEntryNode,
     OrderNode,
+    OrderStatusType,
     PeriodTypeEnum,
     PlaceProductTaxEnum,
     PriceUnitsEnum,
@@ -24,9 +25,11 @@ __all__ = [
     "BerthProductNode",
     "Mutation",
     "OldAPIMutation",
+    "OldAPIQuery",
     "OrderLineNode",
     "OrderLogEntryNode",
     "OrderNode",
+    "OrderStatusType",
     "PeriodTypeEnum",
     "PlaceProductTaxEnum",
     "PriceUnitsEnum",

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -46,7 +46,8 @@ AdditionalProductTaxEnum = graphene.Enum(
     ],
 )
 OrderTypeEnum = graphene.Enum(
-    "OrderTypeEnum", [("BERTH", "BERTH"), ("WINTER_STORAGE", "WINTER_STORAGE")]
+    "OrderTypeEnum",
+    [("BERTH", "BERTH"), ("WINTER_STORAGE", "WINTER_STORAGE"), ("UNKNOWN", "UNKNOWN")],
 )
 
 
@@ -221,3 +222,8 @@ class OrderNode(DjangoObjectType):
     @view_permission_required(Order)
     def get_queryset(cls, queryset, info):
         return super().get_queryset(queryset, info)
+
+
+class OrderStatusType(graphene.ObjectType):
+    order_type = OrderTypeEnum(required=True)
+    status = OrderStatusEnum(required=True)

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -22,6 +22,7 @@ from .factories import (
     OrderLogEntryFactory,
     WinterStorageProductFactory,
 )
+from .utils import random_price, random_tax
 
 FAKE_BAMBORA_API_URL = "https://fake-bambora-api-url/api"
 UI_RETURN_URL = "https://front-end-url/{LANG}/"
@@ -75,6 +76,14 @@ def _generate_order(order_type: str = None):
             lease=WinterStorageLeaseFactory(
                 application=WinterStorageApplicationFactory(), customer=customer_profile
             ),
+        )
+    elif order_type == "empty_order":
+        order = OrderFactory(
+            customer=customer_profile,
+            price=random_price(),
+            tax_percentage=random_tax(),
+            product=None,
+            lease=None,
         )
     else:
         order = OrderFactory(customer=customer_profile)

--- a/payments/tests/factories.py
+++ b/payments/tests/factories.py
@@ -110,7 +110,7 @@ class OrderFactory(factory.django.DjangoModelFactory):
             self.lease = extracted
         elif isinstance(self.product, BerthProduct):
             self.lease = BerthLeaseFactory(customer=self.customer)
-        else:
+        elif isinstance(self.product, WinterStorageProduct):
             self.lease = WinterStorageLeaseFactory(customer=self.customer)
 
     class Meta:


### PR DESCRIPTION
## Description :sparkles:
* Add the `OrderStatus` query, which also allows to check for the order type (`BERTH|WINTER_STORAGE`)

## Issues :bug:
### Closes :no_good_woman:
**[VEN-326](https://helsinkisolutionoffice.atlassian.net/browse/VEN-326):** OrderStatus query

### Related :handshake:
#255 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_queries.py::test_get_order_status
$ pytest payments/tests/test_payments_queries.py::test_get_order_status_order_does_not_exist
```

### Manual testing :construction_worker_man:
```graphql
query ORDER_STATUS {
    orderStatus(orderNumber: "{order_number}") {
        orderType
        status
    }
}
```