### PR TITLE
Add missing fields to harbors WSArea

### DIFF
--- a/harbors/schema.py
+++ b/harbors/schema.py
@@ -111,6 +111,10 @@ class WinterStorageAreaType(graphql_geojson.GeoJSONType):
     max_length_of_section_spaces = graphene.Int()
     number_of_section_spaces = graphene.Int()
     number_of_unmarked_spaces = graphene.Int()
+    number_of_marked_places = graphene.Int()
+    availability_level = graphene.Field(AvailabilityLevelType)
+    max_width = graphene.Int()
+    max_length = graphene.Int()
 
     def resolve_image_file(self, info, **kwargs):
         if self.image_file:


### PR DESCRIPTION
## Description :sparkles:
Prod is broken because WSArea is missing a handful of fields, this PR adds those fields back

## Testing :alembic:
### Manual testing :construction_worker_man:
```graphql
query WSA {
  winterStorageAreas {
    edges {
      node {
      	id
        properties {
          maxWidth
          maxLength
          availabilityLevel {
            title
          }
          numberOfMarkedPlaces
        }
      }
    }
  }
}
```

## Screenshots :camera_flash:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/15201480/91273477-ff699e80-e785-11ea-91f5-02e1a7d43aa4.png">
