### PR TITLE
VEN-547 | Add a mutation to approve orders and send emails

### DIFF
--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -31,6 +31,7 @@ def force_settings(settings):
     settings.MAILER_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
     settings.DEFAULT_FROM_EMAIL = "noreply@foo.bar"
     settings.LANGUAGE_CODE = "en"
+    settings.VENE_UI_RETURN_URL = "https://front-end-url/{LANG}"
 
 
 @pytest.fixture

--- a/payments/apps.py
+++ b/payments/apps.py
@@ -5,7 +5,9 @@ class PaymentsConfig(AppConfig):
     name = "payments"
 
     def ready(self):
-        """Verify active payment provider configuration"""
+        import payments.notifications  # noqa
+
+        # Verify active payment provider configuration
         from .providers import load_provider_config
 
         load_provider_config()

--- a/payments/notifications.py
+++ b/payments/notifications.py
@@ -1,0 +1,42 @@
+from decimal import Decimal
+
+from django.conf import settings
+from django.db.models import TextChoices
+from django.utils.translation import gettext_lazy as _
+from django_ilmoitin.dummy_context import dummy_context
+from django_ilmoitin.registry import notifications
+
+from berth_reservations.tests.factories import CustomerProfileFactory
+
+from .providers import BamboraPayformProvider
+from .tests.conftest import PROVIDER_BASE_CONFIG
+from .tests.factories import OrderFactory
+
+
+class NotificationType(TextChoices):
+    ORDER_APPROVED = (
+        "order_approved",
+        _("Order approved"),
+    )
+
+
+notifications.register(
+    NotificationType.ORDER_APPROVED.value, NotificationType.ORDER_APPROVED.label,
+)
+
+customer = CustomerProfileFactory.build()
+order = OrderFactory.build(
+    customer=customer,
+    product=None,
+    price=Decimal("100"),
+    tax_percentage=Decimal("24.00"),
+)
+
+
+payment_url = BamboraPayformProvider(
+    config=PROVIDER_BASE_CONFIG, ui_return_url=settings.VENE_UI_RETURN_URL
+).get_payment_email_url(order, lang=settings.LANGUAGE_CODE)
+
+dummy_context.update(
+    {NotificationType.ORDER_APPROVED: {"order": order, "payment_url": payment_url}}
+)

--- a/payments/providers/base.py
+++ b/payments/providers/base.py
@@ -125,3 +125,6 @@ class PaymentProvider:
                 url=return_url, path=path, params=urlencode(params)
             )
         )
+
+    def get_payment_email_url(self, order: Order, lang: str = settings.LANGUAGE_CODE):
+        return f"{self.ui_return_url.format(LANG=lang)}/payment?order_number={order.order_number}"

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -227,3 +227,8 @@ class OrderNode(DjangoObjectType):
 class OrderDetailsType(graphene.ObjectType):
     order_type = OrderTypeEnum(required=True)
     status = OrderStatusEnum(required=True)
+
+
+class FailedOrderType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    error = graphene.String()

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -915,6 +915,7 @@ def test_update_order_berth_product(api_client, berth_product, berth_lease):
     order = OrderFactory(
         product=berth_product, lease=berth_lease, customer=berth_lease.customer
     )
+
     global_id = to_global_id(OrderNode, order.id)
 
     variables = {
@@ -933,7 +934,11 @@ def test_update_order_berth_product(api_client, berth_product, berth_lease):
     assert executed["data"]["updateOrder"]["order"] == {
         "id": variables["id"],
         "comment": variables["comment"],
-        "price": str(berth_product.price_value),
+        "price": str(
+            calculate_product_partial_season_price(
+                berth_product.price_value, berth_lease.start_date, berth_lease.end_date
+            )
+        ),
         "taxPercentage": str(berth_product.tax_percentage),
         "dueDate": str(variables["dueDate"].date()),
         "status": variables["status"],

--- a/payments/tests/test_payments_mutations_approve_order.py
+++ b/payments/tests/test_payments_mutations_approve_order.py
@@ -1,0 +1,228 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+from anymail.exceptions import AnymailError
+from dateutil.relativedelta import relativedelta
+from dateutil.utils import today
+from django.core import mail
+from freezegun import freeze_time
+
+from applications.enums import ApplicationStatus
+from berth_reservations.tests.utils import assert_not_enough_permissions
+from leases.enums import LeaseStatus
+from utils.relay import to_global_id
+
+from ..models import Order
+from ..schema.types import OrderNode
+
+APPROVE_ORDER_MUTATION = """
+mutation APPROVE_ORDER_MUTATION($input: ApproveOrderMutationInput!) {
+    approveOrders(input: $input) {
+        failedOrders {
+            id
+            error
+        }
+    }
+}"""
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@freeze_time("2020-01-01T08:00:00Z")
+def test_approve_order(
+    api_client, order: Order, payment_provider, notification_template_order_approved,
+):
+    due_date = (today() + relativedelta(days=14)).date()
+    variables = {
+        "dueDate": due_date,
+        "orders": [
+            {
+                "orderId": to_global_id(OrderNode, order.id),
+                "email": order.lease.application.email,
+            }
+        ],
+    }
+    executed = api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+    payment_url = payment_provider.get_payment_email_url(
+        order, lang=order.lease.application.language
+    )
+
+    order = Order.objects.get(id=order.id)
+
+    assert order.due_date == due_date
+    assert order.lease.status == LeaseStatus.OFFERED
+    assert order.lease.application.status == ApplicationStatus.OFFER_SENT
+
+    assert len(executed["data"]["approveOrders"]["failedOrders"]) == 0
+    assert len(mail.outbox) == 1
+    assert (
+        mail.outbox[0].subject
+        == f"test order approved subject, event: {order.order_number}!"
+    )
+    assert mail.outbox[0].body == f"{ order.order_number } { payment_url }"
+    assert mail.outbox[0].to == [order.lease.application.email]
+
+    assert mail.outbox[0].alternatives == [
+        (f"<b>{ order.order_number } { payment_url }</b>", "text/html")
+    ]
+
+
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@freeze_time("2020-01-01T08:00:00Z")
+def test_approve_order_default_due_date(
+    api_client, order: Order, payment_provider, notification_template_order_approved,
+):
+    order.due_date = today().date()
+    order.save()
+
+    variables = {
+        "orders": [
+            {
+                "orderId": to_global_id(OrderNode, order.id),
+                "email": order.lease.application.email,
+            }
+        ],
+    }
+    expected_due_date = today().date() + relativedelta(weeks=2)
+    assert order.due_date != expected_due_date
+
+    api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+
+    order = Order.objects.get(id=order.id)
+
+    assert order.due_date == expected_due_date
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["api_client", "user", "harbor_services", "berth_supervisor", "berth_handler"],
+    indirect=True,
+)
+def test_approve_order_not_enough_permissions(api_client):
+    variables = {
+        "orders": [],
+    }
+
+    executed = api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+
+    assert_not_enough_permissions(executed)
+
+
+@freeze_time("2020-01-01T08:00:00Z")
+def test_approve_order_does_not_exist(
+    superuser_api_client, payment_provider, notification_template_order_approved,
+):
+    order_id = to_global_id(OrderNode, uuid.uuid4())
+
+    variables = {
+        "orders": [{"orderId": order_id, "email": "foo@bar.com"}],
+    }
+
+    executed = superuser_api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+    assert len(executed["data"]["approveOrders"]["failedOrders"]) == 1
+    assert executed["data"]["approveOrders"]["failedOrders"][0] == {
+        "id": order_id,
+        "error": "Order matching query does not exist.",
+    }
+
+
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@freeze_time("2020-01-01T08:00:00Z")
+def test_approve_order_anymail_error(
+    superuser_api_client,
+    payment_provider,
+    notification_template_order_approved,
+    order: Order,
+):
+    order_id = to_global_id(OrderNode, order.id)
+    previous_order_status = order.status
+    previous_lease_status = order.lease.status
+    previous_application_status = order.lease.application.status
+
+    variables = {
+        "orders": [{"orderId": order_id, "email": "foo@bar.com"}],
+    }
+
+    with patch(
+        "payments.schema.mutations.send_notification",
+        side_effect=AnymailError("Anymail error"),
+    ) as mock:
+        executed = superuser_api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+    mock.assert_called_once()
+
+    assert len(executed["data"]["approveOrders"]["failedOrders"]) == 1
+    assert executed["data"]["approveOrders"]["failedOrders"][0] == {
+        "id": order_id,
+        "error": "Anymail error",
+    }
+
+    order = Order.objects.get(id=order.id)
+
+    assert order.status == previous_order_status
+    assert order.lease.status == previous_lease_status.value
+    assert order.lease.application.status == previous_application_status
+
+
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@freeze_time("2020-01-01T08:00:00Z")
+def test_approve_order_one_success_one_failure(
+    superuser_api_client,
+    order: Order,
+    payment_provider,
+    notification_template_order_approved,
+):
+    due_date = (today() + relativedelta(days=14)).date()
+    failure_order_id = to_global_id(OrderNode, uuid.uuid4())
+
+    variables = {
+        "dueDate": due_date,
+        "orders": [
+            {"orderId": failure_order_id, "email": "foo@bar.com"},
+            {
+                "orderId": to_global_id(OrderNode, order.id),
+                "email": order.lease.application.email,
+            },
+        ],
+    }
+    executed = superuser_api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+    payment_url = payment_provider.get_payment_email_url(
+        order, lang=order.lease.application.language
+    )
+
+    order = Order.objects.get(id=order.id)
+
+    assert len(executed["data"]["approveOrders"]["failedOrders"]) == 1
+    assert executed["data"]["approveOrders"]["failedOrders"][0] == {
+        "id": failure_order_id,
+        "error": "Order matching query does not exist.",
+    }
+
+    assert order.due_date == due_date
+    assert order.lease.status == LeaseStatus.OFFERED
+    assert order.lease.application.status == ApplicationStatus.OFFER_SENT
+
+    assert len(mail.outbox) == 1
+    assert (
+        mail.outbox[0].subject
+        == f"test order approved subject, event: {order.order_number}!"
+    )
+    assert mail.outbox[0].body == f"{ order.order_number } { payment_url }"
+    assert mail.outbox[0].to == [order.lease.application.email]
+
+    assert mail.outbox[0].alternatives == [
+        (f"<b>{ order.order_number } { payment_url }</b>", "text/html")
+    ]


### PR DESCRIPTION
## Description :sparkles:
* Add a mutation to approve orders

The mutation takes a list of order `graphene.ID` and a `dueDate`. If no due date is passed, it takes the one already set on the `order`.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-547](https://helsinkisolutionoffice.atlassian.net/browse/VEN-547):**  mutation to finalize lease offer

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_mutations.py
```

### Manual testing :construction_worker_man:
Create an order, with a lease, and application. Then execute the following mutation:
```graphql
mutation ApproveOrders($input: ApproveOrderMutationInput!) {
  approveOrders(input: $input) {
    failedOrders {
      id
      error
    }
  }
}
```

```json
{
  "input": {
    "orders": [
      {
        "orderId": "",
        "email": "foo@bar.com"
      }
    ]
  }
}
```

## Screenshots :camera_flash:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/15201480/92236601-655cd100-eebe-11ea-8f5c-1632dd5aab74.png">