### PR TITLE
VEN-829 | Send different email notification for umarked ws application

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ Lastly, you can load the User Groups:
 And install the model permissions:
 
     ./manage.py set_group_model_permissions
+
+## Running tests
+
+    pytest
+    
+In order to successfully run tests in ```applications/tests/test_applications_notifications.py``` you need to set env variable ```NOTIFICATIONS_ENABLED=1```

--- a/applications/admin.py
+++ b/applications/admin.py
@@ -316,9 +316,14 @@ class WinterStorageApplicationAdmin(admin.ModelAdmin):
         resent_count = 0
         for application in queryset:
             try:
+                notification_type = (
+                    NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.value
+                    if application.is_unmarked_ws_application()
+                    else NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value
+                )
                 send_notification(
                     application.email,
-                    NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value,
+                    notification_type,
                     application.get_notification_context(),
                     application.language,
                 )

--- a/applications/constants.py
+++ b/applications/constants.py
@@ -1,0 +1,2 @@
+MARKED_WS_SENDER = "CreateMarkedWinterStorageApplication"
+UNMARKED_WS_SENDER = "CreateUnmarkedWinterStorageApplication"

--- a/applications/models.py
+++ b/applications/models.py
@@ -281,6 +281,15 @@ class WinterStorageApplication(BaseApplication):
         verbose_name=_("trailer registration number"), max_length=64, blank=True
     )
 
+    def is_unmarked_ws_application(self) -> bool:
+        first_area = self.chosen_areas.first()
+
+        return bool(
+            self.chosen_areas.count() == 1
+            and first_area.number_of_unmarked_spaces
+            and first_area.number_of_unmarked_spaces > 0
+        )
+
     def get_notification_context(self):
         return {
             "created_at": localize_datetime(self.created_at, self.language),

--- a/applications/notifications.py
+++ b/applications/notifications.py
@@ -22,6 +22,10 @@ class NotificationType(TextChoices):
         "winter_storage_application_created",
         _("Winter storage application created"),
     )
+    UNMARKED_WINTER_STORAGE_APPLICATION_CREATED = (
+        "unmarked_winter_storage_application_created",
+        _("Unmarked winter storage application created"),
+    )
 
 
 notifications.register(
@@ -31,6 +35,10 @@ notifications.register(
 notifications.register(
     NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value,
     NotificationType.WINTER_STORAGE_APPLICATION_CREATED.label,
+)
+notifications.register(
+    NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.value,
+    NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.label,
 )
 
 berth_application = BerthApplicationFactory.build()
@@ -48,6 +56,10 @@ dummy_context.update(
             "harbor_choices": sorted(harbor_choices, key=lambda c: c.priority),
         },
         NotificationType.WINTER_STORAGE_APPLICATION_CREATED: {
+            "application": winter_storage_application,
+            "area_choices": sorted(winter_area_choices, key=lambda c: c.priority),
+        },
+        NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED: {
             "application": winter_storage_application,
             "area_choices": sorted(winter_area_choices, key=lambda c: c.priority),
         },

--- a/applications/schema.py
+++ b/applications/schema.py
@@ -4,6 +4,7 @@ from graphene_django.types import DjangoObjectType
 from harbors.schema import HarborType, WinterStorageAreaType
 from utils.relay import get_node_from_global_id
 
+from .constants import MARKED_WS_SENDER, UNMARKED_WS_SENDER
 from .enums import WinterStorageMethod
 from .models import (
     BerthApplication,
@@ -197,9 +198,12 @@ class CreateWinterStorageApplication(graphene.Mutation):
             )
 
         # Send notifications when all m2m relations are saved
-        application_saved.send(
-            sender="CreateWinterStorageApplication", application=application
+        sender = (
+            UNMARKED_WS_SENDER
+            if application.is_unmarked_ws_application()
+            else MARKED_WS_SENDER
         )
+        application_saved.send(sender=sender, application=application)
 
         ok = True
         return CreateWinterStorageApplication(

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -4,6 +4,7 @@ from django.dispatch import Signal
 from django_ilmoitin.utils import send_notification
 from sentry_sdk import capture_exception
 
+from .constants import MARKED_WS_SENDER, UNMARKED_WS_SENDER
 from .notifications import NotificationType
 
 application_saved = Signal(providing_args=["application"])
@@ -11,8 +12,13 @@ application_saved = Signal(providing_args=["application"])
 
 def application_notification_handler(sender, application, **kwargs):
     notification_type = NotificationType.BERTH_APPLICATION_CREATED.value
-    if sender == "CreateWinterStorageApplication":
+    if sender == MARKED_WS_SENDER:
         notification_type = NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value
+    elif sender == UNMARKED_WS_SENDER:
+        notification_type = (
+            NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.value
+        )
+
     try:
         send_notification(
             application.email,

--- a/applications/tests/test_application_models.py
+++ b/applications/tests/test_application_models.py
@@ -1,7 +1,10 @@
 import pytest
 from django.core.exceptions import ValidationError
 
+from harbors.tests.factories import WinterStorageAreaFactory
+
 from ..enums import ApplicationStatus
+from .factories import WinterAreaChoiceFactory
 
 
 def test_berth_application_without_lease_valid_statuses(berth_application):
@@ -25,3 +28,25 @@ def test_berth_application_without_lease_invalid_statuses(berth_application):
     error_msg = str(exception.value)
     assert new_status.name in error_msg
     assert "BerthApplication with no lease can only be" in error_msg
+
+
+def test_winterstorage_application_is_not_unmarked(winter_storage_application):
+    area = WinterStorageAreaFactory()
+    area.number_of_unmarked_spaces = None
+    area.save()
+    WinterAreaChoiceFactory(
+        application=winter_storage_application, winter_storage_area=area
+    )
+
+    assert winter_storage_application.is_unmarked_ws_application() is False
+
+
+def test_unmarked_winterstorage_application_is_unmarked(winter_storage_application):
+    area = WinterStorageAreaFactory()
+    area.number_of_unmarked_spaces = 50
+    area.save()
+    WinterAreaChoiceFactory(
+        application=winter_storage_application, winter_storage_area=area
+    )
+
+    assert winter_storage_application.is_unmarked_ws_application() is True

--- a/applications/tests/test_applications_notifications.py
+++ b/applications/tests/test_applications_notifications.py
@@ -2,6 +2,7 @@ import pytest
 from django.core import mail
 from django_ilmoitin.models import NotificationTemplate
 
+from ..constants import MARKED_WS_SENDER, UNMARKED_WS_SENDER
 from ..notifications import NotificationType
 from ..signals import application_saved
 from .factories import BerthApplicationFactory, WinterStorageApplicationFactory
@@ -27,6 +28,16 @@ def notification_template_winter_application_created():
     )
 
 
+@pytest.fixture
+def notification_template_unmarked_winter_application_created():
+    return NotificationTemplate.objects.language("fi").create(
+        type=NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.value,
+        subject="test unmarked winter application created subject, event: {{ application.first_name }}!",
+        body_html="<b>test winter application created body HTML!</b>",
+        body_text="test winter application created body text!",
+    )
+
+
 def test_berth_application_created_notification_is_sent(
     notification_template_berth_application_created,
 ):
@@ -44,12 +55,26 @@ def test_winter_application_created_notification_is_sent(
     notification_template_winter_application_created,
 ):
     application = WinterStorageApplicationFactory()
-    application_saved.send(
-        sender="CreateWinterStorageApplication", application=application
-    )
+    application_saved.send(sender=MARKED_WS_SENDER, application=application)
 
     assert len(mail.outbox) == 1
     msg = mail.outbox[0]
     assert msg.subject == "test winter application created subject, event: {}!".format(
         application.first_name
+    )
+
+
+def test_unmarked_winter_application_created_notification_is_sent(
+    notification_template_unmarked_winter_application_created,
+):
+    application = WinterStorageApplicationFactory()
+    application_saved.send(sender=UNMARKED_WS_SENDER, application=application)
+
+    assert len(mail.outbox) == 1
+    msg = mail.outbox[0]
+    assert (
+        msg.subject
+        == "test unmarked winter application created subject, event: {}!".format(
+            application.first_name
+        )
     )


### PR DESCRIPTION
## Description :sparkles:
- Send different email notification for umarked ws application
- Improve readme, add instructions for test running

## Issues :bug:
### Closes :no_good_woman:
[VEN-829](https://helsinkisolutionoffice.atlassian.net/browse/VEN-829)

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
    pytest applications/tests/test_applications_notifications.py::test_unmarked_winter_application_created_notification_is_sent
    pytest applications/tests/test_application_models.py::test_winterstorage_application_is_not_unmarked
    pytest applications/tests/test_application_models.py::test_unmarked_winterstorage_application_is_unmarked
