### PR TITLE
VEN-815 | Order notifications

### DIFF
--- a/applications/tests/factories.py
+++ b/applications/tests/factories.py
@@ -9,6 +9,7 @@ from harbors.tests.factories import (
 from ..enums import WinterStorageMethod
 from ..models import (
     BerthApplication,
+    BerthSwitch,
     HarborChoice,
     WinterStorageApplication,
     WinterStorageAreaChoice,
@@ -56,3 +57,12 @@ class WinterAreaChoiceFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = WinterStorageAreaChoice
+
+
+class BerthSwitchFactory(factory.django.DjangoModelFactory):
+    harbor = factory.SubFactory(HarborFactory)
+    pier = factory.Faker("random_int", min=1, max=100)
+    berth_number = factory.Faker("random_int", min=1, max=100)
+
+    class Meta:
+        model = BerthSwitch

--- a/payments/enums.py
+++ b/payments/enums.py
@@ -66,3 +66,15 @@ class OrderStatus(TextChoices):
     CANCELLED = "cancelled", _("Cancelled")
     EXPIRED = "expired", _("Expired")
     PAID = "paid", _("Paid")
+
+
+class OrderType(TextChoices):
+    NEW_BERTH_ORDER = "new_berth_order", _("New berth order")
+    RENEW_BERTH_ORDER = "renew_berth_order", _("Renew berth order")
+    BERTH_SWITCH_ORDER = "berth_switch_order", _("Berth switch order")
+    WINTER_STORAGE_ORDER = "winter_storage_order", _("Winter storage order")
+    UNMARKED_WINTER_STORAGE_ORDER = (
+        "unmarked_winter_storage_order",
+        _("Unmarked winter storage order"),
+    )
+    INVALID = "invalid_order", _("Invalid order")

--- a/payments/notifications/__init__.py
+++ b/payments/notifications/__init__.py
@@ -4,9 +4,8 @@ from django_ilmoitin.registry import notifications
 from .dummy_context import load_dummy_context
 from .types import NotificationType
 
-notifications.register(
-    NotificationType.ORDER_APPROVED.value, NotificationType.ORDER_APPROVED.label,
-)
+for (value, label) in NotificationType.choices:
+    notifications.register(value, label)
 
 try:
     load_dummy_context()

--- a/payments/notifications/dummy_context.py
+++ b/payments/notifications/dummy_context.py
@@ -1,18 +1,47 @@
 from decimal import Decimal
+from typing import Dict, List
 
 from django.conf import settings
 from django_ilmoitin.dummy_context import dummy_context
 
 from berth_reservations.tests.factories import CustomerProfileFactory
-from leases.tests.factories import BerthLeaseFactory
+from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
 
 from ..enums import ProductServiceType
+from ..models import Order, OrderLine
 from ..providers import BamboraPayformProvider
-from ..tests.factories import BerthProductFactory, OrderFactory, OrderLineFactory
+from ..tests.factories import (
+    BerthProductFactory,
+    OrderFactory,
+    OrderLineFactory,
+    WinterStorageProductFactory,
+)
+from ..tests.utils import random_price
 from .types import NotificationType
 
+provider = BamboraPayformProvider(
+    config={
+        "VENE_PAYMENTS_BAMBORA_API_URL": "https://real-bambora-api-url/api",
+        "VENE_PAYMENTS_BAMBORA_API_KEY": "dummy-key",
+        "VENE_PAYMENTS_BAMBORA_API_SECRET": "dummy-secret",
+        "VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS": ["dummy-bank"],
+    },
+    ui_return_url=settings.VENE_UI_RETURN_URL,
+)
 
-def load_dummy_context():
+
+def _get_order_context(
+    order: Order, fixed_services: List[OrderLine], optional_services: List[OrderLine]
+) -> Dict:
+    return {
+        "order": order,
+        "payment_url": provider.get_payment_email_url(order, settings.LANGUAGE_CODE),
+        "fixed_services": fixed_services,
+        "optional_services": optional_services,
+    }
+
+
+def _get_berth_order_context():
     customer = CustomerProfileFactory.build()
     order = OrderFactory.build(
         customer=customer,
@@ -44,23 +73,41 @@ def load_dummy_context():
         ),
     ]
 
-    payment_url = BamboraPayformProvider(
-        config={
-            "VENE_PAYMENTS_BAMBORA_API_URL": "https://real-bambora-api-url/api",
-            "VENE_PAYMENTS_BAMBORA_API_KEY": "dummy-key",
-            "VENE_PAYMENTS_BAMBORA_API_SECRET": "dummy-secret",
-            "VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS": ["dummy-bank"],
-        },
-        ui_return_url=settings.VENE_UI_RETURN_URL,
-    ).get_payment_email_url(order, lang=settings.LANGUAGE_CODE)
+    return _get_order_context(order, fixed_services, optional_services)
 
+
+def _get_winter_storage_order_context():
+    customer = CustomerProfileFactory.build()
+    order = OrderFactory.build(
+        customer=customer,
+        product=WinterStorageProductFactory.build(),
+        lease=WinterStorageLeaseFactory.build(customer=customer),
+        price=Decimal("100"),
+        tax_percentage=Decimal("24.00"),
+    )
+    optional_services = [
+        OrderLineFactory.build(
+            order=order,
+            product__service=ProductServiceType.OPTIONAL_SERVICES()[0],
+            price=random_price(),
+        ),
+        OrderLineFactory.build(
+            order=order,
+            product__service=ProductServiceType.OPTIONAL_SERVICES()[1],
+            price=random_price(),
+        ),
+    ]
+
+    return _get_order_context(order, [], optional_services)
+
+
+def load_dummy_context():
     dummy_context.update(
         {
-            NotificationType.ORDER_APPROVED: {
-                "order": order,
-                "payment_url": payment_url,
-                "fixed_services": fixed_services,
-                "optional_services": optional_services,
-            }
+            NotificationType.NEW_BERTH_ORDER_APPROVED: _get_berth_order_context(),
+            NotificationType.RENEW_BERTH_ORDER_APPROVED: _get_berth_order_context(),
+            NotificationType.BERTH_SWITCH_ORDER_APPROVED: _get_berth_order_context(),
+            NotificationType.NEW_WINTER_STORAGE_ORDER_APPROVED: _get_winter_storage_order_context(),
+            NotificationType.UNMARKED_WINTER_STORAGE_ORDER_APPROVED: _get_winter_storage_order_context(),
         }
     )

--- a/payments/notifications/types.py
+++ b/payments/notifications/types.py
@@ -3,7 +3,23 @@ from django.utils.translation import gettext_lazy as _
 
 
 class NotificationType(TextChoices):
-    ORDER_APPROVED = (
-        "order_approved",
-        _("Order approved"),
+    NEW_BERTH_ORDER_APPROVED = (
+        "new_berth_order_approved",
+        _("New berth order approved"),
+    )
+    RENEW_BERTH_ORDER_APPROVED = (
+        "renew_berth_order_approved",
+        _("Renew berth order approved"),
+    )
+    BERTH_SWITCH_ORDER_APPROVED = (
+        "berth_switch_order_approved",
+        _("Berth switch order approved"),
+    )
+    NEW_WINTER_STORAGE_ORDER_APPROVED = (
+        "new_winter_storage_order_approved",
+        _("New winter storage order approved"),
+    )
+    UNMARKED_WINTER_STORAGE_ORDER_APPROVED = (
+        "unmarked_winter_storage_order_approved",
+        _("Unmarked winter storage order approved"),
     )

--- a/payments/schema/mutations.py
+++ b/payments/schema/mutations.py
@@ -34,6 +34,7 @@ from ..models import (
     WinterStorageProduct,
 )
 from ..providers import get_payment_provider
+from ..utils import get_order_notification_type
 from .types import (
     AdditionalProductNode,
     AdditionalProductTaxEnum,
@@ -508,8 +509,6 @@ class ApproveOrderMutation(graphene.ClientIDMutation):
         WinterStorageApplication,
     )
     def mutate_and_get_payload(cls, root, info, **input):
-        from ..notifications import NotificationType
-
         failed_orders = []
         due_date = input.get("due_date", today().date() + relativedelta(weeks=2))
 
@@ -554,9 +553,9 @@ class ApproveOrderMutation(graphene.ClientIDMutation):
                         ),
                         "payment_url": payment_url,
                     }
-                    send_notification(
-                        email, NotificationType.ORDER_APPROVED.value, context, language
-                    )
+
+                    notification_type = get_order_notification_type(order)
+                    send_notification(email, notification_type.value, context, language)
             except (
                 AnymailError,
                 OSError,

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -188,19 +188,19 @@ def mocked_response_create(*args, **kwargs):
 
 
 @pytest.fixture
-def notification_template_order_approved():
+def notification_template_orders_approved():
     from ..notifications import NotificationType
 
-    notification = NotificationTemplate.objects.language("fi").create(
-        type=NotificationType.ORDER_APPROVED.value,
-        subject="test order approved subject, event: {{ order.order_number }}!",
-        body_html="<b>{{ order.order_number }} {{ payment_url }}</b>",
-        body_text="{{ order.order_number }} {{ payment_url }}",
-    )
-    notification.create_translation(
-        "en",
-        subject="test order approved subject, event: {{ order.order_number }}!",
-        body_html="<b>{{ order.order_number }} {{ payment_url }}</b>",
-        body_text="{{ order.order_number }} {{ payment_url }}",
-    )
-    return notification
+    for value in NotificationType.values:
+        notification = NotificationTemplate.objects.language("fi").create(
+            type=value,
+            subject="test order approved subject, event: {{ order.order_number }}!",
+            body_html="<b>{{ order.order_number }} {{ payment_url }}</b>",
+            body_text="{{ order.order_number }} {{ payment_url }}",
+        )
+        notification.create_translation(
+            "en",
+            subject="test order approved subject, event: {{ order.order_number }}!",
+            body_html="<b>{{ order.order_number }} {{ payment_url }}</b>",
+            body_text="{{ order.order_number }} {{ payment_url }}",
+        )

--- a/payments/tests/test_payments_mutations_approve_order.py
+++ b/payments/tests/test_payments_mutations_approve_order.py
@@ -35,7 +35,7 @@ mutation APPROVE_ORDER_MUTATION($input: ApproveOrderMutationInput!) {
 )
 @freeze_time("2020-01-01T08:00:00Z")
 def test_approve_order(
-    api_client, order: Order, payment_provider, notification_template_order_approved,
+    api_client, order: Order, payment_provider, notification_template_orders_approved,
 ):
     due_date = (today() + relativedelta(days=14)).date()
     variables = {
@@ -80,7 +80,7 @@ def test_approve_order(
 )
 @freeze_time("2020-01-01T08:00:00Z")
 def test_approve_order_default_due_date(
-    api_client, order: Order, payment_provider, notification_template_order_approved,
+    api_client, order: Order, payment_provider, notification_template_orders_approved,
 ):
     order.due_date = today().date()
     order.save()
@@ -120,7 +120,7 @@ def test_approve_order_not_enough_permissions(api_client):
 
 @freeze_time("2020-01-01T08:00:00Z")
 def test_approve_order_does_not_exist(
-    superuser_api_client, payment_provider, notification_template_order_approved,
+    superuser_api_client, payment_provider, notification_template_orders_approved,
 ):
     order_id = to_global_id(OrderNode, uuid.uuid4())
 
@@ -143,7 +143,7 @@ def test_approve_order_does_not_exist(
 def test_approve_order_anymail_error(
     superuser_api_client,
     payment_provider,
-    notification_template_order_approved,
+    notification_template_orders_approved,
     order: Order,
 ):
     order_id = to_global_id(OrderNode, order.id)
@@ -183,7 +183,7 @@ def test_approve_order_one_success_one_failure(
     superuser_api_client,
     order: Order,
     payment_provider,
-    notification_template_order_approved,
+    notification_template_orders_approved,
 ):
     due_date = (today() + relativedelta(days=14)).date()
     failure_order_id = to_global_id(OrderNode, uuid.uuid4())

--- a/payments/tests/test_payments_order_types.py
+++ b/payments/tests/test_payments_order_types.py
@@ -17,7 +17,9 @@ from payments.tests.utils import random_price, random_tax
 
 
 def test_order_type_new_berth_order(berth_lease, berth_product):
-    order = OrderFactory(lease=berth_lease, product=berth_product)
+    order = OrderFactory(
+        lease=berth_lease, product=berth_product, customer=berth_lease.customer
+    )
     assert order.order_type == OrderType.NEW_BERTH_ORDER
 
 

--- a/payments/tests/test_payments_order_types.py
+++ b/payments/tests/test_payments_order_types.py
@@ -1,0 +1,82 @@
+import pytest  # noqa
+
+from applications.enums import ApplicationAreaType
+from applications.tests.factories import (
+    BerthApplicationFactory,
+    BerthSwitchFactory,
+    WinterStorageApplicationFactory,
+)
+from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
+from payments.enums import OrderType
+from payments.tests.factories import (
+    BerthProductFactory,
+    OrderFactory,
+    WinterStorageProductFactory,
+)
+from payments.tests.utils import random_price, random_tax
+
+
+def test_order_type_new_berth_order(berth_lease, berth_product):
+    order = OrderFactory(lease=berth_lease, product=berth_product)
+    assert order.order_type == OrderType.NEW_BERTH_ORDER
+
+
+def test_order_type_renew_berth_order(berth, customer_profile):
+    BerthLeaseFactory(
+        customer=customer_profile,
+        berth=berth,
+        start_date="2020-05-10",
+        end_date="2020-05-15",
+    )
+    lease = BerthLeaseFactory(
+        customer=customer_profile,
+        berth=berth,
+        start_date="2020-06-10",
+        end_date="2020-06-15",
+    )
+    order = OrderFactory(
+        lease=lease, customer=customer_profile, product=BerthProductFactory(),
+    )
+    assert order.order_type == OrderType.RENEW_BERTH_ORDER
+
+
+def test_order_type_berth_switch_order(customer_profile):
+    order = OrderFactory(
+        customer=customer_profile,
+        product=BerthProductFactory(),
+        lease=BerthLeaseFactory(
+            customer=customer_profile,
+            application=BerthApplicationFactory(berth_switch=BerthSwitchFactory()),
+        ),
+    )
+    assert order.order_type == OrderType.BERTH_SWITCH_ORDER
+
+
+def test_order_type_winter_storage_order(customer_profile):
+    order = OrderFactory(
+        customer=customer_profile,
+        product=WinterStorageProductFactory(),
+        lease=WinterStorageLeaseFactory(customer=customer_profile),
+    )
+    assert order.order_type == OrderType.WINTER_STORAGE_ORDER
+
+
+def test_order_type_unmarked_winter_storage_order(customer_profile):
+    order = OrderFactory(
+        customer=customer_profile,
+        product=WinterStorageProductFactory(),
+        lease=WinterStorageLeaseFactory(
+            customer=customer_profile,
+            application=WinterStorageApplicationFactory(
+                area_type=ApplicationAreaType.UNMARKED
+            ),
+        ),
+    )
+    assert order.order_type == OrderType.UNMARKED_WINTER_STORAGE_ORDER
+
+
+def test_order_type_invalid(customer_profile):
+    order = OrderFactory(
+        lease=None, product=None, price=random_price(), tax_percentage=random_tax()
+    )
+    assert order.order_type == OrderType.INVALID

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -11,6 +11,8 @@ from uuid import UUID
 
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from leases.utils import (
     calculate_season_end_date,
@@ -213,3 +215,19 @@ def get_talpa_product_id(
             own_product_number,
         ]
     )
+
+
+def get_order_notification_type(order):
+    from .enums import OrderType
+    from .notifications import NotificationType
+
+    if order.order_type == OrderType.NEW_BERTH_ORDER:
+        return NotificationType.NEW_BERTH_ORDER_APPROVED
+    elif order.order_type == OrderType.BERTH_SWITCH_ORDER:
+        return NotificationType.BERTH_SWITCH_ORDER_APPROVED
+    elif order.order_type == OrderType.WINTER_STORAGE_ORDER:
+        return NotificationType.NEW_WINTER_STORAGE_ORDER_APPROVED
+    elif order.order_type == OrderType.UNMARKED_WINTER_STORAGE_ORDER:
+        return NotificationType.UNMARKED_WINTER_STORAGE_ORDER_APPROVED
+    else:
+        raise ValidationError(_("Order does not have a valid type"))


### PR DESCRIPTION
## Description :sparkles:
* Add an `order_type` prop to the `Order`s to determine which email should be used

The criteria to determine the `order type` is as follows:
* `NEW_BERTH_ORDER` = The order has a `berth lease` and no previous leases for that customer/berth
* `RENEW_BERTH_ORDER` = The order has a `berth lease` and has previous leases for that customer/berth
* `BERTH_SWITCH_ORDER` = The `order.lease.application` has a `berth switch`
* `WINTER_STORAGE_ORDER` = The order has a `winter storage lease`
* `UNMARKED_WINTER_STORAGE_ORDER` = The order has an winter storage application with `area_type == UNMARKED`
* `INVALID` = The order is not associated with any lease


## Issues :bug:
### Closes :no_good_woman:
**[VEN-815](https://helsinkisolutionoffice.atlassian.net/browse/VEN-815):** Insert email templates into the database

### Related :handshake:
#280: Mail notification templates

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_order_types.py
```

### Manual testing :construction_worker_man:
1. Add `Notification`s on the [django admin notifications](http://localhost:8000/admin/django_ilmoitin/notificationtemplate/). You can see the required context fields on the [payments/notifications/dummy_context.py](https://github.com/City-of-Helsinki/berth-reservations/compare/ven-815/order-notifications?expand=1#diff-48a9f92debcc403210e7a307f3c98446)
2. Open the `Preview` for each of them

## Screenshots :camera_flash:
**Previewed Unmarked Winter Storage invoice**
![image](https://user-images.githubusercontent.com/15201480/93605538-8e598780-f9cf-11ea-9810-6bb86fe687fe.png)

## Additional notes :spiral_notepad:
The actual templates are built and compiled separately and inserted into the database manually