### PR TITLE
Hotfix | VEN-630 | Timmi import

### DIFF
--- a/customers/tests/test_customer_models.py
+++ b/customers/tests/test_customer_models.py
@@ -330,49 +330,6 @@ def test_import_customer_data_lease_many_piers_no_berth_found(berth, boat_type):
     assert BerthLease.objects.count() == 0
 
 
-def test_import_customer_data_lease_many_piers_default_berth(berth, boat_type):
-    data = [
-        {
-            "customer_id": "313432",
-            "leases": [
-                {
-                    "harbor_servicemap_id": berth.pier.harbor.servicemap_id,
-                    "pier_id": "Fake-identifier",
-                    "berth_number": berth.number,
-                    "start_date": "2019-06-10",
-                    "end_date": "2019-09-14",
-                    "boat_index": 0,
-                }
-            ],
-            "boats": [
-                {
-                    "boat_type": boat_type.name,
-                    "name": "My Boaty",
-                    "registration_number": "",
-                    "width": "1.40",
-                    "length": "3.30",
-                    "draught": None,
-                    "weight": 500,
-                }
-            ],
-            "orders": [],
-            "comment": "",
-            "id": "48319ebc-5eaf-4285-a565-15848225614b",
-        }
-    ]
-
-    assert CustomerProfile.objects.count() == 0
-
-    result = CustomerProfile.objects.import_customer_data(data)
-
-    assert CustomerProfile.objects.count() == 1
-
-    assert result == {"313432": UUID("48319ebc-5eaf-4285-a565-15848225614b")}
-    profile = CustomerProfile.objects.first()
-    assert profile.berth_leases.first().berth.pier.identifier != "Fake-identifier"
-    assert profile.berth_leases.first().berth.number == berth.number
-
-
 def test_import_customer_data_order_many_piers_no_berth_found(berth, boat_type):
     BerthFactory(pier=PierFactory(harbor=berth.pier.harbor), number=berth.number)
 
@@ -408,48 +365,3 @@ def test_import_customer_data_order_many_piers_no_berth_found(berth, boat_type):
 
     assert CustomerProfile.objects.count() == 1
     assert BerthLease.objects.count() == 0
-
-
-def test_import_customer_data_order_many_piers_default_berth(berth, boat_type):
-    data = [
-        {
-            "customer_id": "313432",
-            "leases": [],
-            "boats": [],
-            "orders": [
-                {
-                    "created_at": "2019-12-02 00:00:00.000",
-                    "order_sum": "251.00",
-                    "vat_percentage": "25.0",
-                    "is_paid": True,
-                    "berth": {
-                        "harbor_servicemap_id": berth.pier.harbor.servicemap_id,
-                        "pier_id": "Fake-identifier",
-                        "berth_number": berth.number,
-                    },
-                    "comment": "Laskunumero: 247509 RAMSAYRANTA A 004",
-                }
-            ],
-            "comment": "",
-            "id": "48319ebc-5eaf-4285-a565-15848225614b",
-        }
-    ]
-
-    assert CustomerProfile.objects.count() == 0
-
-    result = CustomerProfile.objects.import_customer_data(data)
-
-    assert CustomerProfile.objects.count() == 1
-
-    assert result == {"313432": UUID("48319ebc-5eaf-4285-a565-15848225614b")}
-    profile = CustomerProfile.objects.first()
-
-    assert profile.orders.count() == 1
-    assert profile.berth_leases.count() == 1
-
-    lease = profile.berth_leases.first()
-
-    assert profile.orders.first().lease == lease
-
-    assert lease.berth.pier.identifier != "Fake-identifier"
-    assert lease.berth.number == berth.number

--- a/resources/fixtures/helsinki-harbor-resources.json
+++ b/resources/fixtures/helsinki-harbor-resources.json
@@ -37403,6 +37403,20 @@
 },
 {
   "model": "resources.berth",
+  "pk": "8ca69fb7-536b-4397-b164-18f8e1d3b1b6",
+  "fields": {
+    "created_at": "2020-09-22T15:26:42.682Z",
+    "modified_at": "2020-09-22T15:26:42.682Z",
+    "is_active": true,
+    "number": "02",
+    "pier": "6e11b488-7036-4092-9a65-7eb016cd2128",
+    "berth_type": "64dc0afd-8c73-4fe8-8722-688fe2e5d699",
+    "comment": "",
+    "is_accessible": null
+  }
+},
+{
+  "model": "resources.berth",
   "pk": "8cc900df-6435-49e8-92f2-185f08ffb949",
   "fields": {
     "created_at": "2020-04-06T11:56:25.666Z",
@@ -56432,7 +56446,7 @@
   "pk": "e151b91c-a82f-434b-b935-a0e2d983af30",
   "fields": {
     "created_at": "2020-09-22T08:08:27.750Z",
-    "modified_at": "2020-09-22T08:08:27.750Z",
+    "modified_at": "2020-09-22T15:26:04.843Z",
     "is_active": true,
     "number": "01",
     "pier": "c3b8ff59-d610-4441-802f-a924490416c5",


### PR DESCRIPTION
## Description :sparkles:
Last batch of changes critical for the Timmi import
* Remove the logic to identify berths and just try and fetch the specfic berth based on the number and pier identifier
* Handle `ValidationError` when creating leases to dismiss diplicate errors
* Add missing `Merisatama 28 (28) 02` - berth fixture

## Issues :bug:
### Closes :no_good_woman:
**[VEN-630](https://helsinkisolutionoffice.atlassian.net/browse/VEN-630)** 
#289 
#291 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest customers/tests/test_customer_models.py
```