### PR TITLE
VEN-800 | Use the lease harbor for default berth products

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -19,7 +19,7 @@ from ..exceptions import (
     ServiceUnavailableError,
     UnknownReturnCodeError,
 )
-from ..models import AdditionalProduct, Order, OrderLine
+from ..models import AdditionalProduct, BerthProduct, Order, OrderLine
 from ..utils import get_talpa_product_id, price_as_fractional_int
 from .base import PaymentProvider
 
@@ -121,8 +121,9 @@ class BamboraPayformProvider(PaymentProvider):
         area = None
 
         if hasattr(order, "product"):
-            if hasattr(order.product, "harbor"):
-                area = order.product.harbor
+            if isinstance(order.product, BerthProduct):
+                # If the product is the "default" product (applies to all areas)
+                area = order.product.harbor or order.lease.berth.pier.harbor
             elif hasattr(order.product, "winter_storage_area"):
                 area = order.product.winter_storage_area
 

--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -21,7 +21,8 @@ from payments.tests.conftest import (
     FAKE_BAMBORA_API_URL,
     mocked_response_create,
 )
-from payments.utils import price_as_fractional_int
+from payments.tests.factories import BerthProductFactory, OrderFactory
+from payments.utils import get_talpa_product_id, price_as_fractional_int
 
 
 @pytest.mark.parametrize(
@@ -127,6 +128,19 @@ def test_payload_add_products_success(payment_provider, order_with_products: Ord
         assert "tax" in product
         assert "count" in product
         assert "type" in product
+
+
+def test_payload_add_product_default_berth_product(payment_provider, berth_lease):
+    product = BerthProductFactory(harbor=None)
+    order = OrderFactory(
+        customer=berth_lease.customer, lease=berth_lease, product=product
+    )
+    payload = {}
+    payment_provider.payload_add_products(payload, order, "fi")
+    assert "amount" in payload
+    assert payload.get("products")[0].get("id") == get_talpa_product_id(
+        product.id, area=berth_lease.berth.pier.harbor
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description :sparkles:
* When a "default" `BerthProduct` (no `harbor` assigned) is being assigned to an order, take the `area` as the harbor associated to the lease

## Issues :bug:
### Closes :no_good_woman:
**[VEN-800](https://helsinkisolutionoffice.atlassian.net/browse/VEN-800)** 

### Related :handshake:
#278 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform.py::test_payload_add_product_default_berth_product
```
