### PR TITLE
VEN-684 | Add pricing rules for organization customers

### DIFF
--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -4,6 +4,9 @@ import pytest
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 
+from customers.enums import OrganizationType
+from customers.tests.factories import OrganizationFactory
+
 from .factories import CustomerProfileFactory, MunicipalityFactory, UserFactory
 from .utils import create_api_client
 
@@ -119,3 +122,19 @@ def municipality():
 @pytest.fixture
 def customer_profile():
     return CustomerProfileFactory()
+
+
+@pytest.fixture
+def company_customer(customer_profile):
+    OrganizationFactory(
+        customer=customer_profile, organization_type=OrganizationType.COMPANY
+    )
+    return customer_profile
+
+
+@pytest.fixture
+def non_billable_customer(customer_profile):
+    OrganizationFactory(
+        customer=customer_profile, organization_type=OrganizationType.NON_BILLABLE
+    )
+    return customer_profile

--- a/customers/models.py
+++ b/customers/models.py
@@ -258,6 +258,12 @@ class CustomerProfile(TimeStampedModel):
         verbose_name_plural = _("customer profiles")
         ordering = ("id",)
 
+    def is_non_billable_customer(self):
+        return (
+            hasattr(self, "organization")
+            and self.organization.organization_type == OrganizationType.NON_BILLABLE
+        )
+
     def __str__(self):
         if self.user:
             return "{} {} ({})".format(

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -9,7 +9,7 @@ from applications.tests.factories import (
     WinterStorageApplicationFactory,
 )
 from berth_reservations.tests.conftest import *  # noqa
-from berth_reservations.tests.factories import CustomerProfileFactory
+from customers.tests.factories import CustomerProfileFactory
 from leases.tests.conftest import *  # noqa
 from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
 from resources.tests.conftest import *  # noqa

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -915,7 +915,7 @@ def test_berth_season_price(berth):
     assert order.price == Decimal("15.00")
 
 
-def test_order_winter_storage_lease_with_area_right_price(
+def test_order_winter_storage_lease_with_section_right_price(
     winter_storage_section, winter_storage_product, boat
 ):
     winter_storage_lease = WinterStorageLeaseFactory(

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -14,6 +14,7 @@ from dateutil.rrule import MONTHLY, rrule
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from customers.enums import OrganizationType
 from leases.enums import LeaseStatus
 from leases.utils import (
     calculate_season_end_date,
@@ -154,6 +155,22 @@ def calculate_product_partial_year_price(
 @rounded
 def calculate_product_percentage_price(base_price, percentage):
     return base_price * (percentage / 100)
+
+
+@rounded
+def calculate_organization_price(price, organization_type: OrganizationType) -> Decimal:
+    if organization_type == OrganizationType.COMPANY:
+        return price * 2
+    elif organization_type == OrganizationType.NON_BILLABLE:
+        return Decimal("0.00")
+    else:
+        return price
+
+
+def calculate_organization_tax_percentage(tax, organization_type) -> Decimal:
+    return (
+        Decimal("0.00") if organization_type == OrganizationType.NON_BILLABLE else tax
+    )
 
 
 def price_as_fractional_int(price: Decimal) -> int:


### PR DESCRIPTION
## Description :sparkles:
- Company customers pay x2 prices
- Non-billable customers do not pay at all, order should show all prices and taxes as 0 and get marked PAID upon creation

## Issues :bug:
### Closes :no_good_woman:
**[VEN-684](https://helsinkisolutionoffice.atlassian.net/browse/VEN-684)** 

## Testing :alembic:
### Automated tests :gear:️
Several new tests in:
`leases/tests/test_lease_mutations.py`
`payments/tests/test_payments_models.py`

### Manual testing :construction_worker_man:
It's hard to test without the whole payment process in place, should be tested once it's implemented.
