### PR TITLE
Hotfix: Add Hernesaari and Merisatama winter areas

### DIFF
--- a/harbors/fixtures/helsinki-winter-areas.json
+++ b/harbors/fixtures/helsinki-winter-areas.json
@@ -4,28 +4,30 @@
     "pk": 1,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00840",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.05944966921156 60.16830790272025)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "9d577c99-63f3-4234-8138-f70a4f8684f2",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": 89,
         "max_width": 450,
         "max_length": 1200,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": null,
-        "resources_area_id": "9d577c99-63f3-4234-8138-f70a4f8684f2"
+        "number_of_unmarked_spaces": null
     }
 },
 {
@@ -33,28 +35,30 @@
     "pk": 2,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00810",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.02681254992266 60.18674774714384)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "3631fbc5-1454-448f-9a9b-fff64588d208",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": false,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": 100,
         "max_width": 450,
         "max_length": 1200,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": null,
-        "resources_area_id": "3631fbc5-1454-448f-9a9b-fff64588d208"
+        "number_of_unmarked_spaces": null
     }
 },
 {
@@ -62,28 +66,30 @@
     "pk": 3,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00980",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.17741322166875 60.20774673533648)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "3f485ff8-36bf-4786-bfe6-b0729e8e9c6b",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": false,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": 57,
         "max_width": 300,
         "max_length": 1000,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": null,
-        "resources_area_id": "3f485ff8-36bf-4786-bfe6-b0729e8e9c6b"
+        "number_of_unmarked_spaces": null
     }
 },
 {
@@ -91,28 +97,30 @@
     "pk": 4,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00250",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (24.90378498684718 60.18105042830676)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "ed291ec2-1cb3-4049-a642-e290280bd8bf",
+        "image_file": "",
         "repair_area": true,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": 253,
         "max_width": 400,
         "max_length": 2000,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": null,
-        "resources_area_id": "ed291ec2-1cb3-4049-a642-e290280bd8bf"
+        "number_of_unmarked_spaces": null
     }
 },
 {
@@ -120,28 +128,30 @@
     "pk": 5,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00100",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (24.94548797260213 60.17618451955499)",
-        "image_file": "",
         "image_link": "",
         "electricity": false,
         "water": false,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "10f6d541-5e4e-420c-abc4-014a48aca3c4",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": false,
         "summer_storage_for_trailers": false,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 100,
-        "resources_area_id": "10f6d541-5e4e-420c-abc4-014a48aca3c4"
+        "number_of_unmarked_spaces": 100
     }
 },
 {
@@ -149,28 +159,30 @@
     "pk": 6,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00980",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.18298148758502 60.21087037289033)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "a9ef8fe9-86a8-44e4-a806-32ed47494129",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": false,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 100,
-        "resources_area_id": "a9ef8fe9-86a8-44e4-a806-32ed47494129"
+        "number_of_unmarked_spaces": 100
     }
 },
 {
@@ -178,28 +190,30 @@
     "pk": 7,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00980",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.1866507495147 60.21045461576973)",
-        "image_file": "",
         "image_link": "",
         "electricity": false,
         "water": false,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "5bfe1de8-dcc7-4ed4-b16d-c5f2fa08be0d",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": true,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 50,
-        "resources_area_id": "5bfe1de8-dcc7-4ed4-b16d-c5f2fa08be0d"
+        "number_of_unmarked_spaces": 50
     }
 },
 {
@@ -207,28 +221,30 @@
     "pk": 8,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "02480",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (24.44123267787173 59.98406384717072)",
-        "image_file": "",
         "image_link": "",
         "electricity": false,
         "water": false,
         "gate": false,
         "municipality": "kirkkonummi",
+        "resources_area": "72335b05-1913-44e2-8f5d-a4219498b47a",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": null,
-        "resources_area_id": "72335b05-1913-44e2-8f5d-a4219498b47a"
+        "number_of_unmarked_spaces": null
     }
 },
 {
@@ -236,28 +252,30 @@
     "pk": 9,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00930",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.09523033746396 60.20531584911696)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "94d97495-bb5c-4d6e-a91a-5da9e70d0aea",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 100,
-        "resources_area_id": "94d97495-bb5c-4d6e-a91a-5da9e70d0aea"
+        "number_of_unmarked_spaces": 100
     }
 },
 {
@@ -265,28 +283,30 @@
     "pk": 10,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00210",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (24.88585710179059 60.15703401158551)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": false,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "c200c0fa-8afc-43ab-8d43-a3d10be4c44a",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": false,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 125,
-        "resources_area_id": "c200c0fa-8afc-43ab-8d43-a3d10be4c44a"
+        "number_of_unmarked_spaces": 125
     }
 },
 {
@@ -294,28 +314,30 @@
     "pk": 11,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00910",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.09989738114965 60.20733093862237)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "db0323f0-8da5-40e3-a8aa-e46ad4af3e93",
+        "image_file": "",
         "repair_area": true,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": true,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 500,
-        "resources_area_id": "db0323f0-8da5-40e3-a8aa-e46ad4af3e93"
+        "number_of_unmarked_spaces": 500
     }
 },
 {
@@ -323,28 +345,90 @@
     "pk": 12,
     "fields": {
         "servicemap_id": null,
+        "disabled": false,
         "zip_code": "00820",
         "phone": "",
         "email": "",
         "www_url": "",
         "location": "SRID=4326;POINT (25.06423473009268 60.19706228633245)",
-        "image_file": "",
         "image_link": "",
         "electricity": true,
         "water": true,
         "gate": false,
         "municipality": "helsinki",
+        "resources_area": "506b0830-fa3e-4da7-a837-b4ffa1218eb1",
+        "image_file": "",
         "repair_area": false,
         "summer_storage_for_docking_equipment": true,
         "summer_storage_for_trailers": false,
         "summer_storage_for_boats": false,
+        "availability_level": null,
         "number_of_marked_places": null,
         "max_width": null,
         "max_length": null,
         "number_of_section_spaces": null,
         "max_length_of_section_spaces": null,
-        "number_of_unmarked_spaces": 40,
-        "resources_area_id": "506b0830-fa3e-4da7-a837-b4ffa1218eb1"
+        "number_of_unmarked_spaces": 40
+    }
+},
+{
+    "model": "harbors.winterstoragearea",
+    "pk": 13,
+    "fields": {
+        "servicemap_id": null,
+        "disabled": false,
+        "zip_code": "00150",
+        "phone": "",
+        "email": "",
+        "www_url": "",
+        "location": "SRID=4326;POINT (24.92620825420595 60.14831971921458)",
+        "image_link": "",
+        "electricity": false,
+        "water": false,
+        "gate": false,
+        "municipality": "helsinki",
+        "resources_area": "f38c0645-bb9c-4c67-a515-cf11f3787541",
+        "image_file": "",
+        "repair_area": false,
+        "summer_storage_for_docking_equipment": false,
+        "summer_storage_for_trailers": false,
+        "summer_storage_for_boats": false,
+        "availability_level": null,
+        "number_of_marked_places": null,
+        "max_width": null,
+        "max_length": null,
+        "number_of_section_spaces": null,
+        "max_length_of_section_spaces": null,
+        "number_of_unmarked_spaces": 500
+    }
+},
+{
+    "model": "harbors.winterstoragearea",
+    "pk": 14,
+    "fields": {
+        "servicemap_id": null,
+        "zip_code": "00150",
+        "phone": "",
+        "email": "",
+        "www_url": "",
+        "location": "SRID=4326;POINT (24.94499199999997 60.154316)",
+        "image_link": "",
+        "electricity": false,
+        "water": true,
+        "gate": false,
+        "municipality": "helsinki",
+        "resources_area": "38955371-4dd2-4321-8994-f4b52c81aa41",
+        "image_file": "",
+        "summer_storage_for_docking_equipment": false,
+        "summer_storage_for_trailers": false,
+        "summer_storage_for_boats": false,
+        "availability_level": null,
+        "number_of_marked_places": null,
+        "max_width": null,
+        "max_length": null,
+        "number_of_section_spaces": null,
+        "max_length_of_section_spaces": null,
+        "number_of_unmarked_spaces": 27
     }
 },
 {
@@ -363,7 +447,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Storfladan",
-        "street_address": "Storfladav\u00e4gen 3",
+        "street_address": "Storfladavägen 3",
         "master": 1
     }
 },
@@ -382,8 +466,8 @@
     "pk": 4,
     "fields": {
         "language_code": "sv",
-        "name": "B\u00e5tsviken",
-        "street_address": "Simp\u00f6rsgatan 2",
+        "name": "Båtsviken",
+        "street_address": "Simpörsgatan 2",
         "master": 2
     }
 },
@@ -393,7 +477,7 @@
     "fields": {
         "language_code": "fi",
         "name": "Porslahti",
-        "street_address": "Etel\u00e4reimarintie 8",
+        "street_address": "Eteläreimarintie 8",
         "master": 3
     }
 },
@@ -403,7 +487,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Porslax",
-        "street_address": "Sydremmarv\u00e4gen 8",
+        "street_address": "Sydremmarvägen 8",
         "master": 3
     }
 },
@@ -422,8 +506,8 @@
     "pk": 8,
     "fields": {
         "language_code": "sv",
-        "name": "R\u00e5holmen",
-        "street_address": "R\u00e5holmsbanken 11",
+        "name": "Råholmen",
+        "street_address": "Råholmsbanken 11",
         "master": 4
     }
 },
@@ -463,7 +547,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Rosenudden I",
-        "street_address": "Sj\u00f6farargr\u00e4nden 1",
+        "street_address": "Sjöfarargränden 1",
         "master": 6
     }
 },
@@ -483,7 +567,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Rosenudden II",
-        "street_address": "Sj\u00f6farargr\u00e4nden 6",
+        "street_address": "Sjöfarargränden 6",
         "master": 7
     }
 },
@@ -492,8 +576,8 @@
     "pk": 15,
     "fields": {
         "language_code": "fi",
-        "name": "L\u00e4hteel\u00e4",
-        "street_address": "L\u00e4ntinen K\u00e4llvikintie",
+        "name": "Lähteelä",
+        "street_address": "Läntinen Källvikintie",
         "master": 8
     }
 },
@@ -502,8 +586,8 @@
     "pk": 16,
     "fields": {
         "language_code": "sv",
-        "name": "K\u00e4llviken",
-        "street_address": "V\u00e4stra K\u00e4llviksv\u00e4gen",
+        "name": "Källviken",
+        "street_address": "Västra Källviksvägen",
         "master": 8
     }
 },
@@ -543,7 +627,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Smedjeviken",
-        "street_address": "Hallonn\u00e4sgatan 26",
+        "street_address": "Hallonnäsgatan 26",
         "master": 10
     }
 },
@@ -563,7 +647,7 @@
     "fields": {
         "language_code": "sv",
         "name": "Botby",
-        "street_address": "Sj\u00f6\u00e5kerv\u00e4gen 11",
+        "street_address": "Sjöåkervägen 11",
         "master": 11
     }
 },
@@ -572,7 +656,7 @@
     "pk": 23,
     "fields": {
         "language_code": "fi",
-        "name": "Str\u00f6msinlahti",
+        "name": "Strömsinlahti",
         "street_address": "Abraham Wetterin tie 26",
         "master": 12
     }
@@ -582,9 +666,49 @@
     "pk": 24,
     "fields": {
         "language_code": "sv",
-        "name": "Str\u00f6msviken",
-        "street_address": "Abraham Wetters v\u00e4g 26",
+        "name": "Strömsviken",
+        "street_address": "Abraham Wetters väg 26",
         "master": 12
+    }
+},
+{
+    "model": "harbors.winterstorageareatranslation",
+    "pk": 25,
+    "fields": {
+        "language_code": "fi",
+        "name": "Hernesaari",
+        "street_address": "Hernesaarenranta 6",
+        "master": 13
+    }
+},
+{
+    "model": "harbors.winterstorageareatranslation",
+    "pk": 26,
+    "fields": {
+        "language_code": "sv",
+        "name": "Ärtholmen",
+        "street_address": "Ärtholmsstranden 6",
+        "master": 13
+    }
+},
+{
+    "model": "harbors.winterstorageareatranslation",
+    "pk": 27,
+    "fields": {
+        "language_code": "fi",
+        "name": "Merisatama",
+        "street_address": "Merisatamanranta 20",
+        "master": 14
+    }
+},
+{
+    "model": "harbors.winterstorageareatranslation",
+    "pk": 28,
+    "fields": {
+        "language_code": "sv",
+        "name": "Havshamn",
+        "street_address": "Havsstranden 20",
+        "master": 14
     }
 }
 ]

--- a/resources/fixtures/helsinki-ws-resources.json
+++ b/resources/fixtures/helsinki-ws-resources.json
@@ -300,6 +300,26 @@
   }
 },
 {
+  "model": "resources.winterstorageareatranslation",
+  "pk": 36,
+  "fields": {
+    "language_code": "fi",
+    "name": "Merisatama",
+    "street_address": "Merisatamanranta 20",
+    "master": "38955371-4dd2-4321-8994-f4b52c81aa41"
+  }
+},
+{
+  "model": "resources.winterstorageareatranslation",
+  "pk": 37,
+  "fields": {
+    "language_code": "sv",
+    "name": "Havshamn",
+    "street_address": "Havsstranden 20",
+    "master": "38955371-4dd2-4321-8994-f4b52c81aa41"
+  }
+},
+{
   "model": "resources.winterstoragearea",
   "pk": "10f6d541-5e4e-420c-abc4-014a48aca3c4",
   "fields": {
@@ -583,6 +603,28 @@
     "estimated_number_of_section_spaces": null,
     "max_length_of_section_spaces": null,
     "estimated_number_of_unmarked_spaces": 30
+  }
+},
+{
+  "model": "resources.winterstoragearea",
+  "pk": "38955371-4dd2-4321-8994-f4b52c81aa41",
+  "fields": {
+    "created_at": "2020-10-01T15:06:18.800Z",
+    "modified_at": "2020-10-01T15:06:18.800Z",
+    "servicemap_id": null,
+    "zip_code": "00150",
+    "phone": "",
+    "email": "",
+    "www_url": "",
+    "location": "SRID=4326;POINT (24.94499199999997 60.154316)",
+    "image_link": "",
+    "region": "west",
+    "municipality": "helsinki",
+    "image_file": "",
+    "availability_level": null,
+    "estimated_number_of_section_spaces": null,
+    "max_length_of_section_spaces": null,
+    "estimated_number_of_unmarked_spaces": 27
   }
 },
 {


### PR DESCRIPTION
## Description :sparkles:
* Add Hernesaari and Merisatama `WinterStorageArea`s and unmarked places

## Testing :alembic:
### Manual testing :construction_worker_man:
```shell
$ python manage.py loaddata helsinki-ws-resources
$ python manage.py loaddata helsinki-winter-areas
```
Check the Django admin on `Harbors -> Winter Storage Areas` and `Resources -> Winter Storage Areas`

## Additional notes :spiral_notepad:
As per the admins:
* Hernesaari: no water, no electricity, no gate, no summer storage for anything, number of unmarked places: we don't know, the area is 8000 m2 (I estimated 500 places)
* Merisatama: yes water, no electricity, no gate, no summer storage for anything, number of unmarked places: 27


