### PR TITLE
VEN-878 | Remove cancel payment handling

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -290,18 +290,7 @@ class BamboraPayformProvider(PaymentProvider):
                 return self.ui_redirect_failure()
         elif return_code == "1":
             logger.debug("Payment failed.")
-            try:
-                order.set_status(
-                    OrderStatus.REJECTED,
-                    "Code 1 (payment rejected) in Bambora Payform success request.",
-                )
-                return self.ui_redirect_failure()
-            except OrderStatusTransitionError as oste:
-                logger.warning(oste)
-                order.create_log_entry(
-                    "Code 1 (payment rejected) in Bambora Payform success request."
-                )
-                return self.ui_redirect_failure()
+            return self.ui_redirect_failure()
         elif return_code == "4":
             logger.debug("Transaction status could not be updated.")
             order.create_log_entry(

--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -313,7 +313,7 @@ def test_handle_success_request_payment_failed(provider_base_config, order):
     payment_provider = create_bambora_provider(provider_base_config, request)
     returned = payment_provider.handle_success_request()
     order_after = Order.objects.get(order_number=params.get("ORDER_NUMBER"))
-    assert order_after.status == OrderStatus.REJECTED
+    assert order_after.status == OrderStatus.WAITING
     assert isinstance(returned, HttpResponse)
     assert "payment_status=failure" in returned.url
 


### PR DESCRIPTION
## Description :sparkles:
* Remove the state transition (to cancelled) when the payment fails

## Issues :bug:
### Closes :no_good_woman:
**[VEN-878](https://helsinkisolutionoffice.atlassian.net/browse/VEN-878):** Remove cancel payment handling

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform.py::test_handle_success_request_payment_failed
```