### PR TITLE
Hotfix | Fix WSLease str method

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -285,7 +285,7 @@ class WinterStorageLease(AbstractLease):
 
     def __str__(self):
         return " {} > {} - {} ({})".format(
-            self.place, self.start_date, self.end_date, self.status
+            self.place or self.section, self.start_date, self.end_date, self.status
         )
 
 


### PR DESCRIPTION
## Description :sparkles:
When a `WSLease` is associated to a `section` instead of a `place`, it was just showing `None`.

## Testing :alembic:
### Manual testing :construction_worker_man:
Go to the `WinterStorageLease` django section

## Screenshots :camera_flash:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/15201480/95443021-ba2fb380-0964-11eb-8a98-11aaa1daf3af.png">
