### PR TITLE
VEN-891 | Fixed season prices

### DIFF
--- a/leases/tests/test_lease_mutations.py
+++ b/leases/tests/test_lease_mutations.py
@@ -17,7 +17,6 @@ from berth_reservations.tests.utils import (
 from customers.schema import BoatNode, ProfileNode
 from payments.models import BerthPriceGroup, Order
 from payments.tests.factories import BerthProductFactory, WinterStorageProductFactory
-from payments.utils import calculate_product_partial_season_price
 from resources.schema import (
     BerthNode,
     HarborNode,
@@ -998,12 +997,7 @@ def test_create_winter_storage_lease_with_order(
     assert WinterStorageLease.objects.count() == 1
     assert Order.objects.count() == 1
     sqm = winter_storage_place.place_type.width * winter_storage_place.place_type.length
-    expected_price = calculate_product_partial_season_price(
-        product.price_value,
-        calculate_winter_storage_lease_start_date(),
-        calculate_winter_storage_lease_end_date(),
-        summer_season=False,
-    )
+    expected_price = product.price_value
     expected_price = rounded(expected_price * sqm, decimals=2, as_string=True)
 
     assert (

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -84,7 +84,15 @@ class OrderAdmin(admin.ModelAdmin):
         "total_price",
         "order_number",
     )
-    list_display = ("name", "order_number", "status", "customer", "lease", "product")
+    list_display = (
+        "name",
+        "total_price",
+        "order_number",
+        "status",
+        "customer",
+        "lease",
+        "product",
+    )
     list_filter = ("status",)
     search_fields = ("order_number", "customer__id")
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -30,7 +30,6 @@ from .utils import (
     calculate_organization_price,
     calculate_organization_tax_percentage,
     calculate_product_partial_month_price,
-    calculate_product_partial_season_price,
     calculate_product_partial_year_price,
     calculate_product_percentage_price,
     convert_aftertax_to_pretax,
@@ -517,13 +516,6 @@ class Order(UUIDModel, TimeStampedModel):
             tax_percentage = self.product.tax_percentage
 
             if self.lease:
-                price = calculate_product_partial_season_price(
-                    price,
-                    self.lease.start_date,
-                    self.lease.end_date,
-                    summer_season=isinstance(self.lease, BerthLease),
-                )
-
                 # If the order is for a winter product with a lease, the price
                 # has to be calculated based on the dimensions of the place associated
                 # to the lease
@@ -709,19 +701,11 @@ class OrderLine(UUIDModel, TimeStampedModel):
                     price = calculate_product_partial_month_price(
                         price, self.order.lease.start_date, self.order.lease.end_date,
                     )
-                elif self.product.period == PeriodType.SEASON:
-                    # Calculate the actual price for the amount of days on the period
-                    # price = (days_on_lease * product.price_value) / season_days
-                    price = calculate_product_partial_season_price(
-                        price,
-                        self.order.lease.start_date,
-                        self.order.lease.end_date,
-                        summer_season=isinstance(self.order.lease, BerthLease),
-                    )
                 elif self.product.period == PeriodType.YEAR:
                     price = calculate_product_partial_year_price(
                         price, self.order.lease.start_date, self.order.lease.end_date,
                     )
+                # The price for season products should always be full
 
             if hasattr(self.order.customer, "organization"):
                 organization_type = self.order.customer.organization.organization_type


### PR DESCRIPTION
## Description :sparkles:
* Remove partial price calculation for season products

## Issues :bug:
### Closes :no_good_woman:
**[VEN-891](https://helsinkisolutionoffice.atlassian.net/browse/VEN-891):** Full price for season products

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```

### Manual testing :construction_worker_man:
1. Create an application and lease for a berth/WS place
2. Create a berth/ws product for the place you selected
3. From the Django admin, go to create an order and assign it to the lease and product you generated
4. Hit `Save and continue editing`
5. The price should be the same as the product if you created a berth order. If you created a ws order, it would be equivalent to `boat lenght * width * product price`
6. Add an `OrderLine` for a `season` product
7. The price should be the same for the order line, the `order` price should've changed and would be `order price + order line price`

## Screenshots :camera_flash:
Working example:
![image](https://user-images.githubusercontent.com/15201480/95454550-4944c780-0975-11eb-9dac-3eb842582781.png)
