### PR TITLE
Hotifx | Remove payment cancel from notify

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -581,11 +581,7 @@ class Order(UUIDModel, TimeStampedModel):
             return
 
         valid_status_changes = {
-            OrderStatus.WAITING: (
-                OrderStatus.PAID,
-                OrderStatus.REJECTED,
-                OrderStatus.EXPIRED,
-            ),
+            OrderStatus.WAITING: (OrderStatus.PAID, OrderStatus.EXPIRED,),
             OrderStatus.PAID: (OrderStatus.CANCELLED,),
             # In rare cases, Bambora Notify would notify that a previously failed payment
             # was later successful, we should allow this case.

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -347,14 +347,8 @@ class BamboraPayformProvider(PaymentProvider):
             except OrderStatusTransitionError as oste:
                 logger.warning(oste)
         elif return_code == "1":
+            # Don't cancel the order
             logger.debug("Notify: Payment failed.")
-            try:
-                order.set_status(
-                    OrderStatus.REJECTED,
-                    "Code 1 (payment rejected) in Bambora Payform notify request.",
-                )
-            except OrderStatusTransitionError as oste:
-                logger.warning(oste)
         else:
             logger.debug('Notify: Incorrect RETURN_CODE "{}".'.format(return_code))
 


### PR DESCRIPTION
## Description :sparkles:
We disabled cancelling payments from Bambora `success` request, but forgot about the `notify` request. In some cases where the payment was cancelled, the `Order` (and lease and application) would be marked as `rejected`.

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform.py::test_handle_notify_request_payment_failed
```