### PR TITLE
Disable the Merihaan 13 harbor and remove available places

### DIFF
--- a/harbors/fixtures/helsinki-harbors.json
+++ b/harbors/fixtures/helsinki-harbors.json
@@ -1885,6 +1885,7 @@
     "pk": 16,
     "fields": {
         "servicemap_id": "41454",
+        "disabled": true,
         "zip_code": "00530",
         "phone": "",
         "email": "",
@@ -1899,10 +1900,10 @@
         "waste_collection": true,
         "gate": true,
         "lighting": true,
-        "availability_level": 2,
-        "number_of_places": 31,
-        "maximum_width": 300,
-        "maximum_length": 900,
+        "availability_level": null,
+        "number_of_places": null,
+        "maximum_width": null,
+        "maximum_length": null,
         "maximum_depth": null,
         "suitable_boat_types": [
             2,


### PR DESCRIPTION
## Description :sparkles:

The actual changes were this:
* Add the disabled flag to the fixture (`"model": "harbors.harbor", "pk": 16`)
```json
"disabled": true,
```
* Remove all the available places from Merihaan 13
```json
"availability_level": null,
"number_of_places": null,
"maximum_width": null,
"maximum_length": null,
"maximum_depth": null,
```

## Issues :bug:
### Closes :no_good_woman:
**[VEN-888](https://helsinkisolutionoffice.atlassian.net/browse/VEN-888):** Disable Merihaan laituri (Hakaniemenranta 13) from berth applications

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:
1. Run the command to load the fixtures
2. Run the command to load images
3. Check the [Harbor page](http://localhost:8000/admin/harbors/harbor/16/change/)
```shell
$ python manage.py loaddata helsinki-harbors
$ python manage.py harbors_add_helsinki_harbors_images
```

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/15201480/95593528-7fa44480-0a52-11eb-94ac-2fcca9487d7e.png)


## Additional notes :spiral_notepad:
The whole file was changed because it was using a different type of
newline, it was using CRLF when the rest of the project was only using
LF.
