### PR TITLE
VEN-883 | Add mutation to cancel an order

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -581,11 +581,12 @@ class Order(UUIDModel, TimeStampedModel):
             return
 
         valid_status_changes = {
-            OrderStatus.WAITING: (OrderStatus.PAID, OrderStatus.EXPIRED,),
+            OrderStatus.WAITING: (
+                OrderStatus.PAID,
+                OrderStatus.EXPIRED,
+                OrderStatus.REJECTED,
+            ),
             OrderStatus.PAID: (OrderStatus.CANCELLED,),
-            # In rare cases, Bambora Notify would notify that a previously failed payment
-            # was later successful, we should allow this case.
-            OrderStatus.REJECTED: (OrderStatus.PAID,),
         }
         valid_new_status = valid_status_changes.get(old_status, ())
 
@@ -597,15 +598,16 @@ class Order(UUIDModel, TimeStampedModel):
             )
 
         self.status = new_status
+        self.save(update_fields=["status"])
+
         self.lease.status = get_lease_status(new_status)
+        self.lease.save(update_fields=["status"])
 
         if new_status == OrderStatus.PAID:
             application = self.lease.application
             application.status = ApplicationStatus.HANDLED
             self.lease.application.save(update_fields=["status"])
 
-        self.lease.save(update_fields=["status"])
-        self.save(update_fields=["status"])
         self.create_log_entry(
             from_status=old_status, to_status=new_status, comment=comment
         )

--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -395,7 +395,6 @@ def test_handle_notify_request_order_not_found(provider_base_config, order):
     (
         (OrderStatus.WAITING, OrderStatus.PAID),
         (OrderStatus.PAID, OrderStatus.PAID),
-        (OrderStatus.REJECTED, OrderStatus.PAID),
         (OrderStatus.EXPIRED, OrderStatus.EXPIRED),
         (OrderStatus.CANCELLED, OrderStatus.CANCELLED),
     ),


### PR DESCRIPTION
## Description :sparkles:
* Add a mutation to cancel an order (intended to be used by the customer UI)

## Issues :bug:
### Closes :no_good_woman:
**[VEN-883](https://helsinkisolutionoffice.atlassian.net/browse/VEN-883):** Mutation to cancel orders

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_mutations.py::test_cancel_order
$ pytest payments/tests/test_payments_mutations.py::test_cancel_order_invalid_status
$ pytest payments/tests/test_payments_mutations.py::test_cancel_order_does_not_exist
```