### PR TITLE
VEN-875 | Django admin improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# [Unreleased]
+
+<details>
+  <summary>
+    Changes that landed in develop and might be expected in the upcoming releases.
+    Click to see more.
+  </summary>
+...
+</details>
+
+# rel/2020-10-15.1
+
+**Added:**
+
+- Add default section fixture for Merisatama. in ([#330](https://github.com/City-of-Helsinki/berth-reservations/pull/330))

--- a/applications/admin.py
+++ b/applications/admin.py
@@ -144,8 +144,16 @@ class BerthApplicationAdmin(admin.ModelAdmin):
             },
         ),
     ]
-    list_display = ("created_at", "first_name", "last_name", "application_type")
-    list_filter = (ApplicationTypeFilter,)
+    list_display = (
+        "id",
+        "created_at",
+        "first_name",
+        "last_name",
+        "application_type",
+        "status",
+    )
+    list_filter = (ApplicationTypeFilter, "status")
+    search_fields = ("id", "first_name", "last_name")
     actions = ["export_applications", "resend_application_confirmation"]
 
     def application_type(self, obj):
@@ -232,9 +240,17 @@ class WinterStorageAreaChoiceInline(admin.TabularInline):
     max_num = 5
 
 
+class WinterStorageApplicationInline(admin.StackedInline):
+    model = WinterStorageApplication
+    extra = 0
+
+
 class WinterStorageApplicationAdmin(admin.ModelAdmin):
     inlines = [WinterStorageAreaChoiceInline]
-    readonly_fields = ["created_at"]
+    readonly_fields = [
+        "created_at",
+        "area_type",
+    ]
     fieldsets = [
         (
             None,
@@ -292,8 +308,17 @@ class WinterStorageApplicationAdmin(admin.ModelAdmin):
             },
         ),
     ]
-    list_display = ("created_at", "first_name", "last_name")
+    list_display = (
+        "id",
+        "created_at",
+        "first_name",
+        "last_name",
+        "area_type",
+        "status",
+    )
+    list_filter = ("area_type", "status")
     actions = ["export_applications", "resend_application_confirmation"]
+    search_fields = ("id", "first_name", "last_name")
 
     def export_applications(self, request, queryset):
         response = HttpResponse(

--- a/customers/admin.py
+++ b/customers/admin.py
@@ -6,8 +6,9 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import path
 
-from applications.admin import BerthApplicationInline
-from leases.admin import BerthLeaseInline
+from applications.admin import BerthApplicationInline, WinterStorageApplicationInline
+from leases.admin import BerthLeaseInline, WinterStorageLeaseInline
+from payments.admin import OrderInline
 
 from .models import Boat, BoatCertificate, CustomerProfile, Organization
 
@@ -53,7 +54,15 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 
 class CustomerProfileAdmin(admin.ModelAdmin):
-    inlines = (BoatInline, OrganizationInline, BerthApplicationInline, BerthLeaseInline)
+    inlines = (
+        BoatInline,
+        OrganizationInline,
+        BerthApplicationInline,
+        BerthLeaseInline,
+        WinterStorageApplicationInline,
+        WinterStorageLeaseInline,
+        OrderInline,
+    )
 
     change_list_template = "admin/customers/profiles_changelist.html"
 

--- a/leases/admin.py
+++ b/leases/admin.py
@@ -50,6 +50,13 @@ class BerthLeaseAdmin(admin.ModelAdmin):
     raw_id_fields = ("berth", "application")
 
 
+class WinterStorageLeaseInline(admin.StackedInline):
+    model = WinterStorageLease
+    fk_name = "customer"
+    raw_id_fields = ("application",)
+    extra = 0
+
+
 class WinterStorageLeaseAdmin(admin.ModelAdmin):
     inlines = (WinterStorageLeaseChangeInline,)
     raw_id_fields = ("place", "application")

--- a/leases/admin.py
+++ b/leases/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.contrib.contenttypes.admin import GenericStackedInline
+
+from payments.models import Order
 
 from .models import (
     BerthLease,
@@ -45,8 +48,45 @@ class BerthLeaseInline(admin.StackedInline):
     extra = 0
 
 
-class BerthLeaseAdmin(admin.ModelAdmin):
-    inlines = (BerthLeaseChangeInline,)
+class BaseLeaseAdmin(admin.ModelAdmin):
+    def application_id(self, obj):
+        return obj.application.id
+
+    def first_name(self, obj):
+        return obj.application.first_name
+
+    def last_name(self, obj):
+        return obj.application.last_name
+
+    list_filter = ("status",)
+    list_display = (
+        "id",
+        "created_at",
+        "start_date",
+        "end_date",
+        "first_name",
+        "last_name",
+        "status",
+        "application_id",
+    )
+    search_fields = (
+        "id",
+        "application__id",
+        "application__first_name",
+        "application__last_name",
+    )
+
+
+class GenericOrderInline(GenericStackedInline):
+    ct_field = "_lease_content_type"
+    ct_fk_field = "_lease_object_id"
+    model = Order
+    extra = 0
+    exclude = ("_product_content_type", "_lease_content_type")
+
+
+class BerthLeaseAdmin(BaseLeaseAdmin):
+    inlines = (BerthLeaseChangeInline, GenericOrderInline)
     raw_id_fields = ("berth", "application")
 
 
@@ -57,9 +97,9 @@ class WinterStorageLeaseInline(admin.StackedInline):
     extra = 0
 
 
-class WinterStorageLeaseAdmin(admin.ModelAdmin):
-    inlines = (WinterStorageLeaseChangeInline,)
-    raw_id_fields = ("place", "application")
+class WinterStorageLeaseAdmin(BaseLeaseAdmin):
+    inlines = (WinterStorageLeaseChangeInline, GenericOrderInline)
+    raw_id_fields = ("place", "section", "application")
 
 
 admin.site.register(BerthLease, BerthLeaseAdmin)

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -165,6 +165,12 @@ class OrderTokenAdmin(admin.ModelAdmin):
     invalidate_tokens.short_description = _("Invalidate selected tokens")
 
 
+class OrderInline(admin.StackedInline):
+    model = Order
+    extra = 0
+    exclude = ("_product_content_type", "_lease_content_type")
+
+
 admin.site.register([WinterStorageProduct, BerthProduct, OrderLine, OrderLogEntry])
 admin.site.register(AdditionalProduct, AdditionalProductAdmin)
 admin.site.register(BerthPriceGroup, BerthPriceGroupAdmin)

--- a/resources/admin.py
+++ b/resources/admin.py
@@ -25,7 +25,7 @@ class CustomTranslatableAdmin(TranslatableAdmin):
 
     def get_queryset(self, request):
         language_code = self.get_queryset_language(request)
-        return super().get_queryset(request).translated(language_code)
+        return super().get_queryset(request).translated(language_code, "fi")
 
 
 class AvailabilityLevelAdmin(TranslatableAdmin):


### PR DESCRIPTION
## Description :sparkles:
* Add more details to Application list and detail
* Add WinterStorage and Order details to customer view
* Add a default prefetch language for WSAreas (fixes VEN-660)
* Add details to lease admin
* Add a base CHANGELOG 

## Issues :bug:
### Closes :no_good_woman:
**[VEN-875](https://helsinkisolutionoffice.atlassian.net/browse/VEN-875)** 
**[VEN-660](https://helsinkisolutionoffice.atlassian.net/browse/VEN-660):** 

## Testing :alembic:
### Manual testing :construction_worker_man:
* Go through the Application (list and detail), Leases (list and detail), and Customer (detail) pages, you should see more items on the tables
* Go to `resources/winterstoragearea/`, it should show 14 items

## Screenshots :camera_flash:
Winter storage areas (resources) now shows the full list
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15201480/96142475-ce4a5680-0f0a-11eb-9bf6-7b7e60714112.png">

Berth applications
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15201480/96142434-c094d100-0f0a-11eb-838e-adce0d33e539.png">

Winter Storage applications
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15201480/96142399-b672d280-0f0a-11eb-8473-2afb8bf82f33.png">

Winter Storage leases
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15201480/96142219-862b3400-0f0a-11eb-8fbd-1dba55398e7e.png">
