### PR TITLE
VEN-883 | Check if the order is for an unmarked place

### DIFF
--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -4,6 +4,7 @@ from django_ilmoitin.models import NotificationTemplate
 from factory.random import randgen
 from requests import RequestException
 
+from applications.enums import ApplicationAreaType
 from applications.tests.factories import (
     BerthApplicationFactory,
     WinterStorageApplicationFactory,
@@ -82,6 +83,17 @@ def _generate_order(order_type: str = None):
             product=WinterStorageProductFactory(),
             lease=WinterStorageLeaseFactory(
                 application=WinterStorageApplicationFactory(), customer=customer_profile
+            ),
+        )
+    elif order_type == "unmarked_winter_storage_order":
+        order = OrderFactory(
+            customer=customer_profile,
+            product=WinterStorageProductFactory(),
+            lease=WinterStorageLeaseFactory(
+                application=WinterStorageApplicationFactory(
+                    area_type=ApplicationAreaType.UNMARKED
+                ),
+                customer=customer_profile,
             ),
         )
     elif order_type == "empty_order":


### PR DESCRIPTION
## Description :sparkles:
* Raise an error when an unmarked ws place order is being cancelled

## Issues :bug:
### Closes :no_good_woman:
**[VEN-883](https://helsinkisolutionoffice.atlassian.net/browse/VEN-883)** 

### Related :handshake:
#326 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_mutations.py::test_cancel_unmarked_order_fails
```