### PR TITLE
VEN-914 | Add reject berth application mutation

### DIFF
--- a/applications/constants.py
+++ b/applications/constants.py
@@ -1,2 +1,3 @@
 MARKED_WS_SENDER = "CreateMarkedWinterStorageApplication"
 UNMARKED_WS_SENDER = "CreateUnmarkedWinterStorageApplication"
+REJECT_BERTH_SENDER = "RejectBerthApplication"

--- a/applications/models.py
+++ b/applications/models.py
@@ -229,6 +229,7 @@ class BerthApplication(BaseApplication):
         allowed_statuses_without_lease = [
             ApplicationStatus.PENDING,
             ApplicationStatus.EXPIRED,
+            ApplicationStatus.NO_SUITABLE_BERTHS,
         ]
 
         if (

--- a/applications/notifications.py
+++ b/applications/notifications.py
@@ -18,6 +18,10 @@ class NotificationType(TextChoices):
         "berth_application_created",
         _("Berth application created"),
     )
+    BERTH_APPLICATION_REJECTED = (
+        "berth_application_rejected",
+        _("Berth application rejected"),
+    )
     WINTER_STORAGE_APPLICATION_CREATED = (
         "winter_storage_application_created",
         _("Winter storage application created"),
@@ -31,6 +35,10 @@ class NotificationType(TextChoices):
 notifications.register(
     NotificationType.BERTH_APPLICATION_CREATED.value,
     NotificationType.BERTH_APPLICATION_CREATED.label,
+)
+notifications.register(
+    NotificationType.BERTH_APPLICATION_REJECTED.value,
+    NotificationType.BERTH_APPLICATION_REJECTED.label,
 )
 notifications.register(
     NotificationType.WINTER_STORAGE_APPLICATION_CREATED.value,
@@ -52,6 +60,10 @@ dummy_context.update(
     {
         COMMON_CONTEXT: {"created_at": localize_datetime(timezone.now())},
         NotificationType.BERTH_APPLICATION_CREATED: {
+            "application": berth_application,
+            "harbor_choices": sorted(harbor_choices, key=lambda c: c.priority),
+        },
+        NotificationType.BERTH_APPLICATION_REJECTED: {
             "application": berth_application,
             "harbor_choices": sorted(harbor_choices, key=lambda c: c.priority),
         },

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -4,10 +4,11 @@ from django.dispatch import Signal
 from django_ilmoitin.utils import send_notification
 from sentry_sdk import capture_exception
 
-from .constants import MARKED_WS_SENDER, UNMARKED_WS_SENDER
+from .constants import MARKED_WS_SENDER, REJECT_BERTH_SENDER, UNMARKED_WS_SENDER
 from .notifications import NotificationType
 
 application_saved = Signal(providing_args=["application"])
+application_rejected = Signal(providing_args=["application"])
 
 
 def application_notification_handler(sender, application, **kwargs):
@@ -18,6 +19,8 @@ def application_notification_handler(sender, application, **kwargs):
         notification_type = (
             NotificationType.UNMARKED_WINTER_STORAGE_APPLICATION_CREATED.value
         )
+    elif sender == REJECT_BERTH_SENDER:
+        notification_type = NotificationType.BERTH_APPLICATION_REJECTED.value
 
     try:
         send_notification(
@@ -33,4 +36,7 @@ def application_notification_handler(sender, application, **kwargs):
 if settings.NOTIFICATIONS_ENABLED:
     application_saved.connect(
         application_notification_handler, dispatch_uid="application_saved"
+    )
+    application_rejected.connect(
+        application_notification_handler, dispatch_uid="application_rejected"
     )


### PR DESCRIPTION
## Description :sparkles:
- Add reject berth application mutation
- Send application rejected email on mutation

## Issues :bug:
### Closes :no_good_woman:
**[VEN-914](https://helsinkisolutionoffice.atlassian.net/browse/VEN-914)** 

### Related :handshake:

## Testing :alembic:

```
mutation {
  rejectBerthApplication(input: {id: "QmVydGhBcHBsaWNhdGlvbk5vZGU6Mg=="}) {
    __typename
  }
}
```
### Automated tests :gear:️
Two new test cases in `applications/tests/test_applications_new_schema_mutations.py`
One new test case in `applications/tests/test_applications_notifications.py`

### Manual testing :construction_worker_man:

