### PR TITLE
Add postgresql-client to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-install.sh \
       build-essential \
       netcat \
       pkg-config \
+      postgresql-client \
     && pip install --no-cache-dir \
       -r /app/requirements.txt \
     && apt-cleanup.sh \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,8 @@
-FROM postgres:9.6
+FROM postgres:11
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        postgis postgresql-9.6-postgis-2.4 postgresql-9.6-postgis-2.4-scripts
+        postgis postgresql-11-postgis-2.5 postgresql-11-postgis-2.5-scripts
 
 RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 


### PR DESCRIPTION
Add postgresql-client to docker image, needed for the staging and prod db migrations. Also upgrade local postgres docker to use the same version as in prod.

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
