### PR TITLE
VEN-699 | Check that leases don't last for over a year

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -61,6 +62,10 @@ class AbstractLease(TimeStampedModel, UUIDModel):
             )
         if self.start_date > self.end_date:
             raise ValidationError(_("Lease start date cannot be after end date"))
+
+        # Check that the lease ends less than a year after it started
+        if self.end_date > (self.start_date + relativedelta(years=1)):
+            raise ValidationError(_("Lease cannot last for more than a year"))
 
     def save(self, *args, **kwargs):
         # ensure full_clean is always ran

--- a/leases/tests/test_lease_models.py
+++ b/leases/tests/test_lease_models.py
@@ -482,3 +482,19 @@ def test_berth_lease_non_overlapping_leases(berth):
     BerthLeaseFactory(berth=berth, start_date="2020-01-01", end_date="2020-05-01")
 
     assert BerthLease.objects.count() == 2
+
+
+@freeze_time("2020-01-01T08:00:00Z")
+def test_winter_storage_lease_over_a_year_raise_error():
+    with pytest.raises(ValidationError) as exception:
+        WinterStorageLeaseFactory(start_date="2020-01-01", end_date="2022-01-21")
+
+    error_msg = str(exception.value)
+    assert "Lease cannot last for more than a year" in error_msg
+
+
+@freeze_time("2020-01-01T08:00:00Z")
+def test_winter_storage_lease_one_year_no_error():
+    WinterStorageLeaseFactory(start_date="2020-01-01", end_date="2021-01-01")
+
+    assert WinterStorageLease.objects.count() == 1

--- a/payments/migrations/0012_add_storage_on_ice_product.py
+++ b/payments/migrations/0012_add_storage_on_ice_product.py
@@ -2,6 +2,8 @@
 
 from django.db import migrations, models
 
+import payments
+
 
 class Migration(migrations.Migration):
 
@@ -32,6 +34,29 @@ class Migration(migrations.Migration):
                 ],
                 max_length=40,
                 verbose_name="service",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="additionalproduct", name="optional_services_per_period",
+        ),
+        migrations.AddConstraint(
+            model_name="additionalproduct",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    service__in=[
+                        payments.enums.ProductServiceType(
+                            "summer_storage_for_docking_equipment"
+                        ),
+                        payments.enums.ProductServiceType(
+                            "summer_storage_for_trailers"
+                        ),
+                        payments.enums.ProductServiceType("storage_on_ice"),
+                        payments.enums.ProductServiceType("parking_permit"),
+                        payments.enums.ProductServiceType("dinghy_place"),
+                    ]
+                ),
+                fields=("service", "period"),
+                name="optional_services_per_period",
             ),
         ),
     ]

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -93,10 +93,9 @@ def test_additional_product_product_type_optional():
     assert product.product_type == AdditionalProductType.OPTIONAL_SERVICE
 
 
-def test_additional_product_one_service_per_period():
-    service = random.choice(ProductServiceType.OPTIONAL_SERVICES())
-    period = random.choice(list(PeriodType))
-
+@pytest.mark.parametrize("service", ProductServiceType.OPTIONAL_SERVICES())
+@pytest.mark.parametrize("period", PeriodType.values)
+def test_additional_product_one_service_per_period(service, period):
     product = AdditionalProductFactory(service=service, period=period)
 
     with pytest.raises(IntegrityError) as exception:


### PR DESCRIPTION
## Description :sparkles:
* Check that leases don't last for over a year

## Issues :bug:
### Closes :no_good_woman:
**[VEN-699](https://helsinkisolutionoffice.atlassian.net/browse/VEN-699):** Restrict Leases duration to one year

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_models.py::test_winter_storage_lease_over_a_year_raise_error
$ pytest leases/tests/test_lease_models.py::test_winter_storage_lease_one_year_no_error
```

### Manual testing :construction_worker_man:
1. Go to the GraphQL API
2. Try to create a lease
3. The API should return a message error: `Lease cannot last for more than a year`
```graphql
mutation CreateWinterStorageLease($input: CreateWinterStorageLeaseMutationInput!) {
  createWinterStorageLease(input: $input) {
    winterStorageLease {
      id
      startDate
      endDate
    }
  }
}
```
```json
{
  "input": {
    "applicationId": "",
    "sectionId": "V2ludGVyU3RvcmFnZVNlY3Rpb25Ob2RlOjQ2NTAxY2Q3LWU3MzAtNGZhZi05YTc5LWFjOTEzOGQ0MWFiYg==",
    "startDate": "2020-12-01",
    "endDate": "2022-12-02"
  }
}
```

## Additional notes :spiral_notepad:
At the moment, BerthLeases are not allowed to end on a different year,
so they don't rely on this check, but WinterStorageLeases do.