### PR TITLE
Update docker-compose.yml to use correct target for django service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     django:
         build:
             context: ./
+            target: development
         env_file:
             - ./.env
         environment:


### PR DESCRIPTION
Without this target, dev requirements will not be installed due to changes in the Dockerfile.