### PR TITLE
Cleanup after migration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
 # These variables are available for all stages
 variables:
   APP_MIGRATE_COMMAND: /app/.prod/on_deploy.sh
-  APP_INITIALIZE_COMMAND: /app/.prod/on_initialize.sh
+  #APP_INITIALIZE_COMMAND: /app/.prod/on_initialize.sh
   SERVICE_PORT: "8000"
 
 # Build stage must be included and it must extend .build.

--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -2,5 +2,4 @@
 # Runs migration scripts on each deployment
 python /app/manage.py migrate --noinput
 
-# This can be removed once executed
-python /app/manage.py assign_ws_lease_stickers
+# Admin commands that need to be ran for each env can be added here

--- a/.prod/on_initialize.sh
+++ b/.prod/on_initialize.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Runs database initialization scripts on first install only
+# Runs database initialization scripts on first install only, disabled for now as staging and prod are already seeded
 python /app/manage.py migrate --noinput
 python /app/manage.py geo_import finland --municipalities
 python /app/manage.py geo_import helsinki --divisions

--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,7 +9,13 @@ buffer-size = 32768
 master = 1
 processes = 2
 threads = 2
+# Use nginx log format
 log-format = %(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"
+# do not request log these paths
 route = /healthz donotlog:
 route = /readiness donotlog:
 route = /static donotlog:
+# Supress errors about clients closing sockets, happens with nginx as the ingress
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-install.sh \
       build-essential \
       netcat \
       pkg-config \
-      postgresql-client \
     && pip install --no-cache-dir \
       -r /app/requirements.txt \
     && apt-cleanup.sh \
@@ -43,7 +42,8 @@ FROM appbase as development
 # Install additional dependencies.
 COPY --chown=appuser:appuser requirements-dev.txt /app/requirements-dev.txt
 RUN pip install --no-cache-dir  -r /app/requirements-dev.txt \
-  && pip install --no-cache-dir prequ
+  && pip install --no-cache-dir prequ \
+  && apt-install.sh postgresql-client
 
 # Set environment variables for development.
 ENV DEV_SERVER=1


### PR DESCRIPTION
## Description :sparkles:
Cleanup leftovers from the migration work:
* Reduce uwsgi log spam by ignoring errors about clients dropping connections
* Remove postgres-cmd-line tools from prod image
* Remove sticker assignment management command
* Disable db initialization fixture as it does not work properly, and staging and prod already have data in the db.

