### PR TITLE
Lazy load apps in uwsgi to avoid ssl errors in db connections

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -19,3 +19,6 @@ route = /static donotlog:
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+# Load apps in worker threads, otherwise we get ssl errors from initial db connections
+lazy = true
+lazy-apps = true


### PR DESCRIPTION
## Description :sparkles:

When the container started up, we got SSL errors from db queries, due to the context being forked to multiple uwsgi worker threads. Lazy-load the apps in each worker to avoid this.

## Testing :alembic:
### Manual testing :construction_worker_man:
* Deploy app to staging with this fix included
* Make multiple api calls to it right after deployment is completed
* Check that no errors like this are on the logs:
`psycopg2.OperationalError: SSL error: decryption failed or bad record mac`
`psycopg2.OperationalError: SSL SYSCALL error: EOF detected `

