### PR TITLE
VEN-843 | Profile token

### DIFF
--- a/customers/tests/test_profile_service.py
+++ b/customers/tests/test_profile_service.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from uuid import uuid4
 
-from django.test import RequestFactory
 from faker import Faker
 
 from customers.schema import ProfileNode
@@ -10,26 +9,13 @@ from utils.relay import to_global_id
 
 from .conftest import mocked_response_profile
 
-PROFILE_TOKEN_SERVICE = "http://fake-profile-api.com"
-
-
-def test_get_city_profile_token():
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
-    service = ProfileService(r)
-    assert service.profile_token == "token"
-
 
 def test_get_all_profiles():
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     with mock.patch(
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=5),
     ):
-        profiles = ProfileService(r).get_all_profiles()
+        profiles = ProfileService(profile_token="token").get_all_profiles()
 
     assert len(profiles.keys()) == 5
     for id, user_profile in profiles.items():
@@ -40,9 +26,6 @@ def test_get_all_profiles():
 
 
 def test_get_profile(customer_profile, user, hki_profile_address):
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     with mock.patch(
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(
@@ -57,7 +40,7 @@ def test_get_profile(customer_profile, user, hki_profile_address):
             use_edges=False,
         ),
     ):
-        profile = ProfileService(r).get_profile(customer_profile.id)
+        profile = ProfileService(profile_token="token").get_profile(customer_profile.id)
 
     assert profile.id == customer_profile.id
     assert profile.first_name == user.first_name
@@ -70,9 +53,6 @@ def test_get_profile(customer_profile, user, hki_profile_address):
 
 def test_parse_user_edge(hki_profile_address):
     faker = Faker()
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
 
     user_id = uuid4()
     email = faker.email()
@@ -86,7 +66,7 @@ def test_parse_user_edge(hki_profile_address):
         }
     }
 
-    user = ProfileService(r).parse_user_edge(edge)
+    user = ProfileService(profile_token="token").parse_user_edge(edge)
     assert user.id == user_id
     assert user.first_name == edge.get("node").get("first_name")
     assert user.last_name == edge.get("node").get("last_name")

--- a/leases/schema/mutations.py
+++ b/leases/schema/mutations.py
@@ -422,19 +422,23 @@ class SendExistingInvoicesInput:
 
 class SendExistingBerthInvoicesMutation(graphene.ClientIDMutation):
     class Input(SendExistingInvoicesInput):
-        pass
+        profile_token = graphene.String(
+            required=True, description="API token for Helsinki profile GraphQL API",
+        )
 
     result = graphene.Field(SendExistingInvoicesType)
 
     @classmethod
     @view_permission_required(CustomerProfile)
     @change_permission_required(BerthLease, WinterStorageLease, Order)
-    def mutate_and_get_payload(cls, root, info, **input):
+    def mutate_and_get_payload(cls, root, info, profile_token, **input):
         from payments.schema import OrderNode
 
         try:
             result = BerthInvoicingService(
-                request=info.context, due_date=input.get("due_date")
+                request=info.context,
+                profile_token=profile_token,
+                due_date=input.get("due_date"),
             ).send_invoices()
         except AutomaticInvoicingError as e:
             raise VenepaikkaGraphQLError(e)

--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -38,10 +38,12 @@ class BaseInvoicingService:
     due_date: date
 
     request: HttpRequest
+    profile_token: str
 
-    def __init__(self, request: HttpRequest, due_date: date = None):
+    def __init__(self, request: HttpRequest, profile_token: str, due_date: date = None):
         # Default the due date to 14 days from the date when the task is executed
         self.request = request
+        self.profile_token = profile_token
         self.due_date = due_date or (today() + relativedelta(days=14)).date()
 
     @staticmethod
@@ -131,7 +133,7 @@ class BaseInvoicingService:
         leases = self.get_valid_leases(self.season_start)
 
         # Fetch all the profiles from the Profile service
-        profiles = ProfileService(self.request).get_all_profiles()
+        profiles = ProfileService(self.profile_token).get_all_profiles()
 
         for lease in leases:
             order = None

--- a/leases/tests/test_lease_mutations_send_invoices.py
+++ b/leases/tests/test_lease_mutations_send_invoices.py
@@ -59,11 +59,6 @@ def test_send_berth_invoices_success(api_client, notification_template_orders_ap
 
     user = UserFactory()
 
-    # Add the tokens to the headers
-    api_client.execute_options["context"].META[
-        "HTTP_API_TOKENS"
-    ] = f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -73,13 +68,13 @@ def test_send_berth_invoices_success(api_client, notification_template_orders_ap
 
     assert Order.objects.count() == 0
 
-    variables = {"dueDate": "2020-01-31"}
+    variables = {"dueDate": "2020-01-31", "profileToken": "token"}
 
     with mock.patch(
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        executed = api_client.execute(SEND_EXISTING_INVOICES_MUTATION, input=variables,)
+        executed = api_client.execute(SEND_EXISTING_INVOICES_MUTATION, input=variables)
 
     result = executed["data"]["sendExistingBerthInvoices"]["result"]
     assert len(result.get("successful_orders")) == 1
@@ -97,9 +92,9 @@ def test_send_berth_invoices_success(api_client, notification_template_orders_ap
 def test_send_berth_invoices_not_enough_permissions(
     api_client, berth_application, berth
 ):
-    variables = {"dueDate": "2020-01-31"}
+    variables = {"dueDate": "2020-01-31", "profileToken": "token"}
 
-    executed = api_client.execute(SEND_EXISTING_INVOICES_MUTATION, input=variables,)
+    executed = api_client.execute(SEND_EXISTING_INVOICES_MUTATION, input=variables)
 
     assert_not_enough_permissions(executed)
 
@@ -123,11 +118,6 @@ def test_send_berth_invoices_missing_email(
 
     user = UserFactory()
 
-    # Add the tokens to the headers
-    superuser_api_client.execute_options["context"].META[
-        "HTTP_API_TOKENS"
-    ] = f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -137,7 +127,7 @@ def test_send_berth_invoices_missing_email(
 
     assert Order.objects.count() == 0
 
-    variables = {"dueDate": "2020-01-31"}
+    variables = {"dueDate": "2020-01-31", "profileToken": "token"}
 
     with mock.patch(
         "customers.services.profile.requests.post",
@@ -172,11 +162,6 @@ def test_send_berth_invoices_failed_lease(
 
     user = UserFactory()
 
-    # Add the tokens to the headers
-    superuser_api_client.execute_options["context"].META[
-        "HTTP_API_TOKENS"
-    ] = f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -186,7 +171,7 @@ def test_send_berth_invoices_failed_lease(
 
     assert Order.objects.count() == 0
 
-    variables = {"dueDate": "2020-01-31"}
+    variables = {"dueDate": "2020-01-31", "profileToken": "token"}
 
     with mock.patch(
         "customers.services.profile.requests.post",

--- a/leases/tests/test_send_berth_invoice_service.py
+++ b/leases/tests/test_send_berth_invoice_service.py
@@ -45,9 +45,6 @@ def test_send_berth_invoices(notification_template_orders_approved):
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -61,7 +58,9 @@ def test_send_berth_invoices(notification_template_orders_approved):
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -121,9 +120,6 @@ def test_use_berth_leases_from_last_season(notification_template_orders_approved
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -137,7 +133,9 @@ def test_use_berth_leases_from_last_season(notification_template_orders_approved
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -197,9 +195,6 @@ def test_use_berth_leases_from_current_season(notification_template_orders_appro
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -213,7 +208,9 @@ def test_use_berth_leases_from_current_season(notification_template_orders_appro
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -264,9 +261,6 @@ def test_berth_lease_harbor_product(notification_template_orders_approved):
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -280,7 +274,9 @@ def test_berth_lease_harbor_product(notification_template_orders_approved):
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -313,9 +309,6 @@ def test_berth_lease_default_product(notification_template_orders_approved):
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -329,7 +322,9 @@ def test_berth_lease_default_product(notification_template_orders_approved):
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -358,9 +353,6 @@ def test_berth_lease_no_product():
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -374,7 +366,9 @@ def test_berth_lease_no_product():
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -408,9 +402,6 @@ def test_send_berth_invoices_missing_email(notification_template_orders_approved
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -424,7 +415,9 @@ def test_send_berth_invoices_missing_email(notification_template_orders_approved
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -472,9 +465,6 @@ def test_send_berth_invoices_invalid_example_email(
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -488,7 +478,9 @@ def test_send_berth_invoices_invalid_example_email(
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -534,9 +526,6 @@ def test_send_berth_invoices_send_error(notification_template_orders_approved):
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -554,7 +543,9 @@ def test_send_berth_invoices_send_error(notification_template_orders_approved):
             "payments.utils.send_notification",
             side_effect=AnymailError("Anymail error"),
         ):
-            result = BerthInvoicingService(request=r).send_invoices()
+            result = BerthInvoicingService(
+                request=RequestFactory().request(), profile_token="token"
+            ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -625,9 +616,6 @@ def test_send_berth_invoices_only_not_renewed(notification_template_orders_appro
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -641,7 +629,9 @@ def test_send_berth_invoices_only_not_renewed(notification_template_orders_appro
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=0, data=data),
     ):
-        result = BerthInvoicingService(request=r).send_invoices()
+        result = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        ).send_invoices()
 
     successful_orders: List[UUID] = result.get("successful_orders")
     failed_orders: List[Dict[UUID, str]] = result.get("failed_orders")
@@ -699,9 +689,6 @@ def test_send_berth_invoices_invalid_limit_reached(
 
     user = UserFactory()
 
-    r = RequestFactory().request(
-        HTTP_API_TOKENS=f'{{"{PROFILE_TOKEN_SERVICE}": "token"}}'
-    )
     data = {
         "id": to_global_id(ProfileNode, customer.id),
         "first_name": user.first_name,
@@ -715,7 +702,9 @@ def test_send_berth_invoices_invalid_limit_reached(
         "customers.services.profile.requests.post",
         side_effect=mocked_response_profile(count=1, data=data),
     ), pytest.raises(AutomaticInvoicingError) as exception:
-        service = BerthInvoicingService(request=r)
+        service = BerthInvoicingService(
+            request=RequestFactory().request(), profile_token="token"
+        )
         service.MAXIMUM_FAILURES = 1
         service.send_invoices()
 


### PR DESCRIPTION
## Description :sparkles:
* Since Federation strips the profile token before it reaches our backend, we need to receive it as an input for the mutations that require it.
  * The same way [Youth Membership](https://github.com/City-of-Helsinki/youth-membership/blob/develop/youths/schema/mutations.py#L187-L189) does it

## Issues :bug:
### Related :handshake:
**[VEN-843](https://helsinkisolutionoffice.atlassian.net/browse/VEN-843)**: Send invoice for existing berth leases 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest customers/tests/test_profile_service.py
$ pytest leases/tests/test_lease_mutations_send_invoices.py
$ pytest leases/tests/test_send_berth_invoice_service.py
```