### PR TITLE
VEN-981, VEN-994 | Email template tweaks

### DIFF
--- a/templates/email/messages/additional_service_invoice_fi.html
+++ b/templates/email/messages/additional_service_invoice_fi.html
@@ -32,7 +32,7 @@
     </tr>
     {% for order_line in optional_services %}
         <tr>
-            <td colspan="2">{{ order_line.product.get_service_display() }}:</td>
+            <td>{{ order_line.product.get_service_display() }}:</td>
             <td>{{ order_line.price }}&euro;</td>
         </tr>
     {% endfor %}

--- a/templates/email/messages/additional_service_invoice_fi.html
+++ b/templates/email/messages/additional_service_invoice_fi.html
@@ -1,5 +1,6 @@
 <p>Hyvä asiakas, tässä lasku lisäpalvelusta. Voit maksaa sen klikkaamalla "siirry maksamaan" -painiketta alempana tässä
     viestissä.</p>
+<br/>
 
 <h3>Lasku</h3>
 
@@ -9,9 +10,6 @@
             Sopimus
         </td>
         <td>{{ contract.type }}</td>
-    </tr>
-    <tr>
-        <td colspan="2">&nbsp;</td>
     </tr>
     <tr>
         <td>
@@ -27,15 +25,45 @@
     </tr>
     <tr>
         <td colspan="2">
+           &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">
             <hr/>
         </td>
     </tr>
-    {% for order_line in optional_services %}
-        <tr>
-            <td>{{ order_line.product.get_service_display() }}:</td>
-            <td>{{ order_line.price }}&euro;</td>
-        </tr>
-    {% endfor %}
+    <tr>
+        <td colspan="2">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td>
+            Laskun aihe:
+        </td>
+        <td>{{ order.product.get_service_display() }}</td>
+    </tr>
+    <tr>
+        <td>
+            Sopimuskausi:
+        </td>
+        <td>{{ contract.from }} - {{ contract.to }}</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            &nbsp;
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <hr/>
+        </td>
+    </tr>
+    <tr>
+        <td>{{ order.product.get_service_display() }} yhteensä:</td>
+        <td>{{ order.price }}&euro;</td>
+    </tr>
     <tr>
         <td>
             YHTEENSÄ:

--- a/templates/email/messages/berth_none_offered_fi.html
+++ b/templates/email/messages/berth_none_offered_fi.html
@@ -4,7 +4,7 @@
 
 {% for choice in harbor_choices %}
     <b>{{ choice.harbor.name }}</b>
-    <p>{{ choice.harbor.address }}</p>
+    <p>{{ choice.harbor.street_address }}</p>
 {% endfor %}
 
 <p>Kysymykset ja lisätiedot: <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a></p>


### PR DESCRIPTION
## Description :sparkles:

* Adjust colspan in `additional_service_invoice`
* Make `additional_service_invoice` correspond to the design
* Fix `berth_none_offered` address

## Issues :bug:
### Closes :no_good_woman:
**[VEN-981](https://helsinkisolutionoffice.atlassian.net/browse/VEN-981):** Create email template for additional service invoice
**[VEN-994](https://helsinkisolutionoffice.atlassian.net/browse/VEN-994):** Email template for "no berth to assign" case
