### PR TITLE
VEN-843 | Preview invoice query

### DIFF
--- a/leases/schema/queries.py
+++ b/leases/schema/queries.py
@@ -7,7 +7,12 @@ from customers.models import CustomerProfile
 from users.decorators import view_permission_required
 
 from ..models import BerthLease, WinterStorageLease
-from .types import BerthLeaseNode, LeaseStatusEnum, WinterStorageLeaseNode
+from .types import (
+    BerthLeaseNode,
+    LeaseStatusEnum,
+    SendExistingInvoicesPreviewType,
+    WinterStorageLeaseNode,
+)
 
 
 class AbstractLeaseNodeFilter(django_filters.FilterSet):
@@ -33,6 +38,8 @@ class Query:
         filterset_class=AbstractLeaseNodeFilter,
         description="`WinterStorageLeases` are ordered by `createdAt` in ascending order by default.",
     )
+
+    send_berth_invoice_preview = graphene.Field(SendExistingInvoicesPreviewType)
 
     @view_permission_required(BerthLease, BerthApplication, CustomerProfile)
     def resolve_berth_leases(self, info, statuses=None, start_year=None, **kwargs):
@@ -69,3 +76,8 @@ class Query:
             .prefetch_related("application__customer__boats")
             .order_by("created_at")
         )
+
+    @view_permission_required(BerthLease)
+    def resolve_send_berth_invoice_preview(self, info, **kwargs):
+        count = BerthLease.objects.get_renewable_leases().count()
+        return SendExistingInvoicesPreviewType(expected_leases=count)

--- a/leases/schema/types.py
+++ b/leases/schema/types.py
@@ -90,3 +90,7 @@ class SendExistingInvoicesType(graphene.ObjectType):
     successful_orders = graphene.List(graphene.ID)
     failed_orders = graphene.List(FailedInstanceType)
     failed_leases = graphene.List(FailedInstanceType)
+
+
+class SendExistingInvoicesPreviewType(graphene.ObjectType):
+    expected_leases = graphene.Int(required=True)


### PR DESCRIPTION
## Description :sparkles:
* Add a preview query for invoicing to show expected leases

## Issues :bug:
### Related :handshake:
**[VEN-843](https://helsinkisolutionoffice.atlassian.net/browse/VEN-843):** Send invoice for existing berth leases

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_queries.py::test_query_send_berth_invoice_preview
```

### Manual testing :construction_worker_man:
```graphql
query SendBerthInvoicePreview {
    sendBerthInvoicePreview {
        expectedLeases
    }
}
```
