### PR TITLE
VEN-1016 | Integrate additional invoice email template

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -942,6 +942,9 @@ msgstr "Talvisäilytyspaikkalasku"
 msgid "Unmarked winter storage order approved"
 msgstr "Nostojärjestyspaikkalasku"
 
+msgid "Additional product order approved"
+msgstr "Lisäpalvelulasku"
+
 msgid "Payment service is unreachable"
 msgstr "Maksupalvelu ei ole käytettävissä"
 

--- a/payments/notifications/dummy_context.py
+++ b/payments/notifications/dummy_context.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import Dict, List
 
+from dateutil.utils import today
 from django.conf import settings
 from django_ilmoitin.dummy_context import dummy_context
 
@@ -118,23 +119,20 @@ def _get_winter_storage_order_context(subject: str = "Winter storage order"):
 
 
 def _get_additional_product_order_context(subject: str = "Additional product order"):
-    customer = CustomerProfileFactory.build()
-    order = OrderFactory.build(
-        customer=customer,
-        lease=BerthLeaseFactory.build(customer=customer),
-        product=None,
-        price=Decimal("0.00"),
-        tax_percentage=Decimal("0.00"),
-    )
-    optional_services = [
-        OrderLineFactory.build(
-            order=order,
-            product__service=ProductServiceType.OPTIONAL_SERVICES()[0],
-            price=random_price(),
-        ),
-    ]
-
-    return _get_order_context(subject, order, [], optional_services)
+    return {
+        "subject": subject,
+        "order": {
+            "lease": {
+                "start_date": today().date(),
+                "end_date": today().date(),
+                "berth": {"pier": {"harbor": {"name": "Satama"}}},
+            },
+            "total_price": Decimal("100.00"),
+        },
+        "additional_product": {"name": "Product name", "season": "2020 - 2021"},
+        "payment_url": "http://foo.com",
+        "due_date": today().date(),
+    }
 
 
 def load_dummy_context():

--- a/payments/tests/test_payments_mutations_approve_ap_order.py
+++ b/payments/tests/test_payments_mutations_approve_ap_order.py
@@ -29,7 +29,7 @@ mutation APPROVE_ORDER_MUTATION($input: ApproveOrderMutationInput!) {
     "api_client", ["berth_services"], indirect=True,
 )
 @pytest.mark.parametrize(
-    "order", ["additional_product_order"], indirect=True,
+    "order", ["additional_product_order_with_lease_order"], indirect=True,
 )
 @freeze_time("2020-01-01T08:00:00Z")
 def test_approve_ap_order(

--- a/scripts/load_notification_templates.py
+++ b/scripts/load_notification_templates.py
@@ -78,6 +78,10 @@ if __name__ == "__main__":
             "html": "um_ws_invoice_{lang}.html",
             "plain": None,
         },
+        PaymentNotificationType.ADDITIONAL_PRODUCT_ORDER_APPROVED: {
+            "html": "additional_service_invoice_{lang}.html",
+            "plain": None,
+        },
     }
 
     from scripts.generate_email_templates import generate_templates

--- a/templates/email/messages/additional_service_invoice_fi.html
+++ b/templates/email/messages/additional_service_invoice_fi.html
@@ -9,19 +9,19 @@
         <td>
             Sopimus
         </td>
-        <td>{{ contract.type }}</td>
+        <td>Venepaikka</td>
     </tr>
     <tr>
         <td>
             Venepaikka:
         </td>
-        <td>{{ contract.berth }}</td>
+        <td>{{ order.lease.berth.pier.harbor.name }}</td>
     </tr>
     <tr>
         <td>
             Sopimuskausi:
         </td>
-        <td>{{ contract.from }} - {{ contract.to }}</td>
+        <td>{{ order.lease.start_date }} - {{ order.lease.end_date }}</td>
     </tr>
     <tr>
         <td colspan="2">
@@ -42,13 +42,13 @@
         <td>
             Laskun aihe:
         </td>
-        <td>{{ order.product.get_service_display() }}</td>
+        <td>{{ additional_product.name }}</td>
     </tr>
     <tr>
         <td>
             Sopimuskausi:
         </td>
-        <td>{{ contract.from }} - {{ contract.to }}</td>
+        <td>Talvi {{ additional_product.season }}</td>
     </tr>
     <tr>
         <td colspan="2">
@@ -61,14 +61,14 @@
         </td>
     </tr>
     <tr>
-        <td>{{ order.product.get_service_display() }} yhteensä:</td>
-        <td>{{ order.price }}&euro;</td>
+        <td>{{ additional_product.name }} yhteensä:</td>
+        <td>{{ order.total_price }}&euro;</td>
     </tr>
     <tr>
         <td>
             YHTEENSÄ:
         </td>
-        <td>{{ order.total }} / vuosi
+        <td>{{ order.total_price }}&euro;
         </td>
     </tr>
 </table>


### PR DESCRIPTION
## Description :sparkles:
- Take additional invoice email template into use (only FI)

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1016](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1016)** 

### Related :handshake:

## Testing :alembic:

### Manual testing :construction_worker_man:
- generate and load email templates
- go to http://localhost:8000/admin/django_ilmoitin/notificationtemplate/
- Select "Additional product order approved" and hit "Preview"
- You should see the template in action
