### PR TITLE
VEN-843 | Set the correct lease status on creation

### DIFF
--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -73,6 +73,9 @@ class BaseInvoicingService:
         lease.start_date = start_date
         lease.end_date = end_date
 
+        # Set correct status
+        lease.status = LeaseStatus.DRAFTED
+
         # If the previous lease has an application attached,
         # it will fail since it is a OneToOne field
         lease.application = None


### PR DESCRIPTION
## Description :sparkles:
When creating the lease, we are just copying the previous one which will
be on paid status. For proper bookkeeping, we should set it as drafted
to follow the correct flow from drafted -> offered/error -> paid/rejected.

The lease would in any case be marked as offered/error by the script,
but better to follow the right steps.

## Testing :alembic:
### Manual testing :construction_worker_man:
After running the script, check the `Lease changes` on the new lease. You should see the transition from `drafted -> offered`

## Screenshots :camera_flash:
**For example:**
<img width="523" alt="image" src="https://user-images.githubusercontent.com/15201480/101617016-c265a700-3a18-11eb-8543-18e72e7663d0.png">

**From local testing:**
<img width="571" alt="image" src="https://user-images.githubusercontent.com/15201480/101619275-ba5b3680-3a1b-11eb-8716-9f698d70f4db.png">

