### PR TITLE
VEN-1043 | Update payment application status

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.forms import ChoiceField, UUIDField
 from django.utils.translation import gettext_lazy as _
 
+from leases.models import BerthLease, WinterStorageLease
+
 from .enums import LeaseOrderType
 from .models import (
     AdditionalProduct,
@@ -70,6 +72,7 @@ class OrderAdmin(admin.ModelAdmin):
         "order_number",
         "lease_order_type",
         "order_type",
+        "place",
     )
     list_display = (
         "id",
@@ -78,7 +81,8 @@ class OrderAdmin(admin.ModelAdmin):
         "total_price",
         "status",
         "customer",
-        "lease",
+        "lease_id",
+        "place",
         "product",
         "lease_order_type",
         "order_type",
@@ -135,6 +139,17 @@ class OrderAdmin(admin.ModelAdmin):
             else None
         )
 
+    def lease_id(self, obj):
+        return obj.lease.id if obj.lease else None
+
+    def place(self, obj):
+        if obj.lease:
+            if isinstance(obj.lease, BerthLease):
+                return obj.lease.berth
+            elif isinstance(obj.lease, WinterStorageLease):
+                return obj.lease.place or obj.lease.section
+        return None
+
     pretax_price.short_description = _("Pretax price")
     pretax_price.admin_order_field = "pretax_price"
 
@@ -146,6 +161,9 @@ class OrderAdmin(admin.ModelAdmin):
 
     total_tax_percentage.short_description = _("Total order tax percentage")
     total_tax_percentage.admin_order_field = "total_tax_percentage"
+
+    place.short_description = _("Place")
+    place.admin_order_field = "place"
 
 
 class OrderTokenAdmin(admin.ModelAdmin):

--- a/payments/models.py
+++ b/payments/models.py
@@ -668,17 +668,18 @@ class Order(UUIDModel, TimeStampedModel):
         self.lease.save(update_fields=["status", "comment"])
 
         if new_status == OrderStatus.PAID:
-            application = self.lease.application
-            application.status = ApplicationStatus.HANDLED
-            self.lease.application.save(update_fields=["status"])
+            if self.lease.application:
+                application = self.lease.application
+                application.status = ApplicationStatus.HANDLED
+                self.lease.application.save(update_fields=["status"])
 
-            if (
-                isinstance(self.lease, WinterStorageLease)
-                and application.area_type == ApplicationAreaType.UNMARKED
-            ):
-                sticker_number = get_next_sticker_number(self.lease.start_date)
-                self.lease.sticker_number = sticker_number
-                self.lease.save(update_fields=["sticker_number"])
+                if (
+                    isinstance(self.lease, WinterStorageLease)
+                    and application.area_type == ApplicationAreaType.UNMARKED
+                ):
+                    sticker_number = get_next_sticker_number(self.lease.start_date)
+                    self.lease.sticker_number = sticker_number
+                    self.lease.save(update_fields=["sticker_number"])
 
 
 class OrderLine(UUIDModel, TimeStampedModel):


### PR DESCRIPTION
## Description :sparkles:
When a payment is made for a lease which doesn't have an application associated (as is the case with the Timmi leases), it will raise a 500-Server Error because it fails to set the application to handled status.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1043](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1043):** Updating applications on payment success

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_set_status_no_application
```