### PR TITLE
VEN-1050 | Add place name as product name

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -152,7 +152,7 @@ class BerthProduct(AbstractPlaceProduct, TimeStampedModel, UUIDModel):
 
     @property
     def name(self):
-        return _("Berth product") + f": {self}"
+        return _("Berth product")
 
     def price_for_tier(self, tier: PriceTier) -> Decimal:
         if tier == PriceTier.TIER_1:
@@ -182,7 +182,7 @@ class WinterStorageProduct(AbstractPlaceProduct, AbstractBaseProduct):
 
     @property
     def name(self):
-        return _("Winter Storage product") + f": {self}"
+        return _("Winter Storage product")
 
 
 class AdditionalProduct(AbstractBaseProduct):

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -166,7 +166,17 @@ class BamboraPayformProvider(PaymentProvider):
                 int_tax == product.tax_percentage
             )  # make sure the tax is a whole number
             with override(language):
-                product_name = product.name
+                lease = order.lease
+                place = (
+                    lease.berth
+                    if hasattr(lease, "berth")
+                    else lease.place
+                    if hasattr(lease, "place") and lease.place
+                    else lease.section
+                    if hasattr(lease, "section") and lease.section
+                    else area
+                )
+                product_name = f"{product.name}: {place}"
             items.append(
                 {
                     "id": get_talpa_product_id(product.id, area),


### PR DESCRIPTION
## Description :sparkles:
* Update the product name that is sent to Bambora to make it clearer for the user

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1050](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1050):** Bambora payment details contain prices for all tiers

## Screenshots :camera_flash:
**Berth product:**
![image](https://user-images.githubusercontent.com/15201480/102205760-482f9980-3ed4-11eb-98ae-29ea4f109517.png)

**Winter storage product:**
<img width="482" alt="image" src="https://user-images.githubusercontent.com/15201480/102205802-57aee280-3ed4-11eb-9803-59bd054e5afc.png">
