### PR TITLE
Add check for berth switch emails

### DIFF
--- a/templates/email/messages/berth_application_confirmation_en.html
+++ b/templates/email/messages/berth_application_confirmation_en.html
@@ -21,7 +21,7 @@
     <b>Harbor:</b> {{ application.berth_switch.harbor.name }}<br/>
     <b>Pier ID:</b> {{ application.berth_switch.pier or "-" }}<br/>
     <b>Berth number:</b> {{ application.berth_switch.berth_number }}<br/>
-    <b>Special request:</b> {{ application.berth_switch.reason.title }}<br/>
+    <b>Special request:</b> {% if application.berth_switch.reason %}{{ application.berth_switch.reason.title }}{% else %}-{% endif %}<br/>
 {% endif %}
 
 <hr/>

--- a/templates/email/messages/berth_application_confirmation_fi.html
+++ b/templates/email/messages/berth_application_confirmation_fi.html
@@ -21,7 +21,7 @@
     <b>Satama:</b> {{ application.berth_switch.harbor.name }}<br/>
     <b>Laiturin tunnus:</b> {{ application.berth_switch.pier or "-" }}<br/>
     <b>Paikan numero:</b> {{ application.berth_switch.berth_number }}<br/>
-    <b>Erityistoive:</b> {{ application.berth_switch.reason.title }}<br/>
+    <b>Erityistoive:</b> {% if application.berth_switch.reason %}{{ application.berth_switch.reason.title }}{% else %}-{% endif %}<br/>
 {% endif %}
 
 <hr/>

--- a/templates/email/messages/berth_application_confirmation_sv.html
+++ b/templates/email/messages/berth_application_confirmation_sv.html
@@ -21,7 +21,7 @@
     <b>Nuvarande hamn:</b> {{ application.berth_switch.harbor.name }}<br/>
     <b>Kajkod:</b> {{ application.berth_switch.pier or "-" }}<br/>
     <b>Nummer:</b> {{ application.berth_switch.berth_number }}<br/>
-    <b>Särskilda önskemål:</b> {{ application.berth_switch.reason.title }}<br/>
+    <b>Särskilda önskemål:</b> {% if application.berth_switch.reason %}{{ application.berth_switch.reason.title }}{% else %}-{% endif %}<br/>
 {% endif %}
 
 <hr/>


### PR DESCRIPTION
## Description :sparkles:
* Check if the `berth_switch` has a `reason` to avoid failing calling `.title` if `reason is None`

## Issues :bug:
### Closes :no_good_woman:
https://sentry.hel.ninja/aok/berth-api/issues/12382/