### PR TITLE
Fix test failure when generated berth lease start and end year are different

### DIFF
--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -696,6 +696,7 @@ def test_winter_season_price():
     assert order.price == Decimal("10.00")
 
 
+@freeze_time("2020-10-01T08:00:00Z")
 def test_berth_season_price(berth):
     start_date = today()
     end_date = start_date + relativedelta(days=15)


### PR DESCRIPTION
Tests started failing this morning when generated berth lease end occurs in 2021. Fixed by @freeze_time.

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-XXX](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
