### PR TITLE
HOTFIX | Add extra flags to contract generating script

### DIFF
--- a/contracts/management/commands/generate_missing_contracts.py
+++ b/contracts/management/commands/generate_missing_contracts.py
@@ -1,15 +1,30 @@
 from django.core.management import BaseCommand
 
 from contracts.services import get_contract_service
+from leases.enums import LeaseStatus
 from leases.models import BerthLease, WinterStorageLease
 
 
 class Command(BaseCommand):
     help = "Generate contracts for leases in status DRAFTED and OFFERED, which are missing contracts"
 
-    def handle(self, *args, **options):
-        winter_storage_leases = WinterStorageLease.objects.filter(contract=None)
-        berth_leases = BerthLease.objects.filter(contract=None)
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            nargs="?",
+            type=int,
+            help="Specify which season should the contracts be generated for",
+        )
+
+    def handle(self, *args, year=None, **options):
+        winter_storage_leases = WinterStorageLease.objects.filter(
+            contract=None, status=LeaseStatus.PAID
+        )
+        berth_leases = BerthLease.objects.filter(contract=None, status=LeaseStatus.PAID)
+
+        if year:
+            winter_storage_leases = winter_storage_leases.filter(start_date__year=year)
+            berth_leases = berth_leases.filter(start_date__year=year)
 
         failed = []
         success_count = 0


### PR DESCRIPTION
## Description :sparkles:
* Add a `status=PAID` filter to the queryset
* Add an optional `year` flag to specify which season should be generated