### PR TITLE
HOTFIX | Invoicing fixes

### DIFF
--- a/leases/notifications/dummy_context.py
+++ b/leases/notifications/dummy_context.py
@@ -10,9 +10,9 @@ def load_dummy_context():
         {
             NotificationType.AUTOMATIC_INVOICING_EMAIL_ADMINS: {
                 "subject": NotificationType.AUTOMATIC_INVOICING_EMAIL_ADMINS.label,
+                "exited_with_errors": False,
                 "successful_orders": randint(100, 500),
                 "failed_orders": randint(0, 10),
-                "failed_leases": randint(0, 10),
             }
         }
     )

--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseInvoicingService:
-    MAXIMUM_FAILURES = 50
+    MAXIMUM_FAILURES = 100
 
     ADMIN_EMAIL_NOTIFICATION_GROUP_NAME = "Berth services"
 

--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -148,13 +148,13 @@ class BaseInvoicingService:
             self.fail_lease(order.lease, _("Missing customer email"), dont_count=True)
             self.fail_order(order, _("Missing customer email"), dont_count=True)
 
-    def email_admins(self):
+    def email_admins(self, exited_with_errors: bool = False):
         logger.debug("Emailing admins")
         context = {
             "subject": LeaseNotificationType.AUTOMATIC_INVOICING_EMAIL_ADMINS.label,
+            "exited_with_errors": exited_with_errors,
             "successful_orders": len(self.successful_orders),
-            "failed_orders": len(self.failed_orders),
-            "failed_leases": len(self.failed_leases),
+            "failed_orders": len(self.failed_orders) + len(self.failed_leases),
         }
         admins = (
             get_user_model()
@@ -189,63 +189,67 @@ class BaseInvoicingService:
 
         logger.debug(f"Profiles fetched: {len(profiles)}")
 
-        for lease in leases:
-            order = None
-            if self.failure_count >= self.MAXIMUM_FAILURES:
-                error_message = _(
-                    f"Limit of failures reached: {self.failure_count} elements failed"
-                )
-                logger.error(error_message)
-                raise AutomaticInvoicingError(error_message)
+        exited_with_errors = False
+        try:
+            for lease in leases:
+                order = None
+                if self.failure_count >= self.MAXIMUM_FAILURES:
+                    error_message = _(
+                        f"Limit of failures reached: {self.failure_count} elements failed"
+                    )
+                    logger.error(error_message)
+                    raise AutomaticInvoicingError(error_message)
 
-            if lease.customer.id not in profiles:
-                self.fail_lease(
-                    lease, _("The application is not connected to a customer")
-                )
-                continue
+                if lease.customer.id not in profiles:
+                    self.fail_lease(
+                        lease, _("The application is not connected to a customer")
+                    )
+                    continue
 
-            try:
-                with transaction.atomic():
-                    try:
-                        new_lease = self.create_new_lease(
-                            lease, self.season_start, self.season_end
-                        )
-                    except (ValueError, IntegrityError) as e:
-                        logger.exception(e)
-                        self.fail_lease(lease, str(e))
-                        continue
-                    customer = new_lease.customer
+                try:
+                    with transaction.atomic():
+                        try:
+                            new_lease = self.create_new_lease(
+                                lease, self.season_start, self.season_end
+                            )
+                        except (ValueError, IntegrityError) as e:
+                            logger.exception(e)
+                            self.fail_lease(lease, str(e))
+                            continue
+                        customer = new_lease.customer
 
-                    # Get the associated product
-                    product = self.get_product(new_lease)
+                        # Get the associated product
+                        product = self.get_product(new_lease)
 
-                    # If no product is found, the billing can't be done
-                    if not product:
-                        self.fail_lease(new_lease, _("No suitable product found"))
-                        continue
+                        # If no product is found, the billing can't be done
+                        if not product:
+                            self.fail_lease(new_lease, _("No suitable product found"))
+                            continue
 
-                    try:
-                        order = Order.objects.create(
-                            customer=customer, lease=new_lease, product=product
-                        )
+                        try:
+                            order = Order.objects.create(
+                                customer=customer, lease=new_lease, product=product
+                            )
 
-                        helsinki_profile_user = profiles.get(customer.id)
-                        self.send_email(order, helsinki_profile_user)
-                    except ValidationError as e:
-                        logger.exception(e)
-                        self.fail_lease(new_lease, str(e))
-            except (IntegrityError, DataError) as e:
-                logger.exception(e)
-                lease.refresh_from_db()
-                self.fail_lease(lease, str(e))
-                if order:
-                    self.fail_order(order, str(e))
-                pass
-            # Catch any other problem that could come up to avoid breaking the task
-            except Exception as e:
-                logger.exception(e)
-
-        self.email_admins()
+                            helsinki_profile_user = profiles.get(customer.id)
+                            self.send_email(order, helsinki_profile_user)
+                        except ValidationError as e:
+                            logger.exception(e)
+                            self.fail_lease(new_lease, str(e))
+                except (IntegrityError, DataError) as e:
+                    logger.exception(e)
+                    lease.refresh_from_db()
+                    self.fail_lease(lease, str(e))
+                    if order:
+                        self.fail_order(order, str(e))
+                    pass
+                # Catch any other problem that could come up to avoid breaking the task
+                except Exception as e:
+                    logger.exception(e)
+        except AutomaticInvoicingError:
+            exited_with_errors = True
+        finally:
+            self.email_admins(exited_with_errors)
 
 
 class BerthInvoicingService(BaseInvoicingService):

--- a/templates/email/messages/automatic_invoicing_email_admins_en.html
+++ b/templates/email/messages/automatic_invoicing_email_admins_en.html
@@ -1,4 +1,8 @@
+{% if exited_with_errors %}
+<p>Hei! The invoicing exceeded the limit of 100 errors so it stopped.</p>
+{% else %}
 <p>Hei! The invoicing ended successfully.</p>
+{% endif %}
 
 <table style="width: 100%">
     <tr>

--- a/templates/email/messages/automatic_invoicing_email_admins_fi.html
+++ b/templates/email/messages/automatic_invoicing_email_admins_fi.html
@@ -1,4 +1,8 @@
-<p>Hei! Seuraavan kauden laskut lähetetty</p>
+{% if exited_with_errors %}
+<p>Hei! Laskujen lähetys pysäytettiin koska 100 virheen raja ylittyi.</p>
+{% else %}
+<p>Hei! Seuraavan kauden laskut lähetetty.</p>
+{% endif %}
 
 <table style="width: 100%">
     <tr>

--- a/templates/email/plain_messages/automatic_invoicing_email_admins_en.txt
+++ b/templates/email/plain_messages/automatic_invoicing_email_admins_en.txt
@@ -1,4 +1,8 @@
-Hei! The invoicing ended successfully
+{% if exited_with_errors %}
+Hei! The invoicing exceeded the limit of 100 errors so it stopped.
+{% else %}
+Hei! The invoicing ended successfully.
+{% endif %}
 
 Invoices sent successfully: {{ successful_orders }}
 Invoices failed to send: {{ failed_orders }}

--- a/templates/email/plain_messages/automatic_invoicing_email_admins_fi.txt
+++ b/templates/email/plain_messages/automatic_invoicing_email_admins_fi.txt
@@ -1,4 +1,8 @@
-Hei! Seuraavan kauden laskut lähetetty
+{% if exited_with_errors %}
+Hei! Laskujen lähetys pysäytettiin koska 100 virheen raja ylittyi.
+{% else %}
+Hei! Seuraavan kauden laskut lähetetty.
+{% endif %}
 
 Laskun lähetys onnistui: {{ successful_orders }}
 Laskun lähetys epäonnistui: {{ failed_orders }}


### PR DESCRIPTION
## Description :sparkles:
* Increase the error limit to 100
* Ignore counting errors if they're due to a customer is missing email
* Send the email to the admins also when the proccess fails because it hits the error limit

## Screenshots :camera_flash:
Email notice when the process fails
![image](https://user-images.githubusercontent.com/15201480/102493211-861af200-407b-11eb-8cec-170be6d2ae29.png)
