### PR TITLE
HOTFIX | Check that the fields exist when creating an order

### DIFF
--- a/contracts/admin.py
+++ b/contracts/admin.py
@@ -2,4 +2,15 @@ from django.contrib import admin
 
 from .models import VismaBerthContract, VismaWinterStorageContract
 
-admin.site.register([VismaBerthContract, VismaWinterStorageContract])
+
+class ContractAdmin(admin.ModelAdmin):
+    search_fields = ("lease__id",)
+    list_filter = ("status",)
+    list_display = ("id", "created_at", "document_id", "lease_id", "status")
+
+    def lease_id(self, obj):
+        return obj.lease.id if obj.lease else None
+
+
+admin.site.register(VismaBerthContract, ContractAdmin)
+admin.site.register(VismaWinterStorageContract, ContractAdmin)

--- a/leases/admin.py
+++ b/leases/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericStackedInline
 
+from contracts.models import VismaBerthContract, VismaWinterStorageContract
 from payments.models import Order
 
 from .models import (
@@ -58,6 +59,11 @@ class BaseLeaseAdmin(admin.ModelAdmin):
     def last_name(self, obj):
         return obj.application.last_name if obj.application else "-"
 
+    def has_contract(self, obj):
+        return obj.contract is not None
+
+    has_contract.boolean = True
+
     list_filter = ("status",)
 
 
@@ -69,8 +75,12 @@ class GenericOrderInline(GenericStackedInline):
     exclude = ("_product_content_type", "_lease_content_type")
 
 
+class VismaBerthContractInline(admin.StackedInline):
+    model = VismaBerthContract
+
+
 class BerthLeaseAdmin(BaseLeaseAdmin):
-    inlines = (BerthLeaseChangeInline, GenericOrderInline)
+    inlines = (BerthLeaseChangeInline, GenericOrderInline, VismaBerthContractInline)
     raw_id_fields = ("berth", "application")
     list_display = (
         "id",
@@ -84,6 +94,7 @@ class BerthLeaseAdmin(BaseLeaseAdmin):
         "last_name",
         "application_id",
         "status",
+        "has_contract",
     )
     search_fields = (
         "id",
@@ -122,8 +133,16 @@ class WinterStorageLeaseInline(admin.StackedInline):
     extra = 0
 
 
+class VismaWinterStorageContractInline(admin.StackedInline):
+    model = VismaWinterStorageContract
+
+
 class WinterStorageLeaseAdmin(BaseLeaseAdmin):
-    inlines = (WinterStorageLeaseChangeInline, GenericOrderInline)
+    inlines = (
+        WinterStorageLeaseChangeInline,
+        GenericOrderInline,
+        VismaWinterStorageContractInline,
+    )
     raw_id_fields = ("place", "section", "application")
     list_display = (
         "id",
@@ -137,6 +156,7 @@ class WinterStorageLeaseAdmin(BaseLeaseAdmin):
         "last_name",
         "application_id",
         "status",
+        "has_contract",
     )
     search_fields = (
         "id",

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -233,12 +233,18 @@ class BamboraPayformProvider(PaymentProvider):
                 {
                     "email": order.customer_email.strip(),
                     "customer": {
-                        "firstname": order.customer_first_name.capitalize(),
-                        "lastname": order.customer_last_name.capitalize(),
+                        "firstname": order.customer_first_name.capitalize()
+                        if order.customer_first_name
+                        else "",
+                        "lastname": order.customer_last_name.capitalize()
+                        if order.customer_last_name
+                        else "",
                         "email": order.customer_email.strip(),
                         "address_street": order.customer_address,
                         "address_zip": order.customer_zip_code,
-                        "address_city": order.customer_city.capitalize(),
+                        "address_city": order.customer_city.capitalize()
+                        if order.customer_city
+                        else "",
                     },
                 }
             )


### PR DESCRIPTION
## Description :sparkles:
* When taking the fields form the order, make sure that they're not empty to avoid failing