### PR TITLE
VEN-1007 profiling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [Development without Docker](#development-without-docker)
   * [Database](#database)
   * [Daily running](#daily-running)
+  * [Profiling](#profiling)  
   * [Install geospatial libraries](#install-geospatial-libraries)
 * [Keeping Python requirements up to date](#keeping-python-requirements-up-to-date)
 * [Code format](#code-format)
@@ -109,6 +110,27 @@ https://docs.djangoproject.com/en/3.1/ref/contrib/gis/install/geolibs/
 * Run `python manage.py runserver 0:8000`
 
 The project is now running at [localhost:8000](http://localhost:8000)
+
+<a name="profiling"></a>
+### Profiling
+
+Setting BERTH_PROFILING_ENABLED environment variable to 1 enables profiling support, for example:
+
+`BERTH_PROFILING_ENABLED=1 python manage.py runserver`
+
+After a http request is completed, profiling statistics is printed to stderr, including
+time spent calling different functions.
+
+The output can be configured by setting additional environment variables:
+
+* PROFILE_MIN_DURATION_SECONDS: by default, `0`. Only output profiling info for requests taking longer than
+  this threshold.
+* PROFILE_SORT: by default, `cumulative`. Other useful values include `time` and `calls`.
+  See also [cProfile module docs](https://docs.python.org/3/library/profile.html).
+* PROFILE_RESULTS: by default, `100`. controls the number of results shown
+* DUMP_PROFILING_RESULTS: if set to `1`, save every profile result to /tmp/ for further processing.
+
+
 
 <a name="keeping-python-requirements-up-to-date"></a>
 ## Keeping Python requirements up to date

--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -168,6 +168,7 @@ AUTH_USER_MODEL = "users.User"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "utils.profiling.ProfilingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.locale.LocaleMiddleware",

--- a/utils/profiling.py
+++ b/utils/profiling.py
@@ -1,0 +1,117 @@
+import cProfile
+import functools
+import io
+import os
+import pstats
+import sys
+import threading
+import time
+
+__all__ = [
+    "profiling_support",
+    "run_with_profiler",
+    "profile_call",
+    "ProfilingMiddleware",
+]
+
+
+def profiling_support(func):
+    """
+    run a function with profiler enabled, if BERTH_PROFILING_ENABLED is set to 1 in environment.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if get_profile_flag():
+            return profile_call(func, *args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def run_with_profiler(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return profile_call(func, *args, **kwargs)
+
+    return wrapper
+
+
+def profile_call(func, *args, **kwargs):
+    profile = cProfile.Profile()
+    try:
+        profile.enable()
+        return func(*args, **kwargs)
+    finally:
+        profile.disable()
+        dump_profiling_results(
+            profile, f"{func.__name__}-{threading.current_thread().ident}"
+        )
+
+
+def dump_profiling_results(profile, identifier=None):
+    s = io.StringIO()
+    num_results = int(os.getenv("PROFILE_RESULTS", "100"))
+    sortby = os.getenv("PROFILE_SORT", "cumulative")
+    for sort_val in sortby.split(","):
+        ps = pstats.Stats(profile, stream=s).sort_stats(sort_val)
+        ps.print_stats(num_results)
+
+        if os.getenv("PROFILE_CALLEES") == "1":
+            ps.print_callees(num_results)
+
+        if os.getenv("PROFILE_CALLERS") == "1":
+            ps.print_callers(num_results)
+
+    sys.stderr.write(s.getvalue())
+
+    if identifier is None:
+        identifier = ""
+
+    profile.dump_stats(f"/tmp/profile-{time.time()}-{identifier}")
+
+
+class ProfiledThread(threading.Thread):
+    # Overrides threading.Thread.run()
+    # NOTE: if overriding Thread.run() in subclass, this does not work.
+    def run(self):
+        profiler = cProfile.Profile()
+        try:
+            return profiler.runcall(threading.Thread.run, self)
+        finally:
+            profiler.dump_stats(f"/tmp/myprofile-{self.ident}.profile")
+
+
+def get_thread_class():
+    if get_profile_flag():
+        return ProfiledThread
+    else:
+        return threading.Thread
+
+
+def get_profile_flag():
+    return os.getenv("BERTH_PROFILING_ENABLED") == "1"
+
+
+class ProfilingMiddleware:
+
+    PROFILE_MIN_DURATION_SECONDS = 2
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.is_enabled = get_profile_flag()
+
+    def __call__(self, request):
+        if self.is_enabled:
+            start_time = time.time()
+            profiler = cProfile.Profile()
+            profiler.enable()
+            response = self.get_response(request)
+            if time.time() - start_time >= self.PROFILE_MIN_DURATION_SECONDS:
+                profiler.disable()
+                dump_profiling_results(profiler, "request")
+            return response
+
+        else:
+            return self.get_response(request)

--- a/utils/profiling.py
+++ b/utils/profiling.py
@@ -69,7 +69,8 @@ def dump_profiling_results(profile, identifier=None):
     if identifier is None:
         identifier = ""
 
-    profile.dump_stats(f"/tmp/profile-{time.time()}-{identifier}")
+    if os.getenv("DUMP_PROFILING_RESULTS") == "1":
+        profile.dump_stats(f"/tmp/profile-{time.time()}-{identifier}")
 
 
 class ProfiledThread(threading.Thread):
@@ -96,7 +97,9 @@ def get_profile_flag():
 
 class ProfilingMiddleware:
 
-    PROFILE_MIN_DURATION_SECONDS = 2
+    PROFILE_MIN_DURATION_SECONDS = float(
+        os.getenv("PROFILE_MIN_DURATION_SECONDS", "0.0")
+    )
 
     def __init__(self, get_response):
         self.get_response = get_response


### PR DESCRIPTION
## Description :sparkles:

Enables profiling output from dev server.

BERTH_PROFILING_ENABLED=1 python manage.py runserver

What do you think, should we enable something like this in the staging by default? 

## Issues :bug: VEN-1007


### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
