### PR TITLE
Add cancel_url to invoice emails

### DIFF
--- a/payments/providers/base.py
+++ b/payments/providers/base.py
@@ -128,3 +128,8 @@ class PaymentProvider:
 
     def get_payment_email_url(self, order: Order, lang: str = settings.LANGUAGE_CODE):
         return f"{self.ui_return_url.format(LANG=lang)}/payment?order_number={order.order_number}"
+
+    def get_cancellation_email_url(
+        self, order: Order, lang: str = settings.LANGUAGE_CODE
+    ):
+        return f"{self.ui_return_url.format(LANG=lang)}/cancel-order?order_number={order.order_number}"

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -316,9 +316,13 @@ def approve_order(
         request, ui_return_url=settings.VENE_UI_RETURN_URL
     ).get_payment_email_url(order, lang=language)
 
+    cancel_url = get_payment_provider(
+        request, ui_return_url=settings.VENE_UI_RETURN_URL
+    ).get_cancellation_email_url(order, lang=language)
+
     # Send email
     notification_type = get_order_notification_type(order)
-    context = get_context(order, payment_url, notification_type)
+    context = get_context(order, payment_url, cancel_url, notification_type)
     send_notification(email, notification_type.value, context, language)
 
 
@@ -333,7 +337,7 @@ def get_email_subject(notification_type):
     return notification_type.label
 
 
-def get_context(order, payment_url, notification_type):
+def get_context(order, payment_url, cancel_url, notification_type):
     if order.order_type == OrderType.LEASE_ORDER:
         return {
             "subject": get_email_subject(notification_type),
@@ -345,6 +349,7 @@ def get_context(order, payment_url, notification_type):
                 product__service__in=ProductServiceType.OPTIONAL_SERVICES()
             ),
             "payment_url": payment_url,
+            "cancel_url": cancel_url,
         }
     else:
         # We currently support only STORAGE_ON_ICE additional product orders,

--- a/templates/email/messages/berth_offer_new_en.html
+++ b/templates/email/messages/berth_offer_new_en.html
@@ -188,12 +188,11 @@
                 customer service department at <a
                     href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>If you do NOT wish to reserve the boat berth, please:</b>#}
-{#            <p>1. Notify us via this link:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">No thank you, I do not wish to reserve#}
-{#                this boat berth &rarr;</a>#}
+            <b>If you do NOT wish to reserve the boat berth, please:</b>
+            <p>1. Notify us via this link:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">No thank you, I do not wish to reserve this boat berth &rarr;</a>
 
             <p>
                 Please note that if you choose not to reserve the boat berth offered, your

--- a/templates/email/messages/berth_offer_new_fi.html
+++ b/templates/email/messages/berth_offer_new_fi.html
@@ -187,11 +187,11 @@
                 tavoin maksettuja maksuja ei voida ottaa vastaan. Lisätietoja
                 asiakaspalvelustamme <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>Jos ET halua vastaanottaa venepaikkaa:</b>#}
-{#            <p>1. Ilmoita siitä tämän linkin kautta:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">Ei kiitos, en halua tätä venepaikkaa &rarr;</a>#}
+            <b>Jos ET halua vastaanottaa venepaikkaa:</b>
+            <p>1. Ilmoita siitä tämän linkin kautta:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">Ei kiitos, en halua tätä venepaikkaa &rarr;</a>
 
             <p>
                 Huomaathan, että jos päätät olla vastaanottamatta venepaikkaa,

--- a/templates/email/messages/berth_offer_new_sv.html
+++ b/templates/email/messages/berth_offer_new_sv.html
@@ -187,11 +187,11 @@
                 annat sätt tas inte emot. För mer information, kontakta vår kundtjänst via
                 <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>Om du INTE vill ta emot båtplatsen:</b>#}
-{#            <p>1. Meddela om det via denna länk:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">Nej tack, jag vill inte ha den här båtplatsen &rarr;</a>#}
+            <b>Om du INTE vill ta emot båtplatsen:</b>
+            <p>1. Meddela om det via denna länk:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">Nej tack, jag vill inte ha den här båtplatsen &rarr;</a>
 
             <p>
                 Observera att din ansökan förfaller om du inte tar emot båtplatsen. Din ansökan

--- a/templates/email/messages/berth_offer_switch_en.html
+++ b/templates/email/messages/berth_offer_switch_en.html
@@ -188,13 +188,11 @@
                 of a different size. For more information, please contact our customer service
                 department at <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>If you do not wish to accept the boat berth change offered but want your#}
-{#                application to remain valid:</b>#}
-{#            <p>1. Notify us via this link:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">No thank you, I do not wish to reserve#}
-{#                this boat berth &rarr;</a>#}
+            <b>If you do not wish to accept the boat berth change offered but want your application to remain valid:</b>
+            <p>1. Notify us via this link:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">No thank you, I do not wish to reserve this boat berth &rarr;</a>
 
             <p>
                 Please note that if you choose not to accept the berth change offered, you will

--- a/templates/email/messages/berth_offer_switch_fi.html
+++ b/templates/email/messages/berth_offer_switch_fi.html
@@ -189,11 +189,11 @@
                 hinnan erotusta vaihtaessasi eri kokoiseen paikkaan. Lisätietoja asiakaspalvelustamme
                 <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>Jos et halua vastaanottaa vaihtopaikkaa, mutta haluat, että hakemuksesi pysyy voimassa:</b>#}
-{#            <p>1. Ilmoita meille siitä tämän linkin kautta:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">Ei kiitos, en halua tätä venepaikkaa &rarr;</a>#}
+            <b>Jos et halua vastaanottaa vaihtopaikkaa, mutta haluat, että hakemuksesi pysyy voimassa:</b>
+            <p>1. Ilmoita meille siitä tämän linkin kautta:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">Ei kiitos, en halua tätä venepaikkaa &rarr;</a>
 
             <p>
                 Huomaathan, että jos päätät olla vastaanottamatta vaihtopaikkaa, nykyinen venepaikkasi säilyy sinulla.

--- a/templates/email/messages/berth_offer_switch_sv.html
+++ b/templates/email/messages/berth_offer_switch_sv.html
@@ -188,11 +188,11 @@
                 av en annan storlek. För mer information, kontakta vår kundtjänst via
                 <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a>.
             </p>
-{#            <b>Om du inte vill ta emot bytesplatsen, men vill att din ansökan ska bli i kraft:</b>#}
-{#            <p>1. Meddela oss om det via denna länk:</p>#}
-{##}
-{#            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"#}
-{#               href="{{ cancel_url }}">Nej tack, jag vill inte ha den här båtplatsen &rarr;</a>#}
+            <b>Om du inte vill ta emot bytesplatsen, men vill att din ansökan ska bli i kraft:</b>
+            <p>1. Meddela oss om det via denna länk:</p>
+
+            <a style="display: block; padding: 16px; color: #0000BF; background-color: transparent; border: solid 2px #0000BF; text-align: center; text-decoration: none;"
+               href="{{ cancel_url }}">Nej tack, jag vill inte ha den här båtplatsen &rarr;</a>
 
             <p>
                 Observera att du behåller din nuvarande båtplats om du väljer att inte ta emot


### PR DESCRIPTION
## Description :sparkles:

Re-enabled `cancel_url` in relevant email templates.

### Closes :no_good_woman:
**[VEN-1057](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1057): Enable cancel_url on the emails**

### Related :handshake:

**[VEN-913](https://helsinkisolutionoffice.atlassian.net/browse/VEN-913): Cancel order page**

## Additional notes :spiral_notepad:

Should be merged after https://github.com/City-of-Helsinki/berth-reservations-ui/pull/353
