### PR TITLE
Add filtering options to piers and berths

### DIFF
--- a/resources/schema/queries.py
+++ b/resources/schema/queries.py
@@ -35,7 +35,9 @@ class Query:
     berth = relay.Node.Field(BerthNode)
     berths = DjangoFilterConnectionField(
         BerthNode,
-        description="**Requires permissions** to query `leases` field. "
+        description="If filtering by both pier and harbor and the pier does not belong to the given harbor, "
+        "will return an empty list of edges."
+        "\n\n**Requires permissions** to query `leases` field. "
         "Otherwise, everything is available",
     )
 

--- a/resources/schema/types.py
+++ b/resources/schema/types.py
@@ -4,7 +4,7 @@ import graphql_geojson
 from django.utils.translation import gettext_lazy as _
 from graphene import relay
 from graphene_django.fields import DjangoConnectionField
-from graphene_django.filter import DjangoFilterConnectionField
+from graphene_django.filter import DjangoFilterConnectionField, GlobalIDFilter
 from graphene_django.types import DjangoObjectType
 
 from applications.models import BerthApplication, WinterStorageApplication
@@ -69,6 +69,7 @@ class PierNode(graphql_geojson.GeoJSONType):
             "gate",
             "lighting",
             "suitable_boat_types",
+            "harbor",
         ]
         geojson_field = "location"
         interfaces = (relay.Node,)
@@ -83,6 +84,8 @@ class BerthNodeFilterSet(django_filters.FilterSet):
         field_name="berth_type__length", lookup_expr="gte"
     )
     is_available = django_filters.BooleanFilter()
+    harbor = GlobalIDFilter(field_name="pier__harbor", lookup_expr="id")
+    pier = GlobalIDFilter(field_name="pier", lookup_expr="id")
 
     class Meta:
         model = Berth

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -1080,3 +1080,99 @@ def test_get_winter_storage_place_count(api_client):
     assert executed["data"] == {
         "winterStoragePlaces": {"count": count, "totalCount": count}
     }
+
+
+def test_berth_filtering_by_pier(api_client):
+    for _i in range(10):
+        BerthFactory()
+
+    berth = BerthFactory()
+
+    query = """
+        {
+            berths(pier: "%s") {
+                count
+                totalCount
+            }
+        }
+    """ % to_global_id(
+        PierNode._meta.name, berth.pier.id
+    )
+
+    executed = api_client.execute(query)
+    assert executed["data"] == {"berths": {"count": 1, "totalCount": 11}}
+
+
+def test_berth_filtering_by_harbor(api_client):
+    for _i in range(10):
+        BerthFactory()
+
+    berth = BerthFactory()
+
+    query = """
+        {
+            berths(harbor: "%s") {
+                count
+                totalCount
+            }
+        }
+    """ % to_global_id(
+        HarborNode._meta.name, berth.pier.harbor.id
+    )
+
+    executed = api_client.execute(query)
+    assert executed["data"] == {"berths": {"count": 1, "totalCount": 11}}
+
+
+def test_berth_filtering_by_pier_and_harbor(api_client):
+    berth = BerthFactory()
+
+    base_query = """
+        {
+            berths(harbor: "%s", pier: "%s") {
+                count
+            }
+        }
+    """
+
+    executed = api_client.execute(
+        base_query
+        % (
+            to_global_id(HarborNode._meta.name, berth.pier.harbor.id),
+            to_global_id(PierNode._meta.name, berth.pier.id),
+        )
+    )
+    assert executed["data"] == {"berths": {"count": 1}}
+
+    harbor = HarborFactory()
+    pier = PierFactory()
+
+    executed = api_client.execute(
+        base_query
+        % (
+            to_global_id(HarborNode._meta.name, harbor.id),
+            to_global_id(PierNode._meta.name, pier.id),
+        )
+    )
+    assert executed["data"] == {"berths": {"count": 0}}
+
+
+def test_pier_filtering_by_harbor(api_client):
+    for _i in range(10):
+        PierFactory()
+
+    pier = PierFactory()
+
+    query = """
+        {
+            piers(harbor: "%s") {
+                count
+                totalCount
+            }
+        }
+    """ % to_global_id(
+        HarborNode._meta.name, pier.harbor.id
+    )
+
+    executed = api_client.execute(query)
+    assert executed["data"] == {"piers": {"count": 1, "totalCount": 11}}


### PR DESCRIPTION
Enables filtering berths by harbor and pier, and piers by harbor. This enables simplifying deeply nested queries on the FE.