### PR TITLE
VEN-1069 | Cancelled and rejected order dates

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.forms import TypedChoiceField, UUIDField
+from django.utils import timezone
+from django.utils.datetime_safe import strftime
 from django.utils.translation import gettext_lazy as _
 
 from leases.models import BerthLease, WinterStorageLease
@@ -80,6 +82,9 @@ class OrderAdmin(admin.ModelAdmin):
         "lease_order_type",
         "order_type",
         "place",
+        "paid_at",
+        "rejected_at",
+        "cancelled_at",
     )
     list_display = (
         "id",
@@ -172,6 +177,15 @@ class OrderAdmin(admin.ModelAdmin):
     def customer_name(self, obj):
         if obj.customer_first_name or obj.customer_last_name:
             return f"{obj.customer_first_name or ''} {obj.customer_last_name or ''}"
+
+    def paid_at(self, obj):
+        return strftime(timezone.localtime(obj.paid_at), "%d-%m-%Y %H:%M:%S",)
+
+    def cancelled_at(self, obj):
+        return strftime(timezone.localtime(obj.cancelled_at), "%d-%m-%Y %H:%M:%S",)
+
+    def rejected_at(self, obj):
+        return strftime(timezone.localtime(obj.rejected), "%d-%m-%Y %H:%M:%S",)
 
     pretax_price.short_description = _("Pretax price")
     pretax_price.admin_order_field = "pretax_price"

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -198,6 +198,7 @@ class OrderNode(DjangoObjectType):
     order_lines = DjangoConnectionField(OrderLineNode, required=True)
     log_entries = DjangoConnectionField(OrderLogEntryNode, required=True)
     paid_at = graphene.DateTime()
+    cancelled_at = graphene.DateTime()
 
     class Meta:
         model = Order


### PR DESCRIPTION
## Description :sparkles:
* Add a `cancelledAt` and `rejectedAt` props to the `Order` model and node
* Update the `paidAt` prop to a model annotation for better performance

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1069](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1069):** Add cancelled_at to order

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_paid_and_created
```

## Screenshots :camera_flash:
**Fields on django admin**
<img width="364" alt="image" src="https://user-images.githubusercontent.com/15201480/104299137-80bf9480-54cd-11eb-8c2b-b3563b9a69b3.png">
