### PR TITLE
VEN-1063 | Add order cancellation notification type and dummy context

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-16 10:44+0200\n"
+"POT-Creation-Date: 2021-01-18 11:24+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -977,6 +977,9 @@ msgstr "Nostojärjestyspaikkalasku"
 
 msgid "Additional product order approved"
 msgstr "Lisäpalvelulasku"
+
+msgid "Confirmation"
+msgstr "Vahvistus"
 
 msgid "Payment service is unreachable"
 msgstr "Maksupalvelu ei ole käytettävissä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-16 10:44+0200\n"
+"POT-Creation-Date: 2021-01-18 11:24+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -955,6 +955,9 @@ msgstr "Faktura för vinteruppläggningsplats"
 
 msgid "Unmarked winter storage order approved"
 msgstr "Faktura för plats på upplagsområde som fylls i upptagningsordning"
+
+msgid "Confirmation"
+msgstr "Bekräftelse"
 
 msgid "Payment service is unreachable"
 msgstr "Betaltjänsten kan inte nås"

--- a/payments/notifications/types.py
+++ b/payments/notifications/types.py
@@ -27,3 +27,4 @@ class NotificationType(TextChoices):
         "additional_product_order_approved",
         _("Additional product order approved"),
     )
+    ORDER_CANCELLED = ("order_cancelled", _("Confirmation"))

--- a/scripts/load_notification_templates.py
+++ b/scripts/load_notification_templates.py
@@ -83,6 +83,10 @@ if __name__ == "__main__":
             "html": "additional_service_invoice_{lang}.html",
             "plain": None,
         },
+        PaymentNotificationType.ORDER_CANCELLED: {
+            "html": "order_cancelled_{lang}.html",
+            "plain": None,
+        },
         LeaseNotificationType.AUTOMATIC_INVOICING_EMAIL_ADMINS: {
             "html": "automatic_invoicing_email_admins_{lang}.html",
             "plain": "automatic_invoicing_email_admins_{lang}.txt",


### PR DESCRIPTION
## Description :sparkles:
* Add order cancellation notification type and dummy context

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1063](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1063):** Order cancellation confirmation email

### Related :handshake:
#440 

## Testing :alembic:
### Manual testing :construction_worker_man:
1. Load the email templates
```
python ./scripts/load_notification_templates.py
```
2. From Django admin, go to the `Confirmation` template

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/15201480/104897917-a7744400-5981-11eb-94f1-ff0c44034cd5.png)
