### PR TITLE
VEN-1062 | Send an order cancellation email

### DIFF
--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -161,6 +161,25 @@ def notification_template_orders_approved():
         )
 
 
+@pytest.fixture
+def notification_template_order_cancelled():
+    from payments.notifications import NotificationType
+
+    for value in NotificationType.values:
+        notification = NotificationTemplate.objects.language("fi").create(
+            type=value,
+            subject="test order cancelled subject: {{ order.order_number }}!",
+            body_html="<b>{{ order.order_number }}</b>",
+            body_text="{{ order.order_number }}",
+        )
+        notification.create_translation(
+            "en",
+            subject="test order cancelled subject: {{ order.order_number }}!",
+            body_html="<b>{{ order.order_number }}</b>",
+            body_text="{{ order.order_number }}",
+        )
+
+
 @pytest.fixture(autouse=True)
 def patch_contract_service(monkeypatch):
     monkeypatch.setattr(

--- a/payments/notifications/types.py
+++ b/payments/notifications/types.py
@@ -27,4 +27,4 @@ class NotificationType(TextChoices):
         "additional_product_order_approved",
         _("Additional product order approved"),
     )
-    ORDER_CANCELLED = ("order_cancelled", _("Confirmation"))
+    ORDER_CANCELLED = ("order_cancelled", _("Order cancelled"))

--- a/payments/schema/mutations.py
+++ b/payments/schema/mutations.py
@@ -39,7 +39,7 @@ from ..models import (
     WinterStorageProduct,
 )
 from ..providers import get_payment_provider
-from ..utils import approve_order
+from ..utils import approve_order, send_cancellation_notice
 from .types import (
     AdditionalProductNode,
     AdditionalProductTaxEnum,
@@ -479,7 +479,9 @@ class CancelOrderMutation(graphene.ClientIDMutation):
                 )
             order.set_status(OrderStatus.REJECTED, _("Order rejected by customer"))
             order.invalidate_tokens()
-        except (Order.DoesNotExist, ValidationError) as e:
+
+            send_cancellation_notice(order)
+        except (Order.DoesNotExist, ValidationError, AnymailError, OSError,) as e:
             raise VenepaikkaGraphQLError(e)
 
         return CancelOrderMutation()


### PR DESCRIPTION
## Description :sparkles:
* Send an order cancellation email
* Rename the `NotificationType` to make more sense and delegate the email subject to the right function

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1062](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1062):** Send cancellation notice to customer

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_mutations.py::test_cancel_order
```

### Manual testing :construction_worker_man:
1. Generate an order with a lease, the order should be `WAITING` status and lease on `OFFERED` (add an email to `order.customer_email`)
2. From the customer API (`/graphql`), execute the following mutation:
```graphql
mutation CancelOrder {
  cancelOrder(input: {orderNumber: ""}) {
    __typename
  }
}
```
3. You should see the confirmation email on the console