### PR TITLE
HOTFIX | Harbor manager

### DIFF
--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
 
-python /app/manage.py makemigrations
-
 # Runs migration scripts on each deployment
 python /app/manage.py migrate --noinput
-
-# Admin commands that need to be ran for each env can be added here
-python /app/manage.py collectstatic

--- a/payments/notifications/dummy_context.py
+++ b/payments/notifications/dummy_context.py
@@ -40,6 +40,9 @@ def _get_order_context(
         "subject": subject,
         "order": order,
         "payment_url": provider.get_payment_email_url(order, settings.LANGUAGE_CODE),
+        "cancel_url": provider.get_cancellation_email_url(
+            order, settings.LANGUAGE_CODE
+        ),
         "optional_services": optional_services,
     }
 

--- a/resources/models.py
+++ b/resources/models.py
@@ -19,6 +19,7 @@ from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce
 from django.utils.translation import gettext_lazy as _
 from munigeo.models import Municipality
+from parler.managers import TranslatableManager
 from parler.models import TranslatableModel, TranslatedFields
 
 from leases.consts import ACTIVE_LEASE_STATUSES
@@ -133,7 +134,7 @@ class AbstractArea(TimeStampedModel, UUIDModel):
         abstract = True
 
 
-class HarborManager(models.Manager):
+class HarborManager(TranslatableManager):
     def get_queryset(self):
         pier_qs = Pier.objects.filter(harbor=OuterRef("pk")).values("harbor__pk")
         width_qs = pier_qs.annotate(max=Max("max_width")).values("max")


### PR DESCRIPTION
## Description :sparkles:
* Replace the `models.Manager` for parler's `TranslatableManager` since this breaks the Django Admin