### PR TITLE
VEN-1071 | Resend error invoices

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -674,6 +674,7 @@ class Order(UUIDModel, TimeStampedModel):
                 OrderStatus.ERROR,
             ),
             OrderStatus.PAID: (OrderStatus.CANCELLED,),
+            OrderStatus.ERROR: (OrderStatus.WAITING,),
         }
         valid_new_status = valid_status_changes.get(old_status, ())
 

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -16,6 +16,7 @@ from customers.tests.factories import CustomerProfileFactory
 from leases.tests.conftest import *  # noqa
 from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
 from resources.tests.conftest import *  # noqa
+from utils.numbers import random_decimal
 
 from ..enums import OrderStatus, OrderType, PeriodType, PriceUnits, ProductServiceType
 from ..providers import BamboraPayformProvider
@@ -60,11 +61,16 @@ def additional_product():
 def _generate_order(order_type: str = None):
     customer_profile = CustomerProfileFactory()
     if order_type == "berth_order":
+        min_width = random_decimal(1, 5)
+        max_width = random_decimal(min_width + Decimal("0.1"), 10)
+
         order = OrderFactory(
             customer=customer_profile,
-            product=BerthProductFactory(),
+            product=BerthProductFactory(min_width=min_width, max_width=max_width),
             lease=BerthLeaseFactory(
-                application=BerthApplicationFactory(), customer=customer_profile
+                application=BerthApplicationFactory(),
+                customer=customer_profile,
+                berth__berth_type__width=random_decimal(min_width, max_width),
             ),
         )
     elif order_type == "winter_storage_order":

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -363,12 +363,10 @@ def resend_order(order, due_date: date, request: HttpRequest) -> None:
 def send_payment_notification(order, request, email=None):
     from payments.providers import get_payment_provider
 
-    if email is None:
-        email = order.customer_email
-        if order_email := order.customer_email:
-            email = order_email
-        else:
-            raise ValidationError(_("Missing customer email"))
+    order_email = email or order.customer_email
+
+    if not order_email:
+        raise ValidationError(_("Missing customer email"))
 
     language = get_notification_language(order)
     payment_url = get_payment_provider(
@@ -381,7 +379,7 @@ def send_payment_notification(order, request, email=None):
 
     notification_type = get_order_notification_type(order)
     context = get_context(order, payment_url, cancel_url, notification_type)
-    send_notification(email, notification_type.value, context, language)
+    send_notification(order_email, notification_type.value, context, language)
 
 
 def get_notification_language(order):

--- a/utils/numbers.py
+++ b/utils/numbers.py
@@ -35,6 +35,11 @@ def rounded(
 
 
 def random_decimal(
-    min: float = 0, max: float = 100, decimals: int = 2, as_string: bool = False
+    min: Union[float, Decimal] = 0,
+    max: Union[float, Decimal] = 100,
+    decimals: int = 2,
+    as_string: bool = False,
 ) -> DecimalString:
-    return rounded(uniform(min, max), decimals=decimals, as_string=as_string)
+    return rounded(
+        uniform(float(min), float(max)), decimals=decimals, as_string=as_string
+    )


### PR DESCRIPTION
## Description :sparkles:
* When resending the invoice, it checks if it has `error` state and sets it to `waiting/offered` status in case it has been fixed
* Enable order status changes from `error -> waiting`
* Add a check to raise an error if the order doesn't have an email when sending the invoice

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1071](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1071):** Admins can't send fixed invoices

## Testing :alembic:
### Automated tests :gear:️
```shell
$ python payments/tests/test_payments_mutations_resend_order.py
```

### Manual testing :construction_worker_man:
1. Set an order and the lease to `ERROR` states
2. Exectue the the first mutation for that order

```graphql
mutation RESEND_ORDER_MUTATION($input: ResendOrderMutationInput!) {
    resendOrder(input: $input) {
        failedOrders {
            id
            error
        }
        sentOrders
    }
}
```
```json
{
  "input": {
    "orders": ["..."],
    "dueDate": "2021-02-15"
  }
}
```
3. Check the terminal for the sent email, and the statuses of the order and lease
```graphql
query Orders {
  order(id: "") {
    status
    lease {
      ... on BerthLeaseNode{
        status
      }
    }
  }
}
```

## Additional notes :spiral_notepad:
This only covers the case of manually resending one invoice, the case for batch invoicing will come in a separate PR.