### PR TITLE
VEN-1071 | Exclude example.com emails

### DIFF
--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -28,6 +28,7 @@ from leases.utils import calculate_season_end_date, calculate_season_start_date
 from payments.enums import OrderStatus
 from payments.models import BerthProduct, Order, WinterStorageProduct
 from payments.utils import approve_order, resend_order, update_order_from_profile
+from utils.email import is_valid_email
 
 from ..notifications import NotificationType as LeaseNotificationType
 
@@ -164,7 +165,7 @@ class BaseInvoicingService:
 
         # If the profile doesn't have an associated email
         # or if it has an example.com address, set it as failed
-        if email and "example.com" not in email:
+        if is_valid_email(email):
             try:
                 approve_order(
                     order, email, self.due_date, helsinki_profile_user, self.request

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -30,6 +30,7 @@ from leases.utils import (
 )
 from resources.enums import AreaRegion
 from resources.models import Harbor, WinterStorageArea
+from utils.email import is_valid_email
 from utils.numbers import rounded as rounded_decimal
 
 from .enums import OrderStatus, OrderType, ProductServiceType
@@ -365,7 +366,7 @@ def send_payment_notification(order, request, email=None):
 
     order_email = email or order.customer_email
 
-    if not order_email:
+    if not is_valid_email(order_email):
         raise ValidationError(_("Missing customer email"))
 
     language = get_notification_language(order)

--- a/utils/email.py
+++ b/utils/email.py
@@ -1,0 +1,5 @@
+from typing import Optional
+
+
+def is_valid_email(email: Optional[str]) -> bool:
+    return email and "@example.com" not in email


### PR DESCRIPTION
## Description :sparkles:
* Raise an error when the `send_payment_notification` receives an `@example.com` email

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1071](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1071)** 

### Related :handshake:
#455 
#457 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_utils.py::test_send_payment_notification_example_email
```