### PR TITLE
VEN-935 | Terminate winter lease

### DIFF
--- a/leases/notifications/dummy_context.py
+++ b/leases/notifications/dummy_context.py
@@ -4,12 +4,13 @@ from babel.dates import format_date
 from dateutil.utils import today
 from django_ilmoitin.dummy_context import dummy_context
 
-from ..tests.factories import BerthLeaseFactory
+from ..tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
 from .types import NotificationType
 
 
 def load_dummy_context():
     berth_lease = BerthLeaseFactory.build()
+    ws_lease = WinterStorageLeaseFactory.build()
 
     dummy_context.update(
         {
@@ -23,6 +24,11 @@ def load_dummy_context():
                 "subject": NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE.label,
                 "cancellation_date": format_date(today(), locale="fi"),
                 "lease": berth_lease,
+            },
+            NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE: {
+                "subject": NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE.label,
+                "cancellation_date": format_date(today(), locale="fi"),
+                "lease": ws_lease,
             },
         }
     )

--- a/leases/notifications/types.py
+++ b/leases/notifications/types.py
@@ -11,3 +11,7 @@ class NotificationType(TextChoices):
         "berth_lease_terminated_lease_notice",
         _("Terminated berth lease"),
     )
+    WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE = (
+        "ws_lease_terminated_lease_notice",
+        _("Terminated winter storage lease"),
+    )

--- a/leases/schema/mutations.py
+++ b/leases/schema/mutations.py
@@ -1,14 +1,9 @@
 import threading
 
 import graphene
-from anymail.exceptions import AnymailError
-from babel.dates import format_date
-from dateutil.utils import today
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
-from django_ilmoitin.utils import send_notification
 
 from applications.enums import ApplicationAreaType, ApplicationStatus
 from applications.models import BerthApplication, WinterStorageApplication
@@ -16,7 +11,6 @@ from applications.new_schema import BerthApplicationNode, WinterStorageApplicati
 from berth_reservations.exceptions import VenepaikkaGraphQLError
 from contracts.services import get_contract_service
 from customers.models import CustomerProfile
-from customers.services import ProfileService
 from payments.enums import OrderStatus
 from payments.models import BerthProduct, Order, WinterStorageProduct
 from resources.schema import BerthNode, WinterStoragePlaceNode, WinterStorageSectionNode
@@ -26,7 +20,6 @@ from users.decorators import (
     delete_permission_required,
     view_permission_required,
 )
-from utils.email import is_valid_email
 from utils.relay import get_node_from_global_id
 from utils.schema import update_object
 
@@ -36,6 +29,7 @@ from ..notifications import NotificationType
 from ..services import BerthInvoicingService
 from ..stickers import get_next_sticker_number
 from .types import BerthLeaseNode, WinterStorageLeaseNode
+from .utils import terminate_lease
 
 
 class AbstractLeaseInput:
@@ -361,75 +355,57 @@ class DeleteWinterStorageLeaseMutation(graphene.ClientIDMutation):
         return DeleteWinterStorageLeaseMutation()
 
 
+class TerminateLeaseInput:
+    id = graphene.ID(required=True)
+    end_date = graphene.Date(
+        description="The date which will mark the end of the lease. If none is provided, "
+        "it will default to the day when the mutation is called"
+    )
+    profile_token = graphene.String(
+        description="To fetch the email the from Profile service in case the lease doesn't have an application"
+    )
+
+
 class TerminateBerthLeaseMutation(graphene.ClientIDMutation):
-    class Input:
-        id = graphene.ID(required=True)
-        end_date = graphene.Date(
-            description="The date which will mark the end of the lease. If none is provided, "
-            "it will default to the day when the mutation is called"
-        )
-        profile_token = graphene.String(
-            description="To fetch the email the from Profile service in case the lease doesn't have an application"
-        )
+    class Input(TerminateLeaseInput):
+        pass
 
     berth_lease = graphene.Field(BerthLeaseNode)
 
     @classmethod
     @change_permission_required(BerthLease)
     @transaction.atomic
-    def mutate_and_get_payload(cls, root, info, **input):
-        lease: BerthLease = get_node_from_global_id(
-            info, input.pop("id"), only_type=BerthLeaseNode, nullable=False,
+    def mutate_and_get_payload(cls, root, info, id, **input):
+        lease = terminate_lease(
+            info,
+            id,
+            BerthLeaseNode,
+            NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE,
+            end_date=input.get("end_date"),
+            profile_token=input.get("profile_token"),
         )
-
-        if lease.status != LeaseStatus.PAID:
-            raise VenepaikkaGraphQLError(_(f"Lease is not paid: {lease.status}"))
-
-        lease.status = LeaseStatus.TERMINATED
-
-        end_date = input.get("end_date", today())
-        lease.end_date = end_date
-
-        language = (
-            lease.application.language
-            if lease.application
-            else settings.LANGUAGES[0][0]
-        )
-
-        # Always try to retrieve the email from Profile if the token is passed
-        if profile_token := input.get("profile_token"):
-            profile_service = ProfileService(profile_token=profile_token)
-            profile = profile_service.get_profile(lease.customer.id)
-            email = profile.email
-        # If the profile token is not passed, try to get the email from the application
-        elif lease.application:
-            email = lease.application.email
-        else:
-            raise VenepaikkaGraphQLError(
-                _("The lease has no email and no profile token was provided")
-            )
-
-        if not is_valid_email(email):
-            raise VenepaikkaGraphQLError(_("Missing customer email"))
-
-        try:
-            lease.save()
-            send_notification(
-                email,
-                NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE,
-                {
-                    "subject": NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE.label,
-                    "cancelled_at": format_date(today(), locale=language),
-                    "lease": lease,
-                },
-                language=language,
-            )
-        except (AnymailError, OSError, ValidationError, VenepaikkaGraphQLError,) as e:
-            # Flatten all the error messages on a single list
-            errors = sum(e.message_dict.values(), [])
-            raise VenepaikkaGraphQLError(errors)
-
         return TerminateBerthLeaseMutation(berth_lease=lease)
+
+
+class TerminateWinterStorageLeaseMutation(graphene.ClientIDMutation):
+    class Input(TerminateLeaseInput):
+        pass
+
+    winter_storage_lease = graphene.Field(WinterStorageLeaseNode)
+
+    @classmethod
+    @change_permission_required(WinterStorageLease)
+    @transaction.atomic
+    def mutate_and_get_payload(cls, root, info, id, **input):
+        lease = terminate_lease(
+            info,
+            id,
+            WinterStorageLeaseNode,
+            NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE,
+            end_date=input.get("end_date"),
+            profile_token=input.get("profile_token"),
+        )
+        return TerminateWinterStorageLeaseMutation(winter_storage_lease=lease)
 
 
 class AssignNewStickerNumberMutation(graphene.ClientIDMutation):
@@ -581,6 +557,15 @@ class Mutation:
         "\n\n**Requires permissions** to access leases."
         "\n\nErrors:"
         "\n* A winter storage lease that is not `DRAFTED` anymore is passed"
+        "\n* The passed lease ID doesn't exist"
+    )
+    terminate_winter_storage_lease = TerminateWinterStorageLeaseMutation.Field(
+        description="Marks a `WinterStorageLease` as terminated."
+        "\n\nIt **only** works for leases that have been paid. "
+        "It receives an optional date for when the lease should end."
+        "\n\n**Requires permissions** to edit leases."
+        "\n\nErrors:"
+        "\n* A berth lease that is not `PAID` is passed"
         "\n* The passed lease ID doesn't exist"
     )
     assign_new_sticker_number = AssignNewStickerNumberMutation.Field(

--- a/leases/schema/utils.py
+++ b/leases/schema/utils.py
@@ -1,4 +1,22 @@
-from utils.relay import to_global_id
+from datetime import date
+from typing import Type, Union
+
+from anymail.exceptions import AnymailError
+from babel.dates import format_date
+from dateutil.utils import today
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+from django_ilmoitin.utils import send_notification
+
+from berth_reservations.exceptions import VenepaikkaGraphQLError
+from customers.services import ProfileService
+from utils.email import is_valid_email
+from utils.relay import get_node_from_global_id, to_global_id
+
+from ..enums import LeaseStatus
+from ..models import BerthLease, WinterStorageLease
+from ..notifications import NotificationType
 
 
 def parse_invoicing_result(node_type):
@@ -10,3 +28,60 @@ def parse_invoicing_result(node_type):
         return {"id": to_global_id(node_type, id), "error": error}
 
     return parse_to_dict
+
+
+def terminate_lease(
+    info,
+    lease_id: str,
+    lease_type: Union[Type],
+    notification_type: NotificationType,
+    end_date: date = None,
+    profile_token: str = None,
+) -> Union[BerthLease, WinterStorageLease]:
+
+    lease: Union[BerthLease, WinterStorageLease] = get_node_from_global_id(
+        info, lease_id, only_type=lease_type, nullable=False,
+    )
+
+    if lease.status != LeaseStatus.PAID:
+        raise VenepaikkaGraphQLError(_(f"Lease is not paid: {lease.status}"))
+
+    lease.status = LeaseStatus.TERMINATED
+    lease.end_date = end_date or today().date()
+
+    language = (
+        lease.application.language if lease.application else settings.LANGUAGES[0][0]
+    )
+
+    if profile_token:
+        profile_service = ProfileService(profile_token=profile_token)
+        profile = profile_service.get_profile(lease.customer.id)
+        email = profile.email
+    elif lease.application:
+        email = lease.application.email
+    else:
+        raise VenepaikkaGraphQLError(
+            _("The lease has no email and no profile token was provided")
+        )
+
+    if not is_valid_email(email):
+        raise VenepaikkaGraphQLError(_("Missing customer email"))
+
+    try:
+        lease.save()
+        send_notification(
+            email,
+            notification_type,
+            {
+                "subject": notification_type.label,
+                "cancelled_at": format_date(today(), locale=language),
+                "lease": lease,
+            },
+            language=language,
+        )
+    except (AnymailError, OSError, ValidationError, VenepaikkaGraphQLError,) as e:
+        # Flatten all the error messages on a single list
+        errors = sum(e.message_dict.values(), [])
+        raise VenepaikkaGraphQLError(errors)
+
+    return lease

--- a/leases/tests/conftest.py
+++ b/leases/tests/conftest.py
@@ -37,3 +37,13 @@ def notification_template_berth_lease_terminated():
         body_html="<b>test berth lease terminated</b> {{ cancelled_at }} {{ lease.id }}",
         body_text="test berth lease terminated {{ cancelled_at }} {{ lease.id }}",
     )
+
+
+@pytest.fixture
+def notification_template_ws_lease_terminated():
+    return NotificationTemplate.objects.language("fi").create(
+        type=NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE,
+        subject="test ws lease rejected subject",
+        body_html="<b>test ws lease terminated</b> {{ cancelled_at }} {{ lease.id }}",
+        body_text="test ws lease terminated {{ cancelled_at }} {{ lease.id }}",
+    )

--- a/scripts/load_notification_templates.py
+++ b/scripts/load_notification_templates.py
@@ -72,6 +72,10 @@ def load_email_templates():
             "html": "berth_lease_termination_confirmation_{lang}.html",
             "plain": None,
         },
+        LeaseNotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE: {
+            "html": "ws_lease_termination_confirmation_{lang}.html",
+            "plain": None,
+        },
     }
 
     for notification_index, (notification_type, templates) in enumerate(

--- a/templates/email/messages/ws_lease_termination_confirmation_en.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_en.html
@@ -1,0 +1,27 @@
+<p>Dear customer, we have received your cancellation. The invoice, application and contract regarding the place
+    have been cancelled starting from {{ cancellation_date }}.</p>
+
+<h3>Location</h3>
+
+{% if lease.place %}
+<b>{{ lease.place.winter_storage_section.area.name }}</b>
+<p>{{ lease.place.winter_storage_section.area.street_address }}</p>
+<p>Place: {{ lease.place.winter_storage_section.identifier }} {{ lease.place.number }}</p>
+{% else %}
+<b>{{ lease.section.area.name }}</b>
+<p>{{ lease.section.area.street_address }}</p>
+<p>Place: {{ lease.section.identifier }}</p>
+{% endif %}
+<br/>
+
+<p>Questions and further information: <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a></p>
+
+<table style="width: 100%; margin: 48px 0;">
+    <tr>
+        <td style="text-align: center;">
+            <a style="font-size: 16px; color: #0072C6;" href="https://venepaikat.hel.fi">
+                City of Helsinki boating services &rarr;
+            </a>
+        </td>
+    </tr>
+</table>

--- a/templates/email/messages/ws_lease_termination_confirmation_fi.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_fi.html
@@ -1,0 +1,27 @@
+<p>Hyvä asiakas, olemme vastaanottaneet peruutuksen. Lasku, hakemus ja sopimus liittyen paikkaan on
+    peruttu {{ cancellation_date }} alkaen.</p>
+
+<h3>Kohde</h3>
+
+{% if lease.place %}
+<b>{{ lease.place.winter_storage_section.area.name }}</b>
+<p>{{ lease.place.winter_storage_section.area.street_address }}</p>
+<p>Paikka: {{ lease.place.winter_storage_section.identifier }} {{ lease.place.number }}</p>
+{% else %}
+<b>{{ lease.section.area.name }}</b>
+<p>{{ lease.section.area.street_address }}</p>
+<p>Paikka: {{ lease.section.identifier }}</p>
+{% endif %}
+<br/>
+
+<p>Kysymykset ja lisätiedot: <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a></p>
+
+<table style="width: 100%; margin: 48px 0;">
+    <tr>
+        <td style="text-align: center;">
+            <a style="font-size: 16px; color: #0072C6;" href="https://venepaikat.hel.fi">
+                Helsingin kaupungin veneilypalvelut &rarr;
+            </a>
+        </td>
+    </tr>
+</table>

--- a/templates/email/messages/ws_lease_termination_confirmation_sv.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_sv.html
@@ -1,0 +1,27 @@
+<p>Bästa kund, vi har mottagit annulleringen. Fakturan, ansökan och avtalet relaterade till platsen har
+    annullerats {{ cancellation_date }} från.</p>
+
+<h3>Område</h3>
+
+{% if lease.place %}
+<b>{{ lease.place.winter_storage_section.area.name }}</b>
+<p>{{ lease.place.winter_storage_section.area.street_address }}</p>
+<p>Plats: {{ lease.place.winter_storage_section.identifier }} {{ lease.place.number }}</p>
+{% else %}
+<b>{{ lease.section.area.name }}</b>
+<p>{{ lease.section.area.street_address }}</p>
+<p>Plats: {{ lease.section.identifier }}</p>
+{% endif %}
+<br/>
+
+<p>Frågor och mer information: <a href="mailto:venepaikkavaraukset@hel.fi">venepaikkavaraukset@hel.fi</a></p>
+
+<table style="width: 100%; margin: 48px 0;">
+    <tr>
+        <td style="text-align: center;">
+            <a style="font-size: 16px; color: #0072C6;" href="https://venepaikat.hel.fi">
+                Helsingfors stadens båtservicen &rarr;
+            </a>
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
## Description :sparkles:
- Add confirmation email for terminating winter storage leases
- Add generic function to terminate leases
- Add mutation to terminate winter leases 

## Issues :bug:
### Closes :no_good_woman:
**[VEN-935](https://helsinkisolutionoffice.atlassian.net/browse/VEN-935):** Mutation to terminate a lease

### Related :handshake:
#469 

## Testing :alembic:
### Automated tests :gear:️
### Automated tests :gear:️
```shell
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_with_application
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_without_application
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_with_due_date
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_not_enough_permissions
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_doesnt_exist
pytest leases/tests/test_lease_mutations.py::test_terminate_ws_lease_no_email_no_token
```

### Manual testing :construction_worker_man:
```graphql
mutation TERMINATE_WINTER_STORAGE_LEASE($input: TerminateWinterStorageLeaseMutationInput!) {
    terminateWinterStorageLease(input: $input) {
        winterStorageLease {
            status
            endDate
        }
    }
}
```

```json
{
    "id": "<ws lease id>"
}
```

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/15201480/108716011-41e91980-7524-11eb-8c96-b57343109d8c.png)

## Additional notes :spiral_notepad:
The translations for the email subject are still pending
