### PR TITLE
VEN-1085 | Add boolean filter for application_code

### DIFF
--- a/applications/new_schema/types.py
+++ b/applications/new_schema/types.py
@@ -61,6 +61,9 @@ class BerthApplicationFilter(django_filters.FilterSet):
     no_customer = django_filters.BooleanFilter(
         field_name="customer", lookup_expr="isnull"
     )
+    application_code = django_filters.BooleanFilter(
+        field_name="application_code", method="filter_application_code"
+    )
     order_by = django_filters.OrderingFilter(
         fields=("created_at",), label="Supports only `createdAt` and `-createdAt`.",
     )
@@ -74,6 +77,14 @@ class BerthApplicationFilter(django_filters.FilterSet):
     def filter_berth_switch(self, queryset, name, value):
         lookup = "__".join([name, "isnull"])
         return queryset.filter(**{lookup: not value})
+
+    def filter_application_code(self, queryset, name, value):
+        lookup = "__".join([name, "exact"])
+        return (
+            queryset.exclude(**{lookup: ""})
+            if value
+            else queryset.filter(**{lookup: ""})
+        )
 
 
 class BerthApplicationNode(DjangoObjectType):

--- a/applications/tests/conftest.py
+++ b/applications/tests/conftest.py
@@ -44,6 +44,9 @@ def berth_application():
     return berth_application
 
 
+berth_application2 = berth_application
+
+
 @pytest.fixture
 def berth_application_with_customer(berth_application):
     berth_application.customer = CustomerProfileFactory()

--- a/applications/tests/test_applications_new_schema_berth_queries.py
+++ b/applications/tests/test_applications_new_schema_berth_queries.py
@@ -382,3 +382,60 @@ def test_berth_applications_name_filter_no_matching(berth_application, api_clien
     executed = api_client.execute(query)
 
     assert executed["data"] == {"berthApplications": {"edges": []}}
+
+
+BERTH_APPLICATIONS_WITH_APPLICATION_CODE_FILTER_QUERY = """
+query APPLICATIONS {
+    berthApplications(applicationCode: %s) {
+        edges {
+            node {
+                applicationCode
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["berth_services", "berth_handler", "berth_supervisor"],
+    indirect=True,
+)
+def test_berth_applications_application_code_filter_true(
+    berth_application, berth_application2, api_client
+):
+    berth_application.application_code = ""
+    berth_application.save()
+
+    berth_application2.application_code = "test"
+    berth_application2.save()
+
+    query = BERTH_APPLICATIONS_WITH_APPLICATION_CODE_FILTER_QUERY % "true"
+    executed = api_client.execute(query)
+
+    assert executed["data"] == {
+        "berthApplications": {"edges": [{"node": {"applicationCode": "test"}}]}
+    }
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["berth_services", "berth_handler", "berth_supervisor"],
+    indirect=True,
+)
+def test_berth_applications_application_code_filter_false(
+    berth_application, berth_application2, api_client
+):
+    berth_application.application_code = ""
+    berth_application.save()
+
+    berth_application2.application_code = "test"
+    berth_application2.save()
+
+    query = BERTH_APPLICATIONS_WITH_APPLICATION_CODE_FILTER_QUERY % "false"
+    executed = api_client.execute(query)
+
+    assert executed["data"] == {
+        "berthApplications": {"edges": [{"node": {"applicationCode": ""}}]}
+    }


### PR DESCRIPTION
## Description :sparkles:

This filter will return:

- true: all applications with a non-empty `application_code`.
- false: all applications with an empty `applicaiton_code`.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1085](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1085)** 

### Related :handshake:
**[VEN-1093](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1093)** 

## Testing :alembic:
### Automated tests :gear:️

```
pytest applications/tests/test_applications_new_schema_berth_queries.py::test_berth_applications_application_code_filter
pytest applications/tests/test_applications_new_schema_berth_queries.py::test_berth_applications_application_code_filter_empty_string
pytest applications/tests/test_applications_new_schema_berth_queries.py::test_berth_applications_application_code_filter_false
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
