### PR TITLE
date_hierarchy in django admin for orders and leases

### DIFF
--- a/leases/admin.py
+++ b/leases/admin.py
@@ -66,6 +66,8 @@ class BaseLeaseAdmin(admin.ModelAdmin):
 
     list_filter = ("status",)
 
+    date_hierarchy = "start_date"
+
 
 class GenericOrderInline(GenericStackedInline):
     ct_field = "_lease_content_type"

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -71,6 +71,7 @@ class OrderLogEntryInline(admin.StackedInline):
 
 
 class OrderAdmin(admin.ModelAdmin):
+    date_hierarchy = "due_date"
     inlines = (OrderLineInline, OrderLogEntryInline)
     exclude = ("_product_content_type", "_lease_content_type")
     readonly_fields = (


### PR DESCRIPTION
## Description :sparkles:

For debugging similar cases in the future, it would be useful to be able to filter orders by due_date and leases by start_date in the django admin.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1177](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1177):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
