### PR TITLE
VEN-1091 | Don't send invoice to non-billable customers

### DIFF
--- a/leases/schema/mutations.py
+++ b/leases/schema/mutations.py
@@ -92,7 +92,9 @@ class CreateBerthLeaseMutation(graphene.ClientIDMutation):
             order = Order.objects.create(
                 customer=input["customer"], lease=lease, product=product
             )
-            get_contract_service().create_berth_contract(lease)
+            # Do not create a contract for non-billable customers.
+            if not application.customer.is_non_billable_customer():
+                get_contract_service().create_berth_contract(lease)
         except BerthProduct.DoesNotExist as e:
             raise VenepaikkaGraphQLError(e)
         except ValidationError as e:
@@ -257,7 +259,9 @@ class CreateWinterStorageLeaseMutation(graphene.ClientIDMutation):
             order = Order.objects.create(
                 customer=input["customer"], lease=lease, product=product
             )
-            get_contract_service().create_winter_storage_contract(lease)
+            # Do not create a contract for non-billable customers.
+            if not application.customer.is_non_billable_customer():
+                get_contract_service().create_winter_storage_contract(lease)
         except WinterStorageProduct.DoesNotExist as e:
             raise VenepaikkaGraphQLError(e)
         except ValidationError as e:

--- a/leases/services/invoice.py
+++ b/leases/services/invoice.py
@@ -87,9 +87,13 @@ class BaseInvoicingService:
     ) -> Union[BerthLease, WinterStorageLease]:
         """Create a new lease instance"""
 
-        # Make copy of attached contract, if one exists
+        # Make copy of attached contract, if one exists and if the customer is billable.
         contract = None
-        if hasattr(lease, "contract") and lease.contract is not None:
+        if (
+            hasattr(lease, "contract")
+            and lease.contract is not None
+            and not lease.customer.is_non_billable_customer()
+        ):
             contract = lease.contract
 
         # Blank the PK to signal that a new instance has to be created

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -11,8 +11,9 @@ from applications.tests.factories import (
 )
 from berth_reservations.tests.conftest import *  # noqa
 from berth_reservations.tests.utils import MockResponse
+from customers.enums import OrganizationType
 from customers.services import HelsinkiProfileUser
-from customers.tests.factories import CustomerProfileFactory
+from customers.tests.factories import CustomerProfileFactory, OrganizationFactory
 from leases.tests.conftest import *  # noqa
 from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
 from resources.tests.conftest import *  # noqa
@@ -140,6 +141,11 @@ def _generate_order(order_type: str = None):
             price_unit=PriceUnits.PERCENTAGE,
         )
         OrderLineFactory(order=order, product=storage_on_ice, price=Decimal("15.00"))
+    elif order_type == "non_billable_customer_order":
+        OrganizationFactory(
+            customer=customer_profile, organization_type=OrganizationType.NON_BILLABLE
+        )
+        order = OrderFactory(customer=customer_profile, status=OrderStatus.WAITING)
     else:
         order = OrderFactory(customer=customer_profile)
     return order
@@ -174,6 +180,12 @@ def berth_order(customer_profile):
 @pytest.fixture
 def winter_storage_order(customer_profile):
     order = _generate_order("winter_storage_order")
+    return order
+
+
+@pytest.fixture
+def non_billable_customer_order(customer_profile):
+    order = _generate_order("non_billable_customer_order")
     return order
 
 

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -343,7 +343,12 @@ def approve_order(
             order.lease.application.status = ApplicationStatus.OFFER_SENT
             order.lease.application.save()
 
-    send_payment_notification(order, request, email, phone_number=order.customer_phone)
+    if order.customer.is_non_billable_customer():
+        order.set_status(OrderStatus.PAID_MANUALLY, "Non-billable customer.")
+    else:
+        send_payment_notification(
+            order, request, email, phone_number=order.customer_phone
+        )
 
 
 def send_cancellation_notice(order):


### PR DESCRIPTION
## Description :sparkles:

Do not send invoices if an order customer is non-billable and set the order status as paid when accepting the order.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1091](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1091):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest payments/tests/test_payments_utils.py::test_approve_order_with_non_billable_customer
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
