### PR TITLE
VEN-1137 | Mark refused berths available

### DIFF
--- a/leases/consts.py
+++ b/leases/consts.py
@@ -1,4 +1,9 @@
 from .enums import LeaseStatus
 
-ACTIVE_LEASE_STATUSES = (LeaseStatus.DRAFTED, LeaseStatus.OFFERED, LeaseStatus.PAID)
+ACTIVE_LEASE_STATUSES = (
+    LeaseStatus.DRAFTED,
+    LeaseStatus.OFFERED,
+    LeaseStatus.PAID,
+    LeaseStatus.ERROR,
+)
 INACTIVE_LEASE_STATUSES = (LeaseStatus.REFUSED, LeaseStatus.EXPIRED)


### PR DESCRIPTION
## Description :sparkles:
* Mark refused berths (and ws places) as available
When a berth was marked as refused but still had a paid lease on the
previous season, the checks were taking that as a valid condition and
kept the berth marked as not available.

Now, we discard the leases from the previous season that have already
been renewed so we only consider either:
1) leases on the current (or upcoming) season which have not been
   terminated or refused
2) leases on the previous season which have not been renewed and have
   been paid

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1137](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1137):** Mark refused leases as available berths

## Testing :alembic:
### Automated tests :gear:️
```
pytest resources/tests/test_resources_models.py
```

### Manual testing :construction_worker_man:
1. Generate a lease
2. Check the berth, it should be `not available`
3. Reject the lease (through the `cancelOrderMutation`)
4. Check the berth, it should be `available`
