### PR TITLE
VEN-1133 | Mark drafted, offered, and error leases as active

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -88,7 +88,7 @@ class BerthLeaseManager(models.Manager):
         current_season_start = calculate_berth_lease_start_date()
         today = date.today()
 
-        active_current_status = Q(status=LeaseStatus.PAID)
+        active_current_status = Q(status__in=ACTIVE_LEASE_STATUSES)
 
         if today < current_season_start:
             in_current_season = Q(start_date=current_season_start)

--- a/leases/tests/test_lease_models.py
+++ b/leases/tests/test_lease_models.py
@@ -12,6 +12,7 @@ from applications.tests.factories import (
 from berth_reservations.tests.factories import CustomerProfileFactory
 from customers.tests.factories import BoatFactory
 
+from ..consts import ACTIVE_LEASE_STATUSES
 from ..enums import LeaseStatus
 from ..models import (
     BerthLease,
@@ -310,9 +311,10 @@ def test_winter_storage_lease_application_different_customer(winter_storage_leas
     )
 
 
+@pytest.mark.parametrize("status", ACTIVE_LEASE_STATUSES)
 @freeze_time("2020-01-01T08:00:00Z")
-def test_berth_lease_is_active_before_season():
-    lease = BerthLeaseFactory(status=LeaseStatus.PAID)
+def test_berth_lease_is_active_before_season(status):
+    lease = BerthLeaseFactory(status=status)
 
     assert BerthLease.objects.get(id=lease.id).is_active
 


### PR DESCRIPTION
## Description :sparkles:
* Consider future leases as available if it's one of the `ACTIVE_LEASE_STATUSES` (drafted, offered, paid, error)

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1133](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1133):** Future leases are not active

## Testing :alembic:
### Automated tests :gear:️
```
pytest leases/tests/test_lease_models.py::test_berth_lease_is_active_before_season
```

### Manual testing :construction_worker_man:
Execute the query, all the leases should be `isActive = true`
```graphql
query Lease {
  berthLeases(startYear: 2021, first: 3, statuses: [OFFERED, DRAFTED]) {
    count
    edges {
      node {
        status
        isActive
      }
    }
  }
}
```
