### PR TITLE
VEN-700 | Allow leases to start on the day another lease ends

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -183,7 +183,7 @@ class BerthLease(AbstractLease):
         leases_for_given_period = BerthLease.objects.filter(
             berth=self.berth,
             start_date__lte=self.end_date,
-            end_date__gte=self.start_date,
+            end_date__gt=self.start_date,
             status__in=ACTIVE_LEASE_STATUSES,
         )
         creating = self._state.adding

--- a/leases/tests/test_lease_models.py
+++ b/leases/tests/test_lease_models.py
@@ -486,6 +486,17 @@ def test_berth_lease_non_overlapping_leases(berth):
     assert BerthLease.objects.count() == 2
 
 
+@freeze_time("2020-06-01T08:00:00Z")
+def test_allow_berth_lease_to_start_on_the_day_another_ends(berth):
+    lease = BerthLeaseFactory(
+        berth=berth, start_date="2020-01-01", end_date="2020-06-01"
+    )
+    assert not BerthLease.objects.get(id=lease.id).is_active
+
+    BerthLeaseFactory(berth=berth, start_date="2020-06-01", end_date="2020-09-14")
+    assert BerthLease.objects.count() == 2
+
+
 @freeze_time("2020-01-01T08:00:00Z")
 def test_winter_storage_lease_over_a_year_raise_error():
     with pytest.raises(ValidationError) as exception:


### PR DESCRIPTION
## Description :sparkles:

Allows overlapping project A end date & project B start date

## Issues :bug:
### Closes :no_good_woman:
**[VEN-700](https://helsinkisolutionoffice.atlassian.net/browse/VEN-700):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest leases/tests/test_lease_models.py::test_allow_berth_lease_to_start_on_the_day_another_ends
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
