### PR TITLE
VEN-935 | Rename cancelled_at variable on termination template

### DIFF
--- a/leases/notifications/dummy_context.py
+++ b/leases/notifications/dummy_context.py
@@ -22,12 +22,12 @@ def load_dummy_context():
             },
             NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE: {
                 "subject": NotificationType.BERTH_LEASE_TERMINATED_LEASE_NOTICE.label,
-                "cancellation_date": format_date(today(), locale="fi"),
+                "cancelled_at": format_date(today(), locale="fi"),
                 "lease": berth_lease,
             },
             NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE: {
                 "subject": NotificationType.WINTER_STORAGE_LEASE_TERMINATED_LEASE_NOTICE.label,
-                "cancellation_date": format_date(today(), locale="fi"),
+                "cancelled_at": format_date(today(), locale="fi"),
                 "lease": ws_lease,
             },
         }

--- a/templates/email/messages/berth_lease_termination_confirmation_en.html
+++ b/templates/email/messages/berth_lease_termination_confirmation_en.html
@@ -1,5 +1,5 @@
 <p>Dear customer, we have received your cancellation. The invoice, application and contract regarding the place
-    have been cancelled starting from {{ cancellation_date }}.</p>
+    have been cancelled starting from {{ cancelled_at }}.</p>
 
 <h3>Location</h3>
 

--- a/templates/email/messages/berth_lease_termination_confirmation_fi.html
+++ b/templates/email/messages/berth_lease_termination_confirmation_fi.html
@@ -1,5 +1,5 @@
 <p>Hyvä asiakas, olemme vastaanottaneet peruutuksen. Lasku, hakemus ja sopimus liittyen paikkaan on
-    peruttu {{ cancellation_date }} alkaen.</p>
+    peruttu {{ cancelled_at }} alkaen.</p>
 
 <h3>Kohde</h3>
 

--- a/templates/email/messages/berth_lease_termination_confirmation_sv.html
+++ b/templates/email/messages/berth_lease_termination_confirmation_sv.html
@@ -1,5 +1,5 @@
 <p>Bästa kund, vi har mottagit annulleringen. Fakturan, ansökan och avtalet relaterade till platsen har
-    annullerats {{ cancellation_date }} från.</p>
+    annullerats {{ cancelled_at }} från.</p>
 
 <h3>Område</h3>
 

--- a/templates/email/messages/general_cancel_confirmation_en.html
+++ b/templates/email/messages/general_cancel_confirmation_en.html
@@ -1,5 +1,5 @@
 <p>Dear customer, we have received your cancellation. The invoice, application and contract regarding the place
-    have been cancelled starting from {{ cancellation_date }}.</p>
+    have been cancelled starting from {{ cancelled_at }}.</p>
 
 <h3>Location</h3>
 

--- a/templates/email/messages/general_cancel_confirmation_fi.html
+++ b/templates/email/messages/general_cancel_confirmation_fi.html
@@ -1,5 +1,5 @@
 <p>Hyvä asiakas, olemme vastaanottaneet peruutuksen. Lasku, hakemus ja sopimus liittyen paikkaan on
-    peruttu {{ cancellation_date }} alkaen.</p>
+    peruttu {{ cancelled_at }} alkaen.</p>
 
 <h3>Kohde</h3>
 

--- a/templates/email/messages/general_cancel_confirmation_sv.html
+++ b/templates/email/messages/general_cancel_confirmation_sv.html
@@ -1,5 +1,5 @@
 <p>Bästa kund, vi har mottagit annulleringen. Fakturan, ansökan och avtalet relaterade till platsen har
-    annullerats {{ cancellation_date }} från.</p>
+    annullerats {{ cancelled_at }} från.</p>
 
 <h3>Område</h3>
 

--- a/templates/email/messages/ws_lease_termination_confirmation_en.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_en.html
@@ -1,5 +1,5 @@
 <p>Dear customer, we have received your cancellation. The invoice, application and contract regarding the place
-    have been cancelled starting from {{ cancellation_date }}.</p>
+    have been cancelled starting from {{ cancelled_at }}.</p>
 
 <h3>Location</h3>
 

--- a/templates/email/messages/ws_lease_termination_confirmation_fi.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_fi.html
@@ -1,5 +1,5 @@
 <p>Hyvä asiakas, olemme vastaanottaneet peruutuksen. Lasku, hakemus ja sopimus liittyen paikkaan on
-    peruttu {{ cancellation_date }} alkaen.</p>
+    peruttu {{ cancelled_at }} alkaen.</p>
 
 <h3>Kohde</h3>
 

--- a/templates/email/messages/ws_lease_termination_confirmation_sv.html
+++ b/templates/email/messages/ws_lease_termination_confirmation_sv.html
@@ -1,5 +1,5 @@
 <p>Bästa kund, vi har mottagit annulleringen. Fakturan, ansökan och avtalet relaterade till platsen har
-    annullerats {{ cancellation_date }} från.</p>
+    annullerats {{ cancelled_at }} från.</p>
 
 <h3>Område</h3>
 


### PR DESCRIPTION
## Description :sparkles:
* Rename `cancellation_date -> cancelled_at` variable on termination template

For consistency with the other timestamp variables, we will rename this to `cancelled_at`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-935](https://helsinkisolutionoffice.atlassian.net/browse/VEN-935):** Mutation to terminate a lease

### Related :handshake:
#469 
#470 

## Testing :alembic:
### Manual testing :construction_worker_man:
1. Go to the template on the admin
[http://localhost:8000/admin/django_ilmoitin/notificationtemplate/12/change/?language=en](http://localhost:8000/admin/django_ilmoitin/notificationtemplate/12/change/?language=en)
2. Hit `Preview`, the template should render correctly

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/15201480/109797273-eb659480-7c21-11eb-9090-01883fb53e56.png)
