### PR TITLE
VEN-1176 | Add is_invoiceable query for berths

### DIFF
--- a/resources/schema/queries.py
+++ b/resources/schema/queries.py
@@ -46,6 +46,7 @@ class Query:
         min_width=graphene.Float(),
         min_length=graphene.Float(),
         is_available=graphene.Boolean(),
+        is_invoiceable=graphene.Boolean(),
         description="If filtering by both pier and harbor and the pier does not belong to the given harbor, "
         "will return an empty list of edges."
         "\n\n**Requires permissions** to query `leases` field. "
@@ -120,6 +121,8 @@ class Query:
             filters &= Q(berth_type__length__gte=min_length)
         if "is_available" in kwargs:
             filters &= Q(is_available=kwargs.get("is_available"))
+        if "is_invoiceable" in kwargs:
+            filters &= Q(is_invoiceable=kwargs.get("is_invoiceable"))
 
         return info.context.berth_loader.load_many(
             keys=Berth.objects.filter(filters).values_list("id", flat=True)

--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -1162,3 +1162,22 @@ def test_pier_filtering_by_harbor(api_client):
 
     executed = api_client.execute(query)
     assert executed["data"] == {"piers": {"count": 1, "totalCount": 11}}
+
+
+def test_berth_is_invoiceable(api_client):
+    for _i in range(10):
+        BerthFactory()
+
+    BerthFactory(is_invoiceable=False)
+
+    query = """
+        {
+            berths(isInvoiceable: %s) {
+                count
+                totalCount
+            }
+        }
+    """
+
+    executed = api_client.execute(query % "false")
+    assert executed["data"] == {"berths": {"count": 1, "totalCount": 11}}


### PR DESCRIPTION
## Description :sparkles:

Add isInvoiceable query for berths.

## Issues :bug:
### Closes :no_good_woman:

**[VEN-1176](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1176)** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest resources/tests/test_resources_queries.py::test_berth_is_invoiceable
```

### Manual testing :construction_worker_man:

```
query getBerths {
  berths(isInvoiceable: false) {
    count
    totalCount
  }
}
```

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
