### PR TITLE
VEN-1159 | Fix the VismaPay payload fields

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -13,6 +13,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseServerError
 from django.utils.translation import gettext_lazy as _, override
 from requests.exceptions import RequestException
 
+from leases.enums import LeaseStatus
 from leases.utils import terminate_lease
 
 from ..enums import OrderRefundStatus, OrderStatus, OrderType
@@ -269,10 +270,10 @@ class BamboraPayformProvider(PaymentProvider):
     def initiate_refund(self, order: Order) -> OrderRefund:
         # Orders which are PAID_MANUALLY may not have an entry in Bambora,
         # so we can't guarantee that the refund will be executed
-        if order.status != OrderStatus.PAID:
-            raise ValidationError(
-                _("Cannot refund an order that has not been paid through VismaPay")
-            )
+        if (order.status != OrderStatus.PAID) or (
+            hasattr(order, "lease") and order.lease.status != LeaseStatus.PAID
+        ):
+            raise ValidationError(_("Cannot refund an order that is not paid"))
 
         order_token = (
             order.tokens.exclude(token__isnull=True, token__iexact="")

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -289,8 +289,9 @@ class BamboraPayformProvider(PaymentProvider):
         payload = {
             "version": "w3.1",
             "api_key": self.config.get(VENE_PAYMENTS_BAMBORA_API_KEY),
-            "amount": price_as_fractional_int(order.price),
+            "amount": price_as_fractional_int(order.total_price),
             "notify_url": self.get_notify_refund_url(),
+            "email": order.customer_email,
             "order_number": f"{order.order_number}-{order_token.created_at.timestamp()}",
         }
         self.payload_add_auth_code(payload)

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -58,7 +58,7 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
     assert refund.refund_id == "123456"
     assert refund.order == order
     assert refund.status == OrderRefundStatus.PENDING
-    assert refund.amount == order.price
+    assert refund.amount == order.total_price
 
     args = mock_call.call_args.kwargs.get("json")
     assert (
@@ -210,7 +210,9 @@ def test_handle_notify_request_success(
     order.lease.status = LeaseStatus.PAID
     order.lease.save()
     order.save()
-    refund = OrderRefundFactory(order=order, refund_id="1234567", amount=order.price)
+    refund = OrderRefundFactory(
+        order=order, refund_id="1234567", amount=order.total_price
+    )
 
     rf = RequestFactory()
     request = rf.get("/payments/notify_refund/", notify_success_params)
@@ -236,7 +238,9 @@ def test_handle_notify_request_payment_failed(provider_base_config, order):
     order.order_number = "abc123"
     order.status = OrderStatus.PAID
     order.save()
-    refund = OrderRefundFactory(order=order, refund_id="1234567", amount=order.price)
+    refund = OrderRefundFactory(
+        order=order, refund_id="1234567", amount=order.total_price
+    )
 
     params = {
         "AUTHCODE": "8CF2D0EA9947D09B707E3C2953EF3014F1AD12D2BB0DCDBAC3ABD4601B50462B",

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django.test.client import RequestFactory
 from django.utils.timezone import now
@@ -64,6 +65,80 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
         args.get("order_number")
         == f"{order.order_number}-{valid_token.created_at.timestamp()}"
     )
+
+
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@pytest.mark.parametrize(
+    "order_status",
+    [
+        OrderStatus.CANCELLED,
+        OrderStatus.ERROR,
+        OrderStatus.EXPIRED,
+        OrderStatus.PAID_MANUALLY,
+        OrderStatus.REFUNDED,
+        OrderStatus.REJECTED,
+        OrderStatus.WAITING,
+    ],
+)
+def test_initiate_refund_invalid_order_status(
+    provider_base_config: dict, order: Order, order_status
+):
+    """Test the request creator constructs the payload base and returns a url that contains a token"""
+    request = RequestFactory().request()
+    order.status = order_status
+    order.save()
+
+    OrderToken.objects.create(
+        order=order, token="98765", valid_until=now() - relativedelta(hours=1)
+    )
+    OrderToken.objects.create(
+        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+    )
+
+    payment_provider = create_bambora_provider(provider_base_config, request)
+    with pytest.raises(ValidationError) as exception:
+        payment_provider.initiate_refund(order)
+
+    assert "Cannot refund an order that is not paid" in str(exception)
+
+
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+@pytest.mark.parametrize(
+    "lease_status",
+    [
+        LeaseStatus.DRAFTED,
+        LeaseStatus.ERROR,
+        LeaseStatus.EXPIRED,
+        LeaseStatus.OFFERED,
+        LeaseStatus.TERMINATED,
+    ],
+)
+def test_initiate_refund_invalid_lease_status(
+    provider_base_config: dict, order: Order, lease_status
+):
+    """Test the request creator constructs the payload base and returns a url that contains a token"""
+    request = RequestFactory().request()
+    order.status = OrderStatus.PAID
+    order.lease.status = lease_status
+    order.lease.save()
+    order.save()
+
+    OrderToken.objects.create(
+        order=order, token="98765", valid_until=now() - relativedelta(hours=1)
+    )
+    OrderToken.objects.create(
+        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+    )
+
+    payment_provider = create_bambora_provider(provider_base_config, request)
+    with pytest.raises(ValidationError) as exception:
+        payment_provider.initiate_refund(order)
+
+    assert "Cannot refund an order that is not paid" in str(exception)
 
 
 @pytest.mark.parametrize(

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -39,6 +39,8 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
     """Test the request creator constructs the payload base and returns a url that contains a token"""
     request = RequestFactory().request()
     order.status = OrderStatus.PAID
+    order.lease.status = LeaseStatus.PAID
+    order.lease.save()
     order.save()
 
     OrderToken.objects.create(
@@ -169,6 +171,8 @@ def test_handle_initiate_refund_error_validation(order, provider_base_config):
         order=order, token="12345", valid_until=now() + relativedelta(days=7)
     )
     order.status = OrderStatus.PAID
+    order.lease.status = LeaseStatus.PAID
+    order.lease.save()
     order.save()
     request = RequestFactory().request()
 

--- a/payments/tests/test_payments_mutations_refunds.py
+++ b/payments/tests/test_payments_mutations_refunds.py
@@ -11,6 +11,7 @@ from berth_reservations.tests.utils import (
     assert_doesnt_exist,
     assert_not_enough_permissions,
 )
+from leases.enums import LeaseStatus
 from utils.relay import to_global_id
 
 from ..enums import OrderRefundStatus, OrderStatus
@@ -44,6 +45,8 @@ def test_refund_order(
 ):
     order.status = OrderStatus.PAID
     order.customer_email = "foo@email.com"
+    order.lease.status = LeaseStatus.PAID
+    order.lease.save()
     order.save()
     OrderToken.objects.create(
         order=order, token="1245", valid_until=today() + relativedelta(days=7)


### PR DESCRIPTION
## Description :sparkles:
* Replace the refunded amount for the actual order total, not just the product price
* Add the email to the payload for cases when the refund has to be confirmed by the customer

## Issues :bug:
### Related :handshake:
**[VEN-1159](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1159)**
#485 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform_refund.py
```