### PR TITLE
VEN-1251: do not filter by berth length when querying berths for an application

### DIFF
--- a/resources/tests/test_resources_queries.py
+++ b/resources/tests/test_resources_queries.py
@@ -616,10 +616,7 @@ def test_get_piers_filter_by_application(api_client, berth_application, berth):
     executed = api_client.execute(query)
 
     expected_berths = []
-    if (
-        berth.berth_type.length >= berth_application.boat_length
-        and berth.berth_type.width >= berth_application.boat_width
-    ):
+    if berth.berth_type.width >= berth_application.boat_width:
         expected_berths = [
             {
                 "node": {


### PR DESCRIPTION
Admins want to see also berths that are too short. Highlighting will be done in UI.

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1251](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1251):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
