### PR TITLE
 VEN-1201 | Accept/reject switch offer

### DIFF
--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -258,6 +258,17 @@ class AbstractOfferNode:
 
 
 class BerthSwitchOfferNode(DjangoObjectType, AbstractOfferNode):
+    """
+    TODO:
+     Add permission check for this node
+     when the customer login is sorted out
+     Example:
+         @classmethod
+         @view_permission_required(BerthSwitchOffer)
+         def get_queryset(cls, queryset, info):
+             return super().get_queryset(queryset, info)
+    """
+
     application = graphene.Field(
         "applications.new_schema.BerthApplicationNode", required=True
     )
@@ -268,11 +279,6 @@ class BerthSwitchOfferNode(DjangoObjectType, AbstractOfferNode):
         model = BerthSwitchOffer
         interfaces = (graphene.relay.Node,)
         connection_class = CountConnection
-
-    @classmethod
-    @view_permission_required(BerthSwitchOffer)
-    def get_queryset(cls, queryset, info):
-        return super().get_queryset(queryset, info)
 
 
 class OrderDetailsType(graphene.ObjectType):

--- a/payments/tests/test_payments_mutations_accept_berth_switch_offer.py
+++ b/payments/tests/test_payments_mutations_accept_berth_switch_offer.py
@@ -1,0 +1,100 @@
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from berth_reservations.tests.factories import CustomerProfileFactory
+from berth_reservations.tests.utils import assert_doesnt_exist
+from leases.enums import LeaseStatus
+from leases.models import BerthLease
+from leases.tests.factories import BerthLeaseFactory
+from leases.utils import (
+    calculate_berth_lease_end_date,
+    calculate_berth_lease_start_date,
+)
+from payments.enums import OfferStatus
+from payments.schema.types import BerthSwitchOfferNode
+from payments.tests.factories import BerthSwitchOfferFactory
+from utils.relay import to_global_id
+
+ACCEPT_BERTH_SWITCH_OFFER_MUTATION = """
+mutation ACCEPT_BERTH_SWITCH_OFFER_MUTATION($input: AcceptBerthSwitchOfferMutationInput!) {
+    acceptBerthSwitchOffer(input: $input) {
+        __typename
+    }
+}
+"""
+
+
+@freeze_time("2020-02-01T08:00:00Z")
+def test_accept_offer(api_client):
+    customer = CustomerProfileFactory()
+    due_date = date.today() + relativedelta(days=14)
+    berth_switch_offer = BerthSwitchOfferFactory(
+        customer=customer,
+        due_date=due_date,
+        status=OfferStatus.OFFERED,
+        lease=BerthLeaseFactory(
+            customer=customer,
+            start_date=calculate_berth_lease_start_date(),
+            end_date=calculate_berth_lease_end_date(),
+            status=LeaseStatus.PAID,
+        ),
+    )
+
+    variables = {
+        "offerId": to_global_id(BerthSwitchOfferNode, berth_switch_offer.id),
+        "isAccepted": True,
+    }
+
+    api_client.execute(ACCEPT_BERTH_SWITCH_OFFER_MUTATION, input=variables)
+
+    berth_switch_offer.refresh_from_db()
+    berth_switch_offer.lease.refresh_from_db()
+
+    assert berth_switch_offer.status == OfferStatus.ACCEPTED
+    assert berth_switch_offer.lease.status == LeaseStatus.TERMINATED
+
+    new_lease = BerthLease.objects.exclude(id=berth_switch_offer.lease_id).first()
+    assert new_lease.status == LeaseStatus.PAID
+
+
+@freeze_time("2020-02-01T08:00:00Z")
+def test_reject_offer(api_client):
+    customer = CustomerProfileFactory()
+    due_date = date.today() + relativedelta(days=14)
+    berth_switch_offer = BerthSwitchOfferFactory(
+        customer=customer,
+        due_date=due_date,
+        status=OfferStatus.OFFERED,
+        lease=BerthLeaseFactory(
+            customer=customer,
+            start_date=calculate_berth_lease_start_date(),
+            end_date=calculate_berth_lease_end_date(),
+            status=LeaseStatus.PAID,
+        ),
+    )
+
+    variables = {
+        "offerId": to_global_id(BerthSwitchOfferNode, berth_switch_offer.id),
+        "isAccepted": False,
+    }
+
+    api_client.execute(ACCEPT_BERTH_SWITCH_OFFER_MUTATION, input=variables)
+
+    berth_switch_offer.refresh_from_db()
+    berth_switch_offer.lease.refresh_from_db()
+
+    assert berth_switch_offer.status == OfferStatus.REJECTED
+    assert berth_switch_offer.lease.status == LeaseStatus.PAID
+    assert BerthLease.objects.all().count() == 1
+
+
+def test_accept_berth_switch_offer_does_not_exist(api_client):
+    variables = {
+        "offerId": "test",
+        "isAccepted": True,
+    }
+    executed = api_client.execute(ACCEPT_BERTH_SWITCH_OFFER_MUTATION, input=variables)
+
+    assert_doesnt_exist("BerthSwitchOffer", executed)

--- a/payments/tests/test_payments_queries_berth_switch_offers.py
+++ b/payments/tests/test_payments_queries_berth_switch_offers.py
@@ -1,7 +1,6 @@
 import pytest
 
 from applications.new_schema import BerthApplicationNode
-from berth_reservations.tests.utils import assert_not_enough_permissions
 from customers.schema import ProfileNode
 from leases.schema import BerthLeaseNode
 from resources.schema import BerthNode
@@ -54,15 +53,6 @@ def test_get_berth_switch_offers(berth_switch_offer, api_client):
     }
 
 
-@pytest.mark.parametrize(
-    "api_client", ["api_client", "user", "harbor_services"], indirect=True,
-)
-def test_get_berth_switch_offers_not_enough_permissions(api_client):
-    executed = api_client.execute(BERTH_SWITCH_OFFERS_QUERY)
-
-    assert_not_enough_permissions(executed)
-
-
 BERTH_SWITCH_OFFER_QUERY = """
 query BERTH_SWITCH_OFFER_QUERY  {
     berthSwitchOffer(id: "%s") {
@@ -102,13 +92,3 @@ def test_get_berth_switch_offer(berth_switch_offer, api_client):
         "lease": {"id": to_global_id(BerthLeaseNode, berth_switch_offer.lease.id)},
         "berth": {"id": to_global_id(BerthNode, berth_switch_offer.berth.id)},
     }
-
-
-@pytest.mark.parametrize(
-    "api_client", ["api_client", "user", "harbor_services"], indirect=True,
-)
-def test_get_berth_switch_offer_not_enough_permissions(berth_switch_offer, api_client):
-    offer_id = to_global_id(BerthSwitchOfferNode, berth_switch_offer.id)
-    executed = api_client.execute(BERTH_SWITCH_OFFER_QUERY % offer_id)
-
-    assert_not_enough_permissions(executed)


### PR DESCRIPTION
## Description :sparkles:

Add a mutation for accepting & rejecting offers. The accepting uses the logic of berth switching from #487.

Rejecting will mark the offer as REJECTED and nothing else is changed.

The mutation will return the offer and the new lease.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1201](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1201)** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest test_payments_mutations_accept_berth_switch_offer.py
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

### TODO:
- Restore the permission check for `BerthSwitchOfferNode` when the customer login is sorted out.