### PR TITLE
VEN-1216 | Update user profile query permissions and add offers to profile query

### DIFF
--- a/customers/schema/types.py
+++ b/customers/schema/types.py
@@ -9,8 +9,9 @@ from graphql_jwt.decorators import login_required
 from applications.models import BerthApplication
 from applications.new_schema import BerthApplicationNode, WinterStorageApplicationNode
 from applications.new_schema.types import WinterStorageApplicationFilter
-from leases.models import BerthLease
+from leases.models import BerthLease, WinterStorageLease
 from leases.schema import BerthLeaseNode, WinterStorageLeaseNode
+from payments.models import BerthSwitchOffer, Order
 from utils.relay import get_node_from_global_id, return_node_if_user_has_permissions
 from utils.schema import CountConnection
 
@@ -100,6 +101,7 @@ class ProfileNode(DjangoObjectType):
             "winter_storage_applications",
             "winter_storage_leases",
             "orders",
+            "offers",
         )
         interfaces = (relay.Node,)
         connection_class = CountConnection
@@ -134,6 +136,7 @@ class ProfileNode(DjangoObjectType):
     )
     winter_storage_leases = DjangoConnectionField(WinterStorageLeaseNode)
     orders = DjangoConnectionField("payments.schema.OrderNode")
+    offers = DjangoConnectionField("payments.schema.BerthSwitchOfferNode")
 
     def resolve_berth_applications(self, info, **kwargs):
         return self.berth_applications.order_by("created_at")
@@ -145,7 +148,15 @@ class ProfileNode(DjangoObjectType):
     def __resolve_reference(self, info, **kwargs):
         profile = get_node_from_global_id(info, self.id, only_type=ProfileNode)
         return return_node_if_user_has_permissions(
-            profile, info.context.user, CustomerProfile, BerthApplication, BerthLease
+            profile,
+            info.context.user,
+            CustomerProfile,
+            BerthApplication,
+            BerthLease,
+            BerthSwitchOffer,
+            Boat,
+            Order,
+            WinterStorageLease,
         )
 
     @classmethod
@@ -153,5 +164,13 @@ class ProfileNode(DjangoObjectType):
     def get_node(cls, info, id):
         node = super().get_node(info, id)
         return return_node_if_user_has_permissions(
-            node, info.context.user, CustomerProfile, BerthApplication, BerthLease
+            node,
+            info.context.user,
+            CustomerProfile,
+            BerthApplication,
+            BerthLease,
+            BerthSwitchOffer,
+            Boat,
+            Order,
+            WinterStorageLease,
         )

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -524,9 +524,8 @@ def test_get_orders(api_client, order):
 @pytest.mark.parametrize(
     "api_client", ["api_client", "user", "harbor_services"], indirect=True,
 )
-def test_get_orders_not_enough_permissions(api_client):
+def test_get_orders_not_enough_permissions(api_client, order):
     executed = api_client.execute(ORDERS_QUERY)
-
     assert_not_enough_permissions(executed)
 
 


### PR DESCRIPTION
## Description :sparkles:

- Allow customers to view their own Orders and Offers.
- Add BerthSwitchOffer to be queried through ProfileNode.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1216](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1216): Query for the customer personal information** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest customers/tests/test_customers_queries.py::test_query_berth_profile_self_user
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
