### PR TITLE
VEN-1268 | Add berth information to order details

### DIFF
--- a/payments/schema/queries.py
+++ b/payments/schema/queries.py
@@ -157,4 +157,15 @@ class OldAPIQuery:
             elif isinstance(order.lease, WinterStorageLease):
                 order_type = OrderTypeEnum.WINTER_STORAGE
 
-        return OrderDetailsType(status=order.status, order_type=order_type)
+        has_berth = order.lease and isinstance(order.lease, BerthLease)
+        harbor_name = order.lease.berth.pier.harbor.name if has_berth else ""
+        pier_identifier = order.lease.berth.pier.identifier if has_berth else ""
+        berth_number = order.lease.berth.number if has_berth else ""
+
+        return OrderDetailsType(
+            status=order.status,
+            order_type=order_type,
+            harbor=harbor_name,
+            pier=pier_identifier,
+            berth=berth_number,
+        )

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -296,6 +296,9 @@ class BerthSwitchOfferNode(DjangoObjectType, AbstractOfferNode):
 class OrderDetailsType(graphene.ObjectType):
     order_type = OrderTypeEnum(required=True)
     status = OrderStatusEnum(required=True)
+    harbor = graphene.String(required=True)
+    pier = graphene.String(required=True)
+    berth = graphene.String(required=True)
 
 
 class FailedOrderType(graphene.ObjectType):

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -674,6 +674,9 @@ query ORDER_DETAILS {
     orderDetails(orderNumber: "%s") {
         orderType
         status
+        harbor
+        pier
+        berth
     }
 }
 """
@@ -701,9 +704,17 @@ def test_get_order_status(old_schema_api_client, status, order: Order):
     else:
         order_type = OrderTypeEnum.UNKNOWN
 
+    has_berth = order.lease and isinstance(order.lease, BerthLease)
+    harbor_name = order.lease.berth.pier.harbor.name if has_berth else ""
+    pier_identifier = order.lease.berth.pier.identifier if has_berth else ""
+    berth_number = order.lease.berth.number if has_berth else ""
+
     assert executed["data"]["orderDetails"] == {
         "orderType": OrderTypeEnum.get(order_type).name,
         "status": OrderStatusEnum.get(order.status).name,
+        "harbor": harbor_name,
+        "pier": pier_identifier,
+        "berth": berth_number,
     }
 
 


### PR DESCRIPTION
## Description :sparkles:

Add berth information to OrderDetailsType. The 3 added fields include:

- harbor name
- pier identifier
- berth number

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1268](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1268): Add berth information to order details** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest payments/tests/test_payments_queries.py::test_get_order_status
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
