### PR TITLE
VEN-1277 | Fix Talpa ID for storage on ice

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -16,7 +16,7 @@ from requests.exceptions import RequestException
 from leases.enums import LeaseStatus
 from leases.utils import terminate_lease
 
-from ..enums import OrderRefundStatus, OrderStatus, OrderType
+from ..enums import OrderRefundStatus, OrderStatus, ProductServiceType
 from ..exceptions import (
     DuplicateOrderError,
     ExpiredOrderError,
@@ -25,14 +25,7 @@ from ..exceptions import (
     ServiceUnavailableError,
     UnknownReturnCodeError,
 )
-from ..models import (
-    AdditionalProduct,
-    BerthProduct,
-    Order,
-    OrderLine,
-    OrderRefund,
-    OrderToken,
-)
+from ..models import AdditionalProduct, Order, OrderLine, OrderRefund, OrderToken
 from ..utils import get_talpa_product_id, price_as_fractional_int, resolve_area
 from .base import PaymentProvider
 
@@ -212,7 +205,12 @@ class BamboraPayformProvider(PaymentProvider):
                 product_name = product.name
             items.append(
                 {
-                    "id": get_talpa_product_id(product.id, area),
+                    "id": get_talpa_product_id(
+                        product.id,
+                        area,
+                        is_storage_on_ice=product.service
+                        == ProductServiceType.STORAGE_ON_ICE,
+                    ),
                     "title": product_name,
                     "price": price_as_fractional_int(order_line.price),
                     "pretax_price": price_as_fractional_int(order_line.pretax_price),

--- a/payments/tests/test_payments_product_ids.py
+++ b/payments/tests/test_payments_product_ids.py
@@ -1,41 +1,50 @@
 import pytest  # noqa
 
-from payments.tests.factories import BerthProductFactory, WinterStorageProductFactory
+from payments.tests.factories import (
+    AdditionalProductFactory,
+    BerthProductFactory,
+    WinterStorageProductFactory,
+)
 from payments.utils import get_talpa_product_id
 from resources.tests.factories import HarborFactory, WinterStorageAreaFactory
 
 
-def test_berth_product_east():
-    harbor = HarborFactory(region="east")
-    berth_product = BerthProductFactory()
+@pytest.mark.parametrize(
+    "region,business_unit,internal_order",
+    [("east", "2923301", "2923301100"), ("west", "2923302", "2923302200")],
+)
+def test_berth_product(customer_profile, region, business_unit, internal_order):
+    harbor = HarborFactory(region=region)
+    product = BerthProductFactory()
     assert (
-        get_talpa_product_id(berth_product.id, harbor)
-        == f"340100_2923301_2923301100_ _292015_44_{berth_product.id}"
+        get_talpa_product_id(product.id, harbor)
+        == f"340100_{business_unit}_{internal_order}_ _292015_44_{product.id}"
     )
 
 
-def test_berth_product_west():
-    harbor = HarborFactory(region="west")
-    berth_product = BerthProductFactory()
+@pytest.mark.parametrize(
+    "region,business_unit,internal_order",
+    [("east", "2923301", "2923301100"), ("west", "2923302", "2923302200")],
+)
+def test_winter_storage_product(
+    customer_profile, region, business_unit, internal_order
+):
+    area = WinterStorageAreaFactory(region=region)
+    product = WinterStorageProductFactory(winter_storage_area=area)
     assert (
-        get_talpa_product_id(berth_product.id, harbor)
-        == f"340100_2923302_2923302200_ _292015_44_{berth_product.id}"
+        get_talpa_product_id(product.id, area)
+        == f"340100_{business_unit}_{internal_order}_ _292014_44_{product.id}"
     )
 
 
-def test_winter_storage_product_east():
-    area = WinterStorageAreaFactory(region="east")
-    winter_storage_product = WinterStorageProductFactory(winter_storage_area=area)
+@pytest.mark.parametrize(
+    "region,business_unit,internal_order",
+    [("east", "2923301", "2923301100"), ("west", "2923302", "2923302200")],
+)
+def test_storage_on_ice(customer_profile, region, business_unit, internal_order):
+    harbor = HarborFactory(region=region)
+    product = AdditionalProductFactory()
     assert (
-        get_talpa_product_id(winter_storage_product.id, area)
-        == f"340100_2923301_2923301100_ _292014_44_{winter_storage_product.id}"
-    )
-
-
-def test_winter_storage_product_west():
-    area = WinterStorageAreaFactory(region="west")
-    winter_storage_product = WinterStorageProductFactory(winter_storage_area=area)
-    assert (
-        get_talpa_product_id(winter_storage_product.id, area)
-        == f"340100_2923302_2923302200_ _292014_44_{winter_storage_product.id}"
+        get_talpa_product_id(product.id, harbor, True)
+        == f"340100_{business_unit}_{internal_order}_ _292014_44_{product.id}"
     )


### PR DESCRIPTION
## Description :sparkles:
Storage on ice products have a different `function area` (Toimintoalue), even when the corresponding area is a harbor (coming from the lease). This fixes the calculation of the Talpa ID for storage on ice additional products.

* Extract `resolve_area` to a separate util
* Refactor the tests for `product_id`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1277](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1277):** Storing on ice needs proper Talpa ID

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_product_ids.py

# Test that the bambora flow works for storage on ice
$ pytest payments/tests/test_bambora_payform.py::test_payload_additional_product_order
```

### Manual test 👷 
Check the Talpa product ID on the Django Admin for this order: https://berth-reservations-ven-1277-fix-storage-o-6b.test.kuva.hel.ninja/admin/payments/order/17967a8a-96fe-4e67-81bd-1f97194f96ab/change/

The credentials are:
```
user: admin
pass: adminpass
```

For the fields, it should have the corresponding values (separated by an underscore), since the harbor/area is on the east:
```
Tilinumero                      340100
Tulosyksikkö                    2923301
Sisäinen Tilaus                 2923301100
Projekti                        <blank>
Toimintoalue                    292014
ALV-koodi                       44
Vapaaehtoinen Oma Tuotenumero   <uuid>
```