### PR TITLE
VEN-1269 | Add is_application_order to OrderDetails

### DIFF
--- a/payments/schema/queries.py
+++ b/payments/schema/queries.py
@@ -144,6 +144,11 @@ class OldAPIQuery:
             raise VenepaikkaGraphQLError(e)
 
         order_type = OrderTypeEnum.UNKNOWN
+        is_application_order = (
+            hasattr(order, "lease")
+            and getattr(order.lease, "application", None) is not None
+        )
+
         if order.order_type == OrderType.ADDITIONAL_PRODUCT_ORDER:
             order_type = OrderTypeEnum.ADDITIONAL_PRODUCT
         elif order.product:
@@ -168,4 +173,5 @@ class OldAPIQuery:
             harbor=harbor_name,
             pier=pier_identifier,
             berth=berth_number,
+            is_application_order=is_application_order,
         )

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -299,6 +299,7 @@ class OrderDetailsType(graphene.ObjectType):
     harbor = graphene.String(required=True)
     pier = graphene.String(required=True)
     berth = graphene.String(required=True)
+    is_application_order = graphene.Boolean(required=True)
 
 
 class FailedOrderType(graphene.ObjectType):

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -677,6 +677,7 @@ query ORDER_DETAILS {
         harbor
         pier
         berth
+        isApplicationOrder
     }
 }
 """
@@ -687,8 +688,15 @@ query ORDER_DETAILS {
     ["berth_order", "winter_storage_order", "empty_order", "additional_product_order"],
     indirect=True,
 )
+@pytest.mark.parametrize("has_application", [True, False])
 @pytest.mark.parametrize("status", OrderStatus.values)
-def test_get_order_status(old_schema_api_client, status, order: Order):
+def test_get_order_status(
+    old_schema_api_client, status, has_application: bool, order: Order
+):
+    if not has_application and order.lease:
+        order.lease.application = None
+        order.lease.save()
+
     order.status = status
     order.save()
 
@@ -715,6 +723,7 @@ def test_get_order_status(old_schema_api_client, status, order: Order):
         "harbor": harbor_name,
         "pier": pier_identifier,
         "berth": berth_number,
+        "isApplicationOrder": has_application and order.lease is not None,
     }
 
 


### PR DESCRIPTION
## Description :sparkles:
* Add `is_application_order` to `OrderDetailsType`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1269](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1269):** Add is_application_order to OrderDetailsType

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_queries.py::test_get_order_status
```