### PR TITLE
VEN-1208: fix expire old offers cronjob to use proper OfferStatus

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -110,7 +110,7 @@ jobs:
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
 
-      - name: Deploy Order Expiration Cronjob
+      - name: Deploy Offer Expiration Cronjob
         uses: City-of-Helsinki/setup-cronjob-action@main
         with:
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -83,7 +83,7 @@ jobs:
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
 
-      - name: Deploy Order Expiration Cronjob
+      - name: Deploy Offer Expiration Cronjob
         uses: City-of-Helsinki/setup-cronjob-action@main
         with:
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -98,7 +98,7 @@ jobs:
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
 
-      - name: Deploy Order Expiration Cronjob
+      - name: Deploy Offer Expiration Cronjob
         uses: City-of-Helsinki/setup-cronjob-action@main
         with:
           image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}

--- a/payments/management/commands/expire_too_old_offers.py
+++ b/payments/management/commands/expire_too_old_offers.py
@@ -6,7 +6,7 @@ from .. import base_expiration_command
 
 
 class Command(base_expiration_command.ExpirationCommand):
-    help = 'Sets too old offers from state "waiting" to state "expired".'
+    help = 'Sets too old offers from state "offered" to state "expired".'
     feature_flag_name = "OFFER_EXPIRATION_CRONJOB_ENABLED"
 
     @atomic

--- a/payments/models.py
+++ b/payments/models.py
@@ -1097,7 +1097,7 @@ class BerthSwitchOfferManager(models.Manager):
 
         expire_before_date = date.today() - timedelta(days=older_than_days)
         too_old_pending_offers = self.get_queryset().filter(
-            status=OfferStatus.DRAFTED, due_date__lt=expire_before_date,
+            status=OfferStatus.OFFERED, due_date__lt=expire_before_date,
         )
         if not dry_run:
             for offer in too_old_pending_offers:

--- a/payments/tests/test_payments_offer_expiration.py
+++ b/payments/tests/test_payments_offer_expiration.py
@@ -13,12 +13,14 @@ from payments.tests.factories import BerthSwitchOfferFactory
 @freeze_time("2021-01-09T08:00:00Z")
 def test_expire_too_old_offers():
     offer = BerthSwitchOfferFactory(due_date=datetime.date(2021, 1, 2),)
+    offer.status = OfferStatus.OFFERED
+    offer.save()
     assert (
         BerthSwitchOffer.objects.expire_too_old_offers(older_than_days=7, dry_run=False)
         == 0
     )
     offer.refresh_from_db()
-    assert offer.status == OfferStatus.DRAFTED
+    assert offer.status == OfferStatus.OFFERED
     offer.due_date = datetime.date(2021, 1, 1)
     offer.save()
 


### PR DESCRIPTION
Also fix cronjob names in kubernetes config

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1208](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1208):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:
In Django admin, verify that offer 3a054023-8f6b-4b4b-b701-42576471ad81 status is OFFERED and due_date is 15.3.2021
In pod, run:
python manage.py expire_too_old_offers
Last line of output should be: "expire_too_old_offers done, 1 object(s) were expired."

Verify that the offer status has changed to expired.
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
