### PR TITLE
VEN-1208 | Proper status transition for expiring offers

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -1101,8 +1101,10 @@ class BerthSwitchOfferManager(models.Manager):
         )
         if not dry_run:
             for offer in too_old_pending_offers:
-                offer.status = OfferStatus.EXPIRED
-                offer.save()
+                offer.set_status(
+                    OfferStatus.EXPIRED,
+                    comment=f"{_('Offer expired at')} {expire_before_date}",
+                )
         return len(too_old_pending_offers)
 
 


### PR DESCRIPTION
## Description :sparkles:
* Use `set_status` for expiring orders instead of manually setting the status