### PR TITLE
VEN-1277 | Get the correct Talpa ID on Order admin

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -221,7 +221,7 @@ class OrderAdmin(admin.ModelAdmin):
 
     def talpa_product_id(self, obj):
         return (
-            get_talpa_product_id(obj.product.id, resolve_area(obj.area))
+            get_talpa_product_id(obj.product.id, resolve_area(obj))
             if hasattr(obj, "product")
             else "-"
         )


### PR DESCRIPTION
## Description :sparkles:
* Pass the correct property to the `get_area` so the Talpa ID is shown properly