### PR TITLE
VEN-1277 | Fix test for additional product storage on ice payload

### DIFF
--- a/payments/tests/test_bambora_payform.py
+++ b/payments/tests/test_bambora_payform.py
@@ -1,4 +1,5 @@
 import hmac
+import random
 from decimal import Decimal
 from unittest import mock
 
@@ -149,7 +150,16 @@ def test_payload_additional_product_order(
 ):
     if storage_on_ice:
         additional_product.service = ProductServiceType.STORAGE_ON_ICE
-        additional_product.save()
+    else:
+        additional_product.service = random.choice(
+            list(
+                filter(
+                    lambda x: x != ProductServiceType.STORAGE_ON_ICE,
+                    ProductServiceType.values,
+                )
+            )
+        )
+    additional_product.save()
 
     berth_product = BerthProductFactory(
         min_width=berth_lease.berth.berth_type.width - 1,


### PR DESCRIPTION
## Description :sparkles:
* Some tests which should not have storage on ice were getting the value because of the randomness, this makes sure that we don't get it.

## Testing ⚗️ 
### Automated testing ⚙️ 
```shell
$ pytest payments/tests/test_bambora_payform.py::test_payload_additional_product_order
```