### PR TITLE
VEN-1211: Mutation to cancel switch offer

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -1147,7 +1147,11 @@ class BerthSwitchOffer(AbstractOffer):
             raise ValidationError(_("The application has to be a switch application"))
 
         # Validate that once the offer has been sent, it will have a due date
-        if self.status != OfferStatus.DRAFTED and not self.due_date:
+        # If offer is transitioned from DRAFTED directly to CANCELLED, then the due date is not set.
+        if (
+            self.status not in [OfferStatus.DRAFTED, OfferStatus.CANCELLED]
+            and not self.due_date
+        ):
             raise ValidationError(_("The offer must have a due date before sending it"))
 
         # Validate that the lease can only be from the current season

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -1019,17 +1019,17 @@ def test_order_due_date_has_to_be_set_for_order_in_offered_status(
     assert "Order cannot be offered without a due date" in errors
 
 
-def test_offer_without_due_date_drafted(berth_switch_offer):
-    berth_switch_offer.status = OfferStatus.DRAFTED
+@pytest.mark.parametrize(
+    "status", [OfferStatus.CANCELLED, OfferStatus.DRAFTED],
+)
+def test_offer_due_date_not_required(berth_switch_offer, status):
+    berth_switch_offer.status = status
     berth_switch_offer.due_date = None
     berth_switch_offer.save()
     assert berth_switch_offer.due_date is None
 
 
-@pytest.mark.parametrize(
-    "status", [OfferStatus.CANCELLED, OfferStatus.OFFERED],
-)
-def test_offer_without_due_date_not_drafted(berth_switch_offer, status):
+def test_offer_due_date_required(berth_switch_offer):
     berth_switch_offer.status = OfferStatus.DRAFTED
     berth_switch_offer.due_date = None
     berth_switch_offer.save()
@@ -1037,7 +1037,7 @@ def test_offer_without_due_date_not_drafted(berth_switch_offer, status):
     assert berth_switch_offer.due_date is None
 
     with pytest.raises(ValidationError) as exception:
-        berth_switch_offer.set_status(status)
+        berth_switch_offer.set_status(OfferStatus.OFFERED)
 
     assert "The offer must have a due date before sending it" in str(exception)
 

--- a/payments/tests/test_payments_mutations_update_offer.py
+++ b/payments/tests/test_payments_mutations_update_offer.py
@@ -1,0 +1,133 @@
+import datetime
+import uuid
+
+import pytest
+from freezegun import freeze_time
+
+from applications.new_schema import BerthApplicationNode
+from berth_reservations.tests.utils import (
+    assert_doesnt_exist,
+    assert_not_enough_permissions,
+)
+from customers.schema import ProfileNode
+from leases.enums import LeaseStatus
+from leases.schema import BerthLeaseNode
+from resources.schema import BerthNode
+from utils.relay import to_global_id
+
+from ..enums import OfferStatus, OrderStatus
+from ..models import BerthSwitchOffer
+from ..schema.types import BerthSwitchOfferNode, OfferStatusEnum
+
+UPDATE_OFFER_MUTATION = """
+mutation UPDATE_OFFER($input: UpdateBerthSwitchOfferMutationInput!) {
+    updateBerthSwitchOffer(input: $input) {
+        berthSwitchOffer {
+            id
+            offerNumber
+            dueDate
+            status
+            customerFirstName
+            customerLastName
+            customer {
+                id
+            }
+            berth {
+                id
+            }
+            application {
+                id
+            }
+            lease {
+                id
+            }
+        }
+    }
+}
+"""
+
+
+@freeze_time("2021-01-01T08:00:00Z")
+@pytest.mark.parametrize(
+    "api_client", ["berth_services"], indirect=True,
+)
+@pytest.mark.parametrize("initial_status", [OfferStatus.OFFERED, OfferStatus.DRAFTED])
+@pytest.mark.parametrize("due_date", [datetime.date(2021, 1, 31), None])
+def test_set_offer_status_to_cancelled(
+    berth_switch_offer, due_date, api_client, initial_status
+):
+    if initial_status == OfferStatus.DRAFTED:
+        berth_switch_offer.due_date = None
+    else:
+        berth_switch_offer.due_date = datetime.date(2021, 1, 15)
+    berth_switch_offer.status = initial_status
+    berth_switch_offer.save()
+    global_id = to_global_id(BerthSwitchOfferNode, berth_switch_offer.id)
+
+    variables = {
+        "id": global_id,
+        "status": OfferStatusEnum.get(OfferStatus.CANCELLED).name,
+    }
+    if due_date:
+        variables["dueDate"] = due_date
+
+    assert BerthSwitchOffer.objects.count() == 1
+
+    executed = api_client.execute(UPDATE_OFFER_MUTATION, input=variables)
+
+    assert BerthSwitchOffer.objects.count() == 1
+
+    expected_due_date = None
+    if due_date:
+        expected_due_date = str(due_date)
+    elif berth_switch_offer.due_date:
+        expected_due_date = str(berth_switch_offer.due_date)
+
+    assert executed["data"]["updateBerthSwitchOffer"]["berthSwitchOffer"] == {
+        "id": variables["id"],
+        "status": OfferStatus.CANCELLED.name,
+        "dueDate": expected_due_date,
+        "offerNumber": berth_switch_offer.offer_number,
+        "customerFirstName": berth_switch_offer.customer_first_name,
+        "customerLastName": berth_switch_offer.customer_last_name,
+        "customer": {"id": to_global_id(ProfileNode, berth_switch_offer.customer.id)},
+        "berth": {"id": to_global_id(BerthNode, berth_switch_offer.berth.id)},
+        "application": {
+            "id": to_global_id(BerthApplicationNode, berth_switch_offer.application.id)
+        },
+        "lease": {"id": to_global_id(BerthLeaseNode, berth_switch_offer.lease.id)},
+    }
+    berth_switch_offer.refresh_from_db()
+    berth_switch_offer.lease.refresh_from_db()
+    assert berth_switch_offer.log_entries.count() == 1
+    log_entry = berth_switch_offer.log_entries.first()
+    assert log_entry.to_status == OrderStatus.CANCELLED
+    assert "Manually updated by admin" in log_entry.comment
+    assert berth_switch_offer.lease.status == LeaseStatus.PAID
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["api_client", "user", "harbor_services", "berth_supervisor", "berth_handler"],
+    indirect=True,
+)
+def test_update_order_not_enough_permissions(api_client):
+    variables = {
+        "id": to_global_id(BerthSwitchOfferNode, uuid.uuid4()),
+    }
+
+    assert BerthSwitchOffer.objects.count() == 0
+
+    executed = api_client.execute(UPDATE_OFFER_MUTATION, input=variables)
+
+    assert BerthSwitchOffer.objects.count() == 0
+    assert_not_enough_permissions(executed)
+
+
+def test_update_offer_does_not_exist(superuser_api_client):
+    variables = {
+        "id": to_global_id(BerthSwitchOfferNode, uuid.uuid4()),
+    }
+    executed = superuser_api_client.execute(UPDATE_OFFER_MUTATION, input=variables)
+
+    assert_doesnt_exist("BerthSwitchOffer", executed)


### PR DESCRIPTION
## Description :sparkles:

Added a UpdateBerthSwitchOfferMutation, which currently supports just changing the offer status and due_date (it's based on the corresponding UpdateOrderMutation so it was easiest to do this way).

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1211](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1211):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
