### PR TITLE
VEN-1262 | Create boat when a lease is created

### DIFF
--- a/leases/schema/utils.py
+++ b/leases/schema/utils.py
@@ -1,4 +1,11 @@
-from utils.relay import to_global_id
+from typing import Optional
+
+from django.utils.translation import gettext_lazy as _
+
+from berth_reservations.exceptions import VenepaikkaGraphQLError
+from customers.models import Boat
+from resources.models import BoatType
+from utils.relay import get_node_from_global_id, to_global_id
 
 
 def parse_invoicing_result(node_type):
@@ -10,3 +17,44 @@ def parse_invoicing_result(node_type):
         return {"id": to_global_id(node_type, id), "error": error}
 
     return parse_to_dict
+
+
+def lookup_or_create_boat(info, input: dict) -> Optional[Boat]:
+    boat: Optional[Boat] = None
+
+    if input.get("boat_id"):
+        from customers.schema import BoatNode
+
+        boat = get_node_from_global_id(
+            info, input.pop("boat_id"), only_type=BoatNode, nullable=False,
+        )
+
+        if boat.owner.id != input["customer"].id:
+            raise VenepaikkaGraphQLError(
+                _("Boat does not belong to the same customer as the Application")
+            )
+    elif application := input.get("application"):
+        # TODO: Remove this mapping
+        # This will only be done until the Harbors app is removed.
+        # The boat types are loaded from a fixture and they have the same ID and translations,
+        # so this is a safe temporary solution
+        boat_type = BoatType.objects.get(id=application.boat_type_id,)
+
+        boat_input = {
+            "boat_type": boat_type,
+            "name": application.boat_name,
+            "model": application.boat_model,
+            "length": application.boat_length,
+            "width": application.boat_width,
+            "draught": getattr(application, "boat_draught", None),
+            "weight": getattr(application, "boat_weight", None),
+            "propulsion": getattr(application, "boat_propulsion", ""),
+            "hull_material": getattr(application, "boat_hull_material", ""),
+            "intended_use": getattr(application, "boat_intended_use", ""),
+        }
+        boat, _created = Boat.objects.update_or_create(
+            owner=application.customer,
+            registration_number=application.boat_registration_number,
+            defaults=boat_input,
+        )
+    return boat


### PR DESCRIPTION
## Description :sparkles:
* Create boat when a lease is created
* Extract `lookup_boat` to a separate util to lookup or create the necessary boat

When a lease is being created for an application and no boat is passed, it creates a boat based on the information filled on the application. This is handled during the lease creation process, that way we ensure that we don’t end up creating unnecessary boats that will just clutter the system. If necessary, this can be refactored to create boats on other steps of the process.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1262](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1262):** Create boat during application processing

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest leases/tests/test_lease_mutations.py
```

### Manual testing :construction_worker_man:
Create a lease for an existing application, check that the results are the expected:
```graphql
mutation CreateLease {
  createBerthLease(input: {applicationId: "", berthId: "QmVydGhOb2RlOjBhNjEzYTQzLTAxMjktNDQxNS1iNjlhLTZjMmI4ZmJkYzJkMQ=="}) {
    berthLease {
      customer {
        id
      }
      boat {
        id
        name
        model
        registrationNumber
        width
        length
        owner {
          id
        }
      }
    }
  }
}
```