### PR TITLE
VEN-1234 | Set OrderNode due date to optional

### DIFF
--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -204,7 +204,7 @@ class OrderNode(DjangoObjectType):
     total_price = graphene.Decimal(required=True)
     total_pretax_price = graphene.Decimal(required=True)
     total_tax_percentage = graphene.Decimal(required=True)
-    due_date = graphene.Date(required=True)
+    due_date = graphene.Date()
     order_lines = DjangoConnectionField(OrderLineNode, required=True)
     log_entries = DjangoConnectionField(OrderLogEntryNode, required=True)
     paid_at = graphene.DateTime(

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -630,6 +630,35 @@ def test_get_order(api_client, order):
     }
 
 
+ORDER_QUERY_DUE_DATE = """
+query ORDER {
+    order(id: "%s") {
+        id
+        dueDate
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "api_client",
+    ["berth_supervisor", "berth_handler", "berth_services"],
+    indirect=True,
+)
+def test_get_order_without_due_date(api_client, order):
+    order.due_date = None
+    order.status = OrderStatus.DRAFTED
+    order.save()
+    order_global_id = to_global_id(OrderNode, order.id)
+
+    executed = api_client.execute(ORDER_QUERY_DUE_DATE % order_global_id)
+
+    assert executed["data"]["order"] == {
+        "id": order_global_id,
+        "dueDate": None,
+    }
+
+
 @pytest.mark.parametrize(
     "api_client", ["api_client", "user", "harbor_services"], indirect=True,
 )


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1234](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1234): Differentiate between sent/unsent invoices**

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest payments/tests/test_payments_queries.py::test_get_order_without_due_date
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
