### PR TITLE
VEN-1283: modify UpdateOrderMutation to allow multiple Orders at a time

### DIFF
--- a/payments/schema/mutations.py
+++ b/payments/schema/mutations.py
@@ -40,7 +40,7 @@ from utils.relay import get_node_from_global_id
 from utils.schema import update_object
 
 from ..enums import OfferStatus, OrderStatus, OrderType, ProductServiceType
-from ..exceptions import VenepaikkaPaymentError
+from ..exceptions import OrderStatusTransitionError, VenepaikkaPaymentError
 from ..models import (
     AdditionalProduct,
     BerthProduct,
@@ -396,52 +396,71 @@ class CreateAdditionalProductOrderMutation(graphene.ClientIDMutation):
         return CreateAdditionalProductOrderMutation(order=order)
 
 
-class UpdateOrderMutation(graphene.ClientIDMutation):
-    class Input(OrderInput):
-        id = graphene.ID(required=True)
+class UpdateOrderInput(OrderInput, graphene.InputObjectType):
+    id = graphene.ID(required=True)
 
-    order = graphene.Field(OrderNode)
+
+class UpdateOrdersMutation(graphene.ClientIDMutation):
+    class Input:
+        orders = graphene.List(UpdateOrderInput, required=True)
+
+    successful_orders = graphene.List(OrderNode)
+    failed_orders = graphene.List(FailedOrderType)
 
     @classmethod
     @change_permission_required(Order)
     @view_permission_required(BerthLease, WinterStorageLease)
-    @transaction.atomic
-    def mutate_and_get_payload(cls, root, info, **input):
-        order = get_node_from_global_id(
-            info, input.pop("id"), only_type=OrderNode, nullable=False
-        )
-        lease_id = input.pop("lease_id", None)
-        if lease_id:
-            lease = None
+    def mutate_and_get_payload(cls, root, info, orders, **input):
+
+        successful_orders = []
+        failed_orders = []
+
+        for order_input in orders:
+            order_id = order_input.pop("id")
             try:
-                lease = get_node_from_global_id(
-                    info, lease_id, BerthLeaseNode, nullable=True
-                )
-            # If a different node type is received get_node raises an assertion error
-            # when trying to validate the type
-            except AssertionError:
-                lease = get_node_from_global_id(
-                    info, lease_id, WinterStorageLeaseNode, nullable=True
-                )
-            finally:
-                if not lease:
-                    raise VenepaikkaGraphQLError(
-                        _("Lease with the given ID does not exist")
+                with transaction.atomic():
+                    order = get_node_from_global_id(
+                        info, order_id, only_type=OrderNode, nullable=False
                     )
-                input["lease"] = lease
+                    if lease_id := order_input.pop("lease_id", None):
+                        lease = None
+                        try:
+                            lease = get_node_from_global_id(
+                                info, lease_id, BerthLeaseNode, nullable=True
+                            )
+                        # If a different node type is received get_node raises an assertion error
+                        # when trying to validate the type
+                        except AssertionError:
+                            lease = get_node_from_global_id(
+                                info, lease_id, WinterStorageLeaseNode, nullable=True
+                            )
+                        finally:
+                            if not lease:
+                                raise VenepaikkaGraphQLError(
+                                    _("Lease with the given ID does not exist")
+                                )
+                            order_input["lease"] = lease
 
-        try:
-            # handle case where input has both lease and status.
-            # set order status only after changing the lease, because setting order status
-            # usually triggers a change in lease status.
-            new_status = input.pop("status", None)
-            update_object(order, input)
-            if new_status:
-                order.set_status(new_status, _("Manually updated by admin"))
+                    # handle case where order_input has both lease and status.
+                    # set order status only after changing the lease, because setting order status
+                    # usually triggers a change in lease status.
+                    new_status = order_input.pop("status", None)
+                    update_object(order, order_input)
+                    if new_status:
+                        order.set_status(new_status, _("Manually updated by admin"))
 
-        except (ValidationError, IntegrityError) as e:
-            raise VenepaikkaGraphQLError(e)
-        return UpdateOrderMutation(order=order)
+            except (
+                ValidationError,
+                IntegrityError,
+                VenepaikkaGraphQLError,
+                OrderStatusTransitionError,
+            ) as e:
+                failed_orders.append(FailedOrderType(id=order_id, error=str(e)))
+            else:
+                successful_orders.append(order)
+        return UpdateOrdersMutation(
+            successful_orders=successful_orders, failed_orders=failed_orders
+        )
 
 
 class DeleteOrderMutation(graphene.ClientIDMutation):
@@ -1060,7 +1079,7 @@ class Mutation:
     create_additional_product_order = CreateAdditionalProductOrderMutation.Field(
         description="Creates an `Order` object and the `OrderLine`s for only one additional product."
     )
-    update_order = UpdateOrderMutation.Field(
+    update_orders = UpdateOrdersMutation.Field(
         description="Updates an `Order` object."
         "\n\n**Requires permissions** to edit payments."
         "\n\nErrors:"

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -832,10 +832,14 @@ def test_create_order_lease_does_not_exist(
     assert_in_errors("Lease with the given ID does not exist", executed)
 
 
-UPDATE_ORDER_MUTATION = """
-mutation UPDATE_ORDER($input: UpdateOrderMutationInput!) {
-    updateOrder(input: $input) {
-        order {
+UPDATE_ORDERS_MUTATION = """
+mutation UPDATE_ORDERS($input: UpdateOrdersMutationInput!) {
+    updateOrders(input: $input) {
+        failedOrders {
+            id
+            error
+        }
+        successfulOrders {
             id
             comment
             price
@@ -889,27 +893,33 @@ def test_update_order_berth_product(
     )
 
     global_id = to_global_id(OrderNode, order.id)
-
+    due_date = today()
     # only valid state transitions
     variables = {
-        "id": global_id,
-        "comment": "foobar",
-        "dueDate": today(),
-        "status": OrderStatusEnum.get(status_choice.value).name,
+        "orders": [
+            {
+                "id": global_id,
+                "comment": "foobar",
+                "dueDate": due_date,
+                "status": OrderStatusEnum.get(status_choice.value).name,
+            }
+        ]
     }
 
     assert Order.objects.count() == 1
 
-    executed = api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
+    executed = api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
     assert Order.objects.count() == 1
 
-    assert executed["data"]["updateOrder"]["order"] == {
-        "id": variables["id"],
-        "comment": variables["comment"],
+    assert len(executed["data"]["updateOrders"]["failedOrders"]) == 0
+    assert len(executed["data"]["updateOrders"]["successfulOrders"]) == 1
+    assert executed["data"]["updateOrders"]["successfulOrders"][0] == {
+        "id": global_id,
+        "comment": "foobar",
         "price": str(berth_product.price_for_tier(berth_lease.berth.pier.price_tier)),
         "taxPercentage": str(berth_product.tax_percentage),
-        "dueDate": str(variables["dueDate"].date()),
-        "status": variables["status"],
+        "dueDate": str(due_date.date()),
+        "status": OrderStatusEnum.get(status_choice.value).name,
         "customer": {"id": to_global_id(ProfileNode, order.customer.id)},
         "product": {"id": to_global_id(BerthProductNode, order.product.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
@@ -934,19 +944,26 @@ def test_set_order_status_to_paid_manually(
     )
     assert order.status == initial_status
     global_id = to_global_id(OrderNode, order.id)
+
     variables = {
-        "id": global_id,
-        "status": OrderStatusEnum.get(OrderStatus.PAID_MANUALLY).name,
+        "orders": [
+            {
+                "id": global_id,
+                "status": OrderStatusEnum.get(OrderStatus.PAID_MANUALLY).name,
+            }
+        ]
     }
 
     assert Order.objects.count() == 1
 
-    executed = api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
+    executed = api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
 
     assert Order.objects.count() == 1
 
-    assert executed["data"]["updateOrder"]["order"] == {
-        "id": variables["id"],
+    assert len(executed["data"]["updateOrders"]["failedOrders"]) == 0
+    assert len(executed["data"]["updateOrders"]["successfulOrders"]) == 1
+    assert executed["data"]["updateOrders"]["successfulOrders"][0] == {
+        "id": global_id,
         "comment": order.comment,
         "price": str(berth_product.price_for_tier(berth_lease.berth.pier.price_tier)),
         "taxPercentage": str(berth_product.tax_percentage),
@@ -984,18 +1001,24 @@ def test_set_order_status_to_cancelled(
     assert order.status == initial_status
     global_id = to_global_id(OrderNode, order.id)
     variables = {
-        "id": global_id,
-        "status": OrderStatusEnum.get(OrderStatus.CANCELLED).name,
+        "orders": [
+            {
+                "id": global_id,
+                "status": OrderStatusEnum.get(OrderStatus.CANCELLED).name,
+            }
+        ]
     }
 
     assert Order.objects.count() == 1
 
-    executed = api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
+    executed = api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
 
     assert Order.objects.count() == 1
 
-    assert executed["data"]["updateOrder"]["order"] == {
-        "id": variables["id"],
+    assert len(executed["data"]["updateOrders"]["failedOrders"]) == 0
+    assert len(executed["data"]["updateOrders"]["successfulOrders"]) == 1
+    assert executed["data"]["updateOrders"]["successfulOrders"][0] == {
+        "id": global_id,
         "comment": order.comment,
         "status": OrderStatus.CANCELLED.name,
         "price": str(berth_product.price_for_tier(berth_lease.berth.pier.price_tier)),
@@ -1020,25 +1043,26 @@ def test_set_order_status_to_cancelled(
     indirect=True,
 )
 def test_update_order_not_enough_permissions(api_client):
-    variables = {
-        "id": to_global_id(OrderNode, uuid.uuid4()),
-    }
+    variables = {"orders": [{"id": to_global_id(OrderNode, uuid.uuid4())}]}
 
     assert Order.objects.count() == 0
 
-    executed = api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
+    executed = api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
 
     assert Order.objects.count() == 0
     assert_not_enough_permissions(executed)
 
 
 def test_update_order_does_not_exist(superuser_api_client):
-    variables = {
-        "id": to_global_id(OrderNode, uuid.uuid4()),
-    }
-    executed = superuser_api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
+    variables = {"orders": [{"id": to_global_id(OrderNode, uuid.uuid4())}]}
+    executed = superuser_api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
 
-    assert_doesnt_exist("Order", executed)
+    assert len(executed["data"]["updateOrders"]["failedOrders"]) == 1
+    assert len(executed["data"]["updateOrders"]["successfulOrders"]) == 0
+    assert (
+        executed["data"]["updateOrders"]["failedOrders"][0]["error"]
+        == "Order matching query does not exist."
+    )
 
 
 @pytest.mark.parametrize("lease_type", ["berth", "winter"])
@@ -1048,12 +1072,17 @@ def test_update_order_lease_does_not_exist(superuser_api_client, order, lease_ty
         uuid.uuid4(),
     )
     variables = {
-        "id": to_global_id(OrderNode, order.id),
-        "leaseId": lease_id,
+        "orders": [{"id": to_global_id(OrderNode, order.id), "leaseId": lease_id}]
     }
-    executed = superuser_api_client.execute(UPDATE_ORDER_MUTATION, input=variables)
 
-    assert_in_errors("Lease with the given ID does not exist", executed)
+    executed = superuser_api_client.execute(UPDATE_ORDERS_MUTATION, input=variables)
+
+    assert len(executed["data"]["updateOrders"]["failedOrders"]) == 1
+    assert len(executed["data"]["updateOrders"]["successfulOrders"]) == 0
+    assert (
+        executed["data"]["updateOrders"]["failedOrders"][0]["error"]
+        == "Lease with the given ID does not exist"
+    )
 
 
 DELETE_ORDER_MUTATION = """


### PR DESCRIPTION
## Description :sparkles:
* UpdateOrderMutation is now more like ResendOrderMutation and ApproveOrderMutation, allowing multiple orders in input

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1283(https://helsinkisolutionoffice.atlassian.net/browse/VEN-1283):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
