### PR TITLE
VEN-1289 | Check if offer has lease before updating status

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -755,7 +755,7 @@ class Order(UUIDModel, TimeStampedModel):
         self.status = new_status
         self.save(update_fields=["status"])
 
-        if self.order_type == OrderType.LEASE_ORDER:
+        if self.order_type == OrderType.LEASE_ORDER and self.lease:
             self.update_lease_and_application(new_status)
             self.update_sticker_number_if_needed()
 

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -899,6 +899,15 @@ def test_berth_product_range():
     assert BerthProduct.objects.get_in_range(width=2.76) == bp3
 
 
+def test_order_set_status_no_lease(berth):
+    product = BerthProductFactory(min_width=1, max_width=5)
+    order = OrderFactory(product=product, status=OrderStatus.OFFERED, lease=None,)
+
+    order.set_status(OrderStatus.PAID)
+    assert not order.lease
+    assert order.status == OrderStatus.PAID
+
+
 def test_order_set_status_no_application(berth):
     lease = BerthLeaseFactory(berth=berth, application=None, status=LeaseStatus.OFFERED)
     product = BerthProductFactory(


### PR DESCRIPTION
## Description :sparkles:
* Check if offer has lease before updating status

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1289](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1289):** changing the status of order without lease

### Related :handshake:
https://sentry.hel.ninja/aok/berth-api/issues/21242/

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_models.py::test_order_set_status_no_lease
```