### PR TITLE
Updated translations and "no berth" email template

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -265,6 +265,9 @@ msgstr "Venepaikkahakemus luotu"
 msgid "Berth application rejected"
 msgstr "Venepaikkahakemus hylätty"
 
+msgid "Berth application processed"
+msgstr "Venepaikkahakemus käsitelty"
+
 msgid "Winter storage application created"
 msgstr "Talvisäilytyshakemus luotu"
 
@@ -575,7 +578,7 @@ msgid "Street address of the area"
 msgstr "Alueen katuosoite"
 
 msgid "Drafted"
-msgstr "Luonnosteltu"
+msgstr "Luotu"
 
 msgid "Offered"
 msgstr "Tarjottu"
@@ -729,7 +732,7 @@ msgstr "Vene ei kuulu samalle asiakkaalle kuin hakemus"
 
 #, python-brace-format
 msgid "Lease object is not DRAFTED anymore: {lease.status}"
-msgstr "Vuokrasopimuksen kohde ei enää ole luonnosteltu: {lease.status}"
+msgstr "Vuokrasopimuksen kohde ei enää ole luotu -tilassa: {lease.status}"
 
 msgid "Switch date is more than 6 months in the past"
 msgstr ""
@@ -1085,7 +1088,7 @@ msgid "Order rejected by customer"
 msgstr "Asiakkaan hylkäämä tilaus"
 
 msgid "Cannot resend an invoice for a lease that is not currently offered."
-msgstr ""
+msgstr "Ei voi uudelleenlähettää laskua koska vuokrasopimus ei ole tarjottu -tilassa"
 
 msgid ""
 "Profile token is required if an order does not previously have email or "

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -265,6 +265,9 @@ msgstr "Ansökan om båtplats har skapats"
 msgid "Berth application rejected"
 msgstr "Ansökan om båtplats avvisat"
 
+msgid "Berth application processed"
+msgstr "Ansökan om båtplats hanterat"
+
 msgid "Winter storage application created"
 msgstr "Ansökan om vinteruppläggning har skapats"
 

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -45,6 +45,7 @@ from leases.utils import (
 from resources.enums import AreaRegion
 from resources.models import Harbor, WinterStorageArea
 from utils.email import is_valid_email
+from utils.messaging import get_email_subject
 from utils.numbers import rounded as rounded_decimal
 
 from .enums import OfferStatus, OrderStatus, OrderType, ProductServiceType
@@ -530,21 +531,6 @@ def get_notification_language(order):
     if order.lease and order.lease.application:
         language = order.lease.application.language
     return language
-
-
-def get_email_subject(notification_type):
-    from .notifications import NotificationType
-
-    if (
-        notification_type == NotificationType.NEW_BERTH_ORDER_APPROVED
-        or notification_type == NotificationType.RENEW_BERTH_ORDER_APPROVED
-    ):
-        return _("Boat berth invoice")
-    if notification_type == NotificationType.ORDER_CANCELLED:
-        return _("Confirmation")
-    if notification_type == NotificationType.ORDER_REFUNDED:
-        return _("Refund confirmation")
-    return notification_type.label
 
 
 def get_context(

--- a/templates/email/messages/berth_application_confirmation_en.html
+++ b/templates/email/messages/berth_application_confirmation_en.html
@@ -68,7 +68,7 @@
         </tr>
         <tr>
             <td><b>Model</b></td>
-            <td>{ application.boat_model }}</td>
+            <td>{{ application.boat_model }}</td>
         </tr>
     {% endif %}
 

--- a/templates/email/messages/berth_application_confirmation_sv.html
+++ b/templates/email/messages/berth_application_confirmation_sv.html
@@ -68,7 +68,7 @@
         </tr>
         <tr>
             <td><b>Modell</b></td>
-            <td>{ application.boat_model }}</td>
+            <td>{{ application.boat_model }}</td>
         </tr>
     {% endif %}
 

--- a/templates/email/messages/berth_none_offered_fi.html
+++ b/templates/email/messages/berth_none_offered_fi.html
@@ -1,4 +1,4 @@
-<p>Hyvä aiakas, valitettavasti emme pysty tarjoamaan paikkaa kohteesta jota olet hakenut.</p>
+<p>Hyvä asiakas, valitettavasti emme pysty tarjoamaan paikkaa kohteesta jota olet hakenut.</p>
 
 <h3>Kohde</h3>
 

--- a/utils/messaging.py
+++ b/utils/messaging.py
@@ -1,0 +1,21 @@
+from django.utils.translation import gettext_lazy as _
+
+
+def get_email_subject(notification_type):
+    from applications.notifications import (
+        NotificationType as ApplicationsNotificationType,
+    )
+    from payments.notifications import NotificationType as PaymentsNotificationType
+
+    if (
+        notification_type == PaymentsNotificationType.NEW_BERTH_ORDER_APPROVED
+        or notification_type == PaymentsNotificationType.RENEW_BERTH_ORDER_APPROVED
+    ):
+        return _("Boat berth invoice")
+    elif notification_type == PaymentsNotificationType.ORDER_CANCELLED:
+        return _("Confirmation")
+    elif notification_type == PaymentsNotificationType.ORDER_REFUNDED:
+        return _("Refund confirmation")
+    elif notification_type == ApplicationsNotificationType.BERTH_APPLICATION_REJECTED:
+        return _("Berth application processed")
+    return notification_type.label


### PR DESCRIPTION
## Description :sparkles:

Translate "drafted" status as "luotu"

Change the subtitle in the "berth rejected" email as follows:
Venepaikkahakemus käsitelty
Berth application processed
Ansökan om båtplats hanterat

Fix minor typo in a "berth rejected" email template

## Issues :bug:
### Closes :no_good_woman:
**[VEN-XXX](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
