### PR TITLE
VEN-978: add isAvailable to WinterStoragePlaceNode

### DIFF
--- a/resources/admin.py
+++ b/resources/admin.py
@@ -228,6 +228,7 @@ class WinterStoragePlaceAdmin(admin.ModelAdmin):
         "winter_storage_section__area__id",
     )
     list_filter = ("is_active",)
+    readonly_fields = ("is_available",)
 
     def is_available(self, obj):
         return obj.is_available

--- a/resources/schema/types.py
+++ b/resources/schema/types.py
@@ -254,6 +254,8 @@ class WinterStoragePlaceNode(DjangoObjectType):
     width = graphene.Float(description=_("width (m)"), required=True)
     length = graphene.Float(description=_("length (m)"), required=True)
 
+    is_available = graphene.Boolean(required=True)
+
     class Meta:
         model = WinterStoragePlace
         fields = (


### PR DESCRIPTION
## Description :sparkles:

Make isAvailable through graphql api

## Issues :bug:
### Closes :no_good_woman:
**[VEN-978](https://helsinkisolutionoffice.atlassian.net/browse/VEN-978):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
resources/tests/test_resources_queries.py:test_get_winter_storage_places
resources/tests/test_resources_queries.py:test_get_winter_storage_place_with_leases

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
