### PR TITLE
Get refund email from application

### DIFF
--- a/leases/tests/test_send_berth_invoice_service.py
+++ b/leases/tests/test_send_berth_invoice_service.py
@@ -671,10 +671,6 @@ def test_non_invoiceable_berth(notification_template_orders_approved):
         start_date=calculate_season_start_date(today() - relativedelta(years=1)),
         end_date=calculate_season_end_date(today() - relativedelta(years=1)),
     )
-    BerthProductFactory(
-        min_width=lease_with_non_invoiceable_berth.berth.berth_type.width - 1,
-        max_width=lease_with_non_invoiceable_berth.berth.berth_type.width + 1,
-    )
     customer = lease_with_non_invoiceable_berth.customer
 
     lease_with_invoiceable_berth = _lease_with_contract(

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -283,6 +283,10 @@ class BamboraPayformProvider(PaymentProvider):
             raise ValidationError(
                 _("Cannot refund an order that has not been paid through VismaPay")
             )
+        if order_token.is_valid:
+            raise ValidationError(
+                _("Cannot refund an order that has not been settled yet (active token)")
+            )
 
         refund_amount = order.total_price
         email = order.customer_email or (

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -47,7 +47,7 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
         order=order, token="98765", valid_until=now() - relativedelta(hours=1)
     )
     valid_token = OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
 
     payment_provider = create_bambora_provider(provider_base_config, request)
@@ -82,7 +82,7 @@ def test_initiate_refund_no_order_email(provider_base_config: dict, order: Order
     order.save()
 
     OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
 
     payment_provider = create_bambora_provider(provider_base_config, request)
@@ -111,7 +111,7 @@ def test_initiate_refund_no_order_email_or_application(
     order.save()
 
     OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
 
     payment_provider = create_bambora_provider(provider_base_config, request)
@@ -119,6 +119,33 @@ def test_initiate_refund_no_order_email_or_application(
         payment_provider.initiate_refund(order)
 
     assert "Cannot refund an order that has no email" in str(exception)
+
+
+@pytest.mark.parametrize(
+    "order", ["berth_order", "winter_storage_order"], indirect=True,
+)
+def test_initiate_refund_token_still_valid(provider_base_config: dict, order: Order):
+    """Test the request creator constructs the payload base and returns a url that contains a token"""
+    request = RequestFactory().request()
+    order.status = OrderStatus.PAID
+    order.lease.status = LeaseStatus.PAID
+    order.lease.save()
+    order.save()
+
+    OrderToken.objects.create(
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
+    )
+    OrderToken.objects.create(
+        order=order, token="98765", valid_until=now() + relativedelta(hours=1)
+    )
+
+    payment_provider = create_bambora_provider(provider_base_config, request)
+    with pytest.raises(ValidationError) as exception:
+        payment_provider.initiate_refund(order)
+
+    assert "Cannot refund an order that has not been settled yet (active token)" in str(
+        exception
+    )
 
 
 @pytest.mark.parametrize(
@@ -149,7 +176,7 @@ def test_initiate_refund_invalid_order_status(
         order=order, token="98765", valid_until=now() - relativedelta(hours=1)
     )
     OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
 
     payment_provider = create_bambora_provider(provider_base_config, request)
@@ -186,7 +213,7 @@ def test_initiate_refund_invalid_lease_status(
         order=order, token="98765", valid_until=now() - relativedelta(hours=1)
     )
     OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
 
     payment_provider = create_bambora_provider(provider_base_config, request)
@@ -221,7 +248,7 @@ def test_handle_initiate_refund_error_validation(order, provider_base_config):
     """Test the response handler raises PayloadValidationError as expected"""
     r = {"result": 1, "type": "e-payment", "errors": ["Invalid auth code"]}
     OrderToken.objects.create(
-        order=order, token="12345", valid_until=now() + relativedelta(days=7)
+        order=order, token="12345", valid_until=now() - relativedelta(days=7)
     )
     order.status = OrderStatus.PAID
     order.customer_email = "a@b.com"

--- a/payments/tests/test_payments_mutations_refunds.py
+++ b/payments/tests/test_payments_mutations_refunds.py
@@ -49,7 +49,7 @@ def test_refund_order(
     order.lease.save()
     order.save()
     OrderToken.objects.create(
-        order=order, token="1245", valid_until=today() + relativedelta(days=7)
+        order=order, token="1245", valid_until=today() - relativedelta(days=7)
     )
 
     variables = {


### PR DESCRIPTION
## Description :sparkles:

If refund `customer_email` does not exist, try to fetch the email from the related application `email` field.

## Issues :bug:
### Closes :no_good_woman:
-

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
pytest payments/tests/test_bambora_payform_refund.py::test_initiate_refund_no_order_email
pytest payments/tests/test_bambora_payform_refund.py::test_initiate_refund_no_order_email_or_application
```

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
