### PR TITLE
VEN-1300: disallow setting status of paid_manually invoices to refunded

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -734,7 +734,7 @@ class Order(UUIDModel, TimeStampedModel):
                 OrderStatus.CANCELLED,
             ),
             OrderStatus.PAID: (OrderStatus.REFUNDED,),
-            OrderStatus.PAID_MANUALLY: (OrderStatus.REFUNDED,),
+            OrderStatus.PAID_MANUALLY: (),
             OrderStatus.ERROR: (
                 OrderStatus.DRAFTED,
                 OrderStatus.OFFERED,


### PR DESCRIPTION
## Description :sparkles:
There's actually another check in initiate_refund that comes to play before set_status is called, but let's fix it anyway.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1300](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1300):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
