### PR TITLE
Tech | Optimise inlines on CustomerProfile admin

### DIFF
--- a/customers/admin.py
+++ b/customers/admin.py
@@ -44,6 +44,7 @@ class OrganizationInline(admin.StackedInline):
 
 class BoatAdmin(admin.ModelAdmin):
     inlines = (BoatCertificateInline,)
+    search_fields = ("registration_number", "name", "model")
 
 
 class BoatCertificateAdmin(admin.ModelAdmin):

--- a/leases/admin.py
+++ b/leases/admin.py
@@ -45,8 +45,12 @@ class WinterStorageLeaseChangeInline(admin.StackedInline):
 class BerthLeaseInline(admin.StackedInline):
     model = BerthLease
     fk_name = "customer"
-    raw_id_fields = ("berth", "application")
     extra = 0
+    autocomplete_fields = (
+        "application",
+        "boat",
+        "berth",
+    )
 
 
 class BaseLeaseAdmin(admin.ModelAdmin):
@@ -132,7 +136,7 @@ class GenericOrderInline(GenericStackedInline):
 class WinterStorageLeaseInline(admin.StackedInline):
     model = WinterStorageLease
     fk_name = "customer"
-    raw_id_fields = ("application",)
+    autocomplete_fields = ("application", "boat", "place", "section")
     extra = 0
 
 


### PR DESCRIPTION
## Description :sparkles:
* Replace the default `select` for the inline lease forms with `select2` to avoid fetching all the winter places and sections for every instance of the lease