### PR TITLE
VEN-1304: update application status when switch offer status is updated

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -239,7 +239,7 @@ class BerthApplication(BaseApplication):
         if self.berth_switch:
             allowed_statuses_for_switch = [
                 ApplicationStatus.PENDING,
-                ApplicationStatus.HANDLED,
+                ApplicationStatus.OFFER_GENERATED,
                 ApplicationStatus.OFFER_SENT,
                 ApplicationStatus.EXPIRED,
                 ApplicationStatus.REJECTED,

--- a/payments/models.py
+++ b/payments/models.py
@@ -49,6 +49,7 @@ from .utils import (
     generate_order_number,
     get_application_status,
     get_lease_status,
+    get_switch_application_status,
     rounded,
 )
 
@@ -1207,9 +1208,16 @@ class BerthSwitchOffer(AbstractOffer):
         self.status = new_status
         self.save(update_fields=["status"])
 
+        self.update_application(new_status)
+
         self.create_log_entry(
             from_status=old_status, to_status=new_status, comment=comment
         )
+
+    def update_application(self, new_status):
+        if new_application_status := get_switch_application_status(new_status):
+            self.application.status = new_application_status
+            self.application.save(update_fields=["status"])
 
     def create_log_entry(
         self,

--- a/payments/tests/test_payments_mutations_create_berth_switch_offer.py
+++ b/payments/tests/test_payments_mutations_create_berth_switch_offer.py
@@ -37,6 +37,7 @@ mutation CREATE_BERTH_SWITCH_OFFER_MUTATION($input: CreateBerthSwitchOfferMutati
             }
             application {
                 id
+                status
             }
             lease {
                 id
@@ -79,7 +80,7 @@ def test_create_berth_switch_offer_direct_harbor_mapping(
     assert executed["data"]["createBerthSwitchOffer"]["berthSwitchOffer"] == {
         "status": OfferStatus.DRAFTED.name,
         "dueDate": None,
-        "application": {"id": variables["applicationId"]},
+        "application": {"id": variables["applicationId"], "status": "OFFER_GENERATED"},
         "customer": {"id": to_global_id(ProfileNode, berth_lease.customer.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
         "berth": {"id": variables["newBerthId"]},
@@ -119,7 +120,7 @@ def test_create_berth_switch_offer_direct_pier_mapping(
     assert executed["data"]["createBerthSwitchOffer"]["berthSwitchOffer"] == {
         "status": OfferStatus.DRAFTED.name,
         "dueDate": None,
-        "application": {"id": variables["applicationId"]},
+        "application": {"id": variables["applicationId"], "status": "OFFER_GENERATED"},
         "customer": {"id": to_global_id(ProfileNode, berth_lease.customer.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
         "berth": {"id": variables["newBerthId"]},
@@ -164,7 +165,7 @@ def test_create_berth_switch_offer_several_pier_mapping(
     assert executed["data"]["createBerthSwitchOffer"]["berthSwitchOffer"] == {
         "status": OfferStatus.DRAFTED.name,
         "dueDate": None,
-        "application": {"id": variables["applicationId"]},
+        "application": {"id": variables["applicationId"], "status": "OFFER_GENERATED"},
         "customer": {"id": to_global_id(ProfileNode, berth_lease.customer.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
         "berth": {"id": variables["newBerthId"]},
@@ -202,7 +203,7 @@ def test_create_berth_switch_offer_default_pier_mapping(
     assert executed["data"]["createBerthSwitchOffer"]["berthSwitchOffer"] == {
         "status": OfferStatus.DRAFTED.name,
         "dueDate": None,
-        "application": {"id": variables["applicationId"]},
+        "application": {"id": variables["applicationId"], "status": "OFFER_GENERATED"},
         "customer": {"id": to_global_id(ProfileNode, berth_lease.customer.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
         "berth": {"id": variables["newBerthId"]},
@@ -238,7 +239,7 @@ def test_create_berth_switch_offer_old_lease(api_client, berth_application, bert
     assert executed["data"]["createBerthSwitchOffer"]["berthSwitchOffer"] == {
         "status": OfferStatus.DRAFTED.name,
         "dueDate": None,
-        "application": {"id": variables["applicationId"]},
+        "application": {"id": variables["applicationId"], "status": "OFFER_GENERATED"},
         "customer": {"id": to_global_id(ProfileNode, berth_lease.customer.id)},
         "lease": {"id": to_global_id(BerthLeaseNode, berth_lease.id)},
         "berth": {"id": variables["newBerthId"]},

--- a/payments/tests/test_payments_mutations_send_berth_switch_offer.py
+++ b/payments/tests/test_payments_mutations_send_berth_switch_offer.py
@@ -59,6 +59,15 @@ def test_send_berth_switch_offer(
         berth_switch_offer.customer_phone = ""  # trigger update from profile service
         berth_switch_offer.customer_email = ""
     berth_switch_offer.save()
+
+    # set a valid initial status for application
+    berth_switch_offer.application.status = (
+        ApplicationStatus.PENDING
+        if offer_status == OfferStatus.DRAFTED
+        else ApplicationStatus.OFFER_SENT
+    )
+    berth_switch_offer.application.save()
+
     offers = [berth_switch_offer]
 
     variables = {

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -341,6 +341,19 @@ def get_lease_status(new_status) -> LeaseStatus:
         raise ValidationError(_("Invalid order status"))
 
 
+def get_switch_application_status(new_offer_status) -> ApplicationStatus:
+    if new_offer_status == OfferStatus.DRAFTED:
+        return ApplicationStatus.OFFER_GENERATED
+    elif new_offer_status == OfferStatus.OFFERED:
+        return ApplicationStatus.OFFER_SENT
+    elif new_offer_status == OfferStatus.REJECTED:
+        return ApplicationStatus.REJECTED
+    elif new_offer_status == OfferStatus.EXPIRED:
+        return ApplicationStatus.EXPIRED
+    else:
+        return None
+
+
 def get_application_status(new_status) -> ApplicationStatus:
     # return None if application status need not be changed
     if new_status == OrderStatus.REJECTED:
@@ -585,10 +598,7 @@ def send_berth_switch_offer(offer, due_date: date,) -> None:
         offer.save()
 
     # Update offer and application status
-    offer.status = OfferStatus.OFFERED
-    offer.save()
-    offer.application.status = ApplicationStatus.OFFER_SENT
-    offer.application.save()
+    offer.set_status(OfferStatus.OFFERED)
 
     from .notifications import NotificationType
 


### PR DESCRIPTION
## Description :sparkles:

Set application status at these points in offer life cycle:
* offer rejected -> application rejected
* offer expired -> application expired
* After the Offer is generated -> the application is set to OFFER_GENERATED status.
* Offer never needs to enter ApplicationStatus.HANDLED state (which is rendered as "invoice paid" in the admin UI)


## Issues :bug:
### Closes :no_good_woman:
**[VEN-1304](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1304):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
