### PR TITLE
VEN-1313 | Add cleanup for application CharFields

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -273,10 +273,33 @@ class BerthApplication(BaseApplication):
                 )
 
     def save(self, *args, **kwargs):
+        fields_to_strip = [
+            "first_name",
+            "last_name",
+            "email",
+            "phone_number",
+            "address",
+            "zip_code",
+            "municipality",
+            "company_name",
+            "business_id",
+            "boat_registration_number",
+            "boat_name",
+            "boat_model",
+            "application_code",
+            "boat_propulsion",
+            "boat_hull_material",
+            "boat_intended_use",
+            "renting_period",
+            "rent_from",
+            "rent_till",
+        ]
+        for field in fields_to_strip:
+            if field_value := getattr(self, field):
+                setattr(self, field, field_value.strip())
+
         # Ensure clean is always ran
-        # FIXME: exclude decimal fields for now, as GQL API uses floats for those
-        #  which does not work well with Django's validation for DecimalField
-        self.full_clean(exclude=["boat_length", "boat_width", "boat_draught"])
+        self.full_clean()
         super().save(*args, **kwargs)
 
     def clean(self):
@@ -316,6 +339,28 @@ class WinterStorageApplication(BaseApplication):
     trailer_registration_number = models.CharField(
         verbose_name=_("trailer registration number"), max_length=64, blank=True
     )
+
+    def save(self, *args, **kwargs):
+        fields_to_strip = [
+            "first_name",
+            "last_name",
+            "email",
+            "phone_number",
+            "address",
+            "zip_code",
+            "municipality",
+            "company_name",
+            "business_id",
+            "boat_registration_number",
+            "boat_name",
+            "boat_model",
+            "application_code",
+            "trailer_registration_number",
+        ]
+        for field in fields_to_strip:
+            if field_value := getattr(self, field):
+                setattr(self, field, field_value.strip())
+        super().save(*args, **kwargs)
 
     def resolve_area_type(self) -> ApplicationAreaType:
         first_area = self.chosen_areas.first()

--- a/applications/tests/test_application_models.py
+++ b/applications/tests/test_application_models.py
@@ -4,7 +4,11 @@ from django.core.exceptions import ValidationError
 from harbors.tests.factories import WinterStorageAreaFactory
 
 from ..enums import ApplicationAreaType, ApplicationStatus
-from .factories import WinterAreaChoiceFactory
+from .factories import (
+    BerthApplicationFactory,
+    WinterAreaChoiceFactory,
+    WinterStorageApplicationFactory,
+)
 
 
 def test_berth_application_without_lease_valid_statuses(berth_application):
@@ -52,3 +56,80 @@ def test_winterstorage_application_resolve_unmarked_area(winter_storage_applicat
     assert (
         winter_storage_application.resolve_area_type() == ApplicationAreaType.UNMARKED
     )
+
+
+def test_berth_application_stripped_fields():
+    application = BerthApplicationFactory(
+        first_name="    Foo     ",
+        last_name="  Bar \t ",
+        email=" spaces@email.com   ",
+        phone_number=" 01123123",
+        address="   Street 1     ",
+        zip_code="  01010 ",
+        municipality="    Helsinki    ",
+        company_name=" Company   ",
+        business_id=" 010101010 ",
+        boat_registration_number=" BOAT  ",
+        boat_name=" Boat name \t \t",
+        boat_model="    Buster",
+        application_code="     code ",
+        boat_propulsion="      propulsion ",
+        boat_hull_material=" hull ",
+        boat_intended_use=" use ",
+        renting_period="     01-02 ",
+        rent_from=" 01",
+        rent_till="02 ",
+    )
+    assert application.first_name == "Foo"
+    assert application.last_name == "Bar"
+    assert application.email == "spaces@email.com"
+    assert application.phone_number == "01123123"
+    assert application.address == "Street 1"
+    assert application.zip_code == "01010"
+    assert application.municipality == "Helsinki"
+    assert application.company_name == "Company"
+    assert application.business_id == "010101010"
+    assert application.boat_registration_number == "BOAT"
+    assert application.boat_name == "Boat name"
+    assert application.boat_model == "Buster"
+    assert application.application_code == "code"
+    assert application.boat_propulsion == "propulsion"
+    assert application.boat_hull_material == "hull"
+    assert application.boat_intended_use == "use"
+    assert application.renting_period == "01-02"
+    assert application.rent_from == "01"
+    assert application.rent_till == "02"
+
+
+def test_winter_storage_application_stripped_fields():
+    application = WinterStorageApplicationFactory(
+        area_type=None,
+        first_name="    Foo     ",
+        last_name="  Bar \t ",
+        email=" spaces@email.com   ",
+        phone_number=" 01123123",
+        address="   Street 1     ",
+        zip_code="  01010 ",
+        municipality="    Helsinki    ",
+        company_name=" Company   ",
+        business_id=" 010101010 ",
+        boat_registration_number=" BOAT  ",
+        boat_name=" Boat name \t \t",
+        boat_model="    Buster",
+        application_code="     code ",
+        trailer_registration_number="    trailer    ",
+    )
+    assert application.first_name == "Foo"
+    assert application.last_name == "Bar"
+    assert application.email == "spaces@email.com"
+    assert application.phone_number == "01123123"
+    assert application.address == "Street 1"
+    assert application.zip_code == "01010"
+    assert application.municipality == "Helsinki"
+    assert application.company_name == "Company"
+    assert application.business_id == "010101010"
+    assert application.boat_registration_number == "BOAT"
+    assert application.boat_name == "Boat name"
+    assert application.boat_model == "Buster"
+    assert application.application_code == "code"
+    assert application.trailer_registration_number == "trailer"


### PR DESCRIPTION
## Description :sparkles:
* Add a `strip` for all the char fields on `applications`

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1313](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1313):** Cleanup application data

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest applications/tests/test_application_models.py::test_berth_application_stripped_fields
$ pytest applications/tests/test_application_models.py::test_winter_storage_application_stripped_fields
```

### Manual testing :construction_worker_man:
1. Create an application, either on the shell, Django Admin, or GQL API
2. Fill the char fields (e.g. names, email, address) with leading and/or trailing spaces
3. When the application is created, check that the values have been stripped
