### PR TITLE
VEN-1317 | Only check for offer lease status when creating

### DIFF
--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -1089,3 +1089,14 @@ def test_berth_switch_offer_lease_not_paid(lease_status):
         BerthSwitchOfferFactory(lease__status=lease_status)
 
     assert "The associated lease must be paid" in str(exception)
+
+
+def test_berth_switch_offer_lease_changed_status():
+    offer = BerthSwitchOfferFactory(lease__status=LeaseStatus.PAID)
+    offer.lease.status = LeaseStatus.TERMINATED
+    offer.lease.save()
+
+    offer.set_status(OfferStatus.CANCELLED)
+
+    assert offer.status == OfferStatus.CANCELLED
+    assert offer.lease.status == LeaseStatus.TERMINATED


### PR DESCRIPTION
## Description :sparkles:
Since the lease will be terminated later, we only check that the lease
has been paid on the moment we create the offer. Otherwise, this blocks
updating the offer if at some point the lease status changes.

* Check that the lease is on `PAID` status only when it's created
* Check that the lease is on the current season only at the moment of creation

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1317](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1317):** Allow cancelling offers for terminated leases

## Testing :alembic:
### Automated tests :gear:️
```shell
$ python payments/tests/test_payments_models.py::test_berth_switch_offer_lease_changed_status
```