### PR TITLE
Fix | Connect the switch application with the new lease

### DIFF
--- a/payments/schema/mutations.py
+++ b/payments/schema/mutations.py
@@ -973,6 +973,8 @@ class AcceptBerthSwitchOfferMutation(graphene.ClientIDMutation):
                 old_lease_comment=_("Lease terminated due to a berth switch offer"),
                 new_lease_comment=_("Lease created from a berth switch offer"),
             )
+            new_lease.application = offer.application
+            new_lease.save()
             if old_lease.order:
                 new_lease.orders.add(old_lease.order)
         else:

--- a/payments/tests/test_payments_mutations_accept_berth_switch_offer.py
+++ b/payments/tests/test_payments_mutations_accept_berth_switch_offer.py
@@ -60,6 +60,7 @@ def test_accept_offer(old_schema_api_client):
     assert berth_switch_offer.lease.status == LeaseStatus.TERMINATED
     new_lease = BerthLease.objects.exclude(id=berth_switch_offer.lease_id).first()
     assert new_lease.status == LeaseStatus.PAID
+    assert new_lease.application == berth_switch_offer.application
 
 
 @freeze_time("2020-02-01T08:00:00Z")


### PR DESCRIPTION
## Description :sparkles:
* Connect the switch application with the new lease

When the `switch offer` is accepted, the new lease is generated but it's not connected to the application. 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_mutations_accept_berth_switch_offer.py::test_accept_offer
```
