### PR TITLE
VEN-1319 | Refactor refunding to replace amount for products

### DIFF
--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -24,3 +24,11 @@ class UnknownReturnCodeError(VenepaikkaPaymentError):
 
 class ExpiredOrderError(VenepaikkaPaymentError):
     """If the Order is being paid after the due date"""
+
+
+class PaymentNotFoundError(VenepaikkaPaymentError):
+    """When the payment cannot be found on Bambora's system"""
+
+
+class RefundPriceError(VenepaikkaPaymentError):
+    """When the amount to be refunded (taken from Bambora) is different than the price of the order"""

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -257,5 +257,58 @@ def mocked_refund_response_create(*args, **kwargs):
     if any([arg.startswith(FAKE_BAMBORA_API_URL) for arg in args]):
         return MockResponse(data={"result": 10})
     else:
-
         return MockResponse(data={"result": 0, "refund_id": 123456, "type": "instant"})
+
+
+def mocked_refund_payment_details(*args, products=None, **kwargs):
+    def wrapper(*args, **kwargs):
+        if any([arg.startswith(FAKE_BAMBORA_API_URL) for arg in args]):
+            return MockResponse(data={"result": 10})
+        else:
+            from ..providers.bambora_payform import BamboraPaymentDetails
+
+            customer = kwargs.get(
+                "customer",
+                {
+                    "firstname": "Test",
+                    "lastname": "Person",
+                    "email": "test.person@email.com",
+                    "address_street": "",
+                    "address_city": "",
+                    "address_zip": "",
+                    "address_country": "",
+                },
+            )
+            order_number = kwargs.get("order_number", "abc123")
+            refunds = kwargs.get("refunds", [])
+            payment_products = products or [
+                {
+                    "id": "as123",
+                    "product_id": 1123,
+                    "title": "Product 1",
+                    "count": 1,
+                    "pretax_price": 100,
+                    "tax": 24,
+                    "price": 124,
+                    "type": 1,
+                },
+            ]
+            amount = sum([product.get("price") for product in payment_products])
+
+            return BamboraPaymentDetails(
+                {
+                    "id": 123,
+                    "amount": amount,
+                    "currency": "EUR",
+                    "order_number": order_number,
+                    "created_at": "2018-09-12 08:30:22",
+                    "status": 4,
+                    "refund_type": "email",
+                    "source": {"object": "card", "brand": "Visa"},
+                    "customer": customer,
+                    "payment_products": payment_products,
+                    "refunds": refunds,
+                }
+            )
+
+    return wrapper

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -220,6 +220,10 @@ def price_as_fractional_int(price: Decimal) -> int:
     return int(rounded_decimal(price) * 100)
 
 
+def price_from_fractional_int(price: int) -> Decimal:
+    return Decimal(rounded_decimal(price / 100, as_string=True))
+
+
 def generate_order_number() -> str:
     t = time.time() * 1000000 * random.uniform(1, 1000)
     b = base64.b32encode(struct.pack(">Q", int(t)).lstrip(b"\x00")).strip(b"=").lower()


### PR DESCRIPTION
## Description :sparkles:
* Refactor refunding to replace amount for products

As per VismaPay support:
> _We checked some of your test refunds and noticed, that you are refunding with custom amount. With Helsingin kaupunki Liikuntapalvelu (931) merchant account you have to refund products, otherwise the accounting data will break._

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1319](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1319):** Refund VismaPay by products

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform_refund.py
$ pytest payments/tests/test_payments_mutations_refunds.py
```

### Manual testing :construction_worker_man:
TBD