### PR TITLE
VEN-1319 | Cast bambora product price to int

### DIFF
--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -69,6 +69,16 @@ class BamboraPaymentProductDetails:
     price: int
     type: int
 
+    def __init__(self, product_dict: dict):
+        self.id = product_dict.get("id", "")
+        self.product_id = product_dict.get("product_id", "")
+        self.title = product_dict.get("title", "")
+        self.count = int(product_dict.get("count", 1))
+        self.pretax_price = int(product_dict.get("pretax_price", 0))
+        self.tax = int(product_dict.get("tax", 24))
+        self.price = int(product_dict.get("price", 0))
+        self.type = int(product_dict.get("type", 1))
+
 
 @dataclass
 class BamboraPaymentRefundDetails:
@@ -96,7 +106,7 @@ class BamboraPaymentDetails:
 
     def __init__(self, payment_dict: dict):
         self.id = payment_dict.get("id", "")
-        self.amount = payment_dict.get("amount", 0)
+        self.amount = int(payment_dict.get("amount", 0))
         self.currency = payment_dict.get("currency", "EUR")
         self.order_number = payment_dict.get("order_number", "")
         self.source = payment_dict.get("source", {})
@@ -108,7 +118,7 @@ class BamboraPaymentDetails:
             **payment_dict.get("customer", {})
         )
         self.payment_products = [
-            BamboraPaymentProductDetails(**product)
+            BamboraPaymentProductDetails(product)
             for product in payment_dict.get("payment_products", [])
         ]
 
@@ -116,8 +126,8 @@ class BamboraPaymentDetails:
         for refund in payment_dict.get("refunds", []):
             # Refunds have nested products
             refund_products = [
-                BamboraPaymentProductDetails(**refund)
-                for refund in refund.pop("payment_products", [])
+                BamboraPaymentProductDetails(refund_product)
+                for refund_product in refund.pop("payment_products", [])
             ]
             self.refunds.append(
                 BamboraPaymentRefundDetails(**refund, payment_products=refund_products)

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -293,7 +293,7 @@ def mocked_refund_payment_details(*args, products=None, **kwargs):
                     "type": 1,
                 },
             ]
-            amount = sum([product.get("price") for product in payment_products])
+            amount = sum([int(product.get("price")) for product in payment_products])
 
             return BamboraPaymentDetails(
                 {

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -79,7 +79,7 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
                 convert_aftertax_to_pretax(place_price, order.product.tax_percentage)
             ),
             "tax": int(order.product.tax_percentage),
-            "price": price_as_fractional_int(place_price),
+            "price": str(price_as_fractional_int(place_price)),
             "type": 1,
         }
     ]


### PR DESCRIPTION
## Description :sparkles:
* VismaPay sends the product price as string (not int), so cast it to int to operate properly