### PR TITLE
VEN-1229 | Add changes to migrations made during the transition

### DIFF
--- a/applications/migrations/0028_replace_berth_switch_harbor_with_resources.py
+++ b/applications/migrations/0028_replace_berth_switch_harbor_with_resources.py
@@ -4,12 +4,69 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
+old_harbor_mapping = {
+    1: "40393",
+    2: "41636",
+    3: "40971",
+    4: "39913",
+    5: "41390",
+    6: "40672",
+    7: "41926",
+    8: "40166",
+    9: "40827",
+    10: "48272",
+    11: "40310",
+    12: "41189",
+    13: "39950",
+    14: "40864",
+    15: "40290",
+    16: "41454",
+    17: "41066",
+    18: "40948",
+    19: "45995",
+    20: "40359",
+    21: "42225",
+    22: "40712",
+    23: "41359",
+    24: "40590",
+    25: "41669",
+    26: "41150",
+    27: "40842",
+    28: "40897",
+    29: "40800",
+    30: "41074",
+    31: "40203",
+    32: "40535",
+    33: "40627",
+    34: "41857",
+    35: "40876",
+    36: "42276",
+    37: "41472",
+    38: "42136",
+    39: "41415",
+    40: "41637",
+    41: "42130",
+    42: "48272",
+    43: "41189",
+    44: "40359",
+    45: "41359",
+    46: "40393",
+    47: "40864",
+    48: "40864",
+    49: "41454",
+    50: "40971",
+    51: "41472",
+    52: "41390",
+}
+
+
 def berth_switch_save_servicemap_id(apps, schema_editor):
     BerthSwitch = apps.get_model("applications", "BerthSwitch")
 
     for switch in BerthSwitch.objects.all():
         if hasattr(switch, "_temp_servicemap_id"):
-            switch._temp_servicemap_id = switch.harbor.servicemap_id
+            switch._temp_servicemap_id = old_harbor_mapping[int(switch.harbor_id)]
+            switch.harbor = None
             switch.save()
 
 
@@ -41,14 +98,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="berthswitch",
-            name="_temp_servicemap_id",
-            field=models.CharField(null=True, blank=True, max_length=8),
-        ),
-        migrations.RunPython(
-            berth_switch_save_servicemap_id, reverse_code=migrations.RunPython.noop
-        ),
         migrations.AlterField(
             model_name="berthswitch",
             name="harbor",
@@ -59,8 +108,13 @@ class Migration(migrations.Migration):
                 null=True,
             ),
         ),
+        migrations.AddField(
+            model_name="berthswitch",
+            name="_temp_servicemap_id",
+            field=models.CharField(null=True, blank=True, max_length=8),
+        ),
         migrations.RunPython(
-            berth_switch_clear_harbor_id, reverse_code=migrations.RunPython.noop
+            berth_switch_save_servicemap_id, reverse_code=migrations.RunPython.noop
         ),
         migrations.RemoveField(model_name="berthswitch", name="harbor",),
         migrations.AddField(

--- a/applications/migrations/0029_replace_harborchoice_harbors_with_resources.py
+++ b/applications/migrations/0029_replace_harborchoice_harbors_with_resources.py
@@ -3,6 +3,61 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+old_harbor_mapping = {
+    1: "40393",
+    2: "41636",
+    3: "40971",
+    4: "39913",
+    5: "41390",
+    6: "40672",
+    7: "41926",
+    8: "40166",
+    9: "40827",
+    10: "48272",
+    11: "40310",
+    12: "41189",
+    13: "39950",
+    14: "40864",
+    15: "40290",
+    16: "41454",
+    17: "41066",
+    18: "40948",
+    19: "45995",
+    20: "40359",
+    21: "42225",
+    22: "40712",
+    23: "41359",
+    24: "40590",
+    25: "41669",
+    26: "41150",
+    27: "40842",
+    28: "40897",
+    29: "40800",
+    30: "41074",
+    31: "40203",
+    32: "40535",
+    33: "40627",
+    34: "41857",
+    35: "40876",
+    36: "42276",
+    37: "41472",
+    38: "42136",
+    39: "41415",
+    40: "41637",
+    41: "42130",
+    42: "48272",
+    43: "41189",
+    44: "40359",
+    45: "41359",
+    46: "40393",
+    47: "40864",
+    48: "40864",
+    49: "41454",
+    50: "40971",
+    51: "41472",
+    52: "41390",
+}
+
 
 def copy_harbor_choices(apps, schema_editor):
     HarborChoice = apps.get_model("applications", "HarborChoice")
@@ -14,7 +69,7 @@ def copy_harbor_choices(apps, schema_editor):
             id=choice.id,
             priority=choice.priority,
             harbor=Harbor.objects.filter(
-                servicemap_id=choice.harbor.servicemap_id
+                servicemap_id=old_harbor_mapping[choice.harbor_id]
             ).first(),
             application=choice.application,
         )

--- a/applications/migrations/0031_replace_winterstorageareachoice_area_with_resources.py
+++ b/applications/migrations/0031_replace_winterstorageareachoice_area_with_resources.py
@@ -4,6 +4,24 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
+old_winter_area_mapping = {
+    1: "9d577c99-63f3-4234-8138-f70a4f8684f2",
+    2: "3631fbc5-1454-448f-9a9b-fff64588d208",
+    3: "3f485ff8-36bf-4786-bfe6-b0729e8e9c6b",
+    4: "ed291ec2-1cb3-4049-a642-e290280bd8bf",
+    5: "10f6d541-5e4e-420c-abc4-014a48aca3c4",
+    6: "a9ef8fe9-86a8-44e4-a806-32ed47494129",
+    7: "5bfe1de8-dcc7-4ed4-b16d-c5f2fa08be0d",
+    8: "72335b05-1913-44e2-8f5d-a4219498b47a",
+    9: "94d97495-bb5c-4d6e-a91a-5da9e70d0aea",
+    10: "c200c0fa-8afc-43ab-8d43-a3d10be4c44a",
+    11: "db0323f0-8da5-40e3-a8aa-e46ad4af3e93",
+    12: "506b0830-fa3e-4da7-a837-b4ffa1218eb1",
+    13: "f38c0645-bb9c-4c67-a515-cf11f3787541",
+    14: "38955371-4dd2-4321-8994-f4b52c81aa41",
+}
+
+
 def copy_area_choices(apps, schema_editor):
     WinterStorageAreaChoice = apps.get_model("applications", "WinterStorageAreaChoice")
     TmpChoice = apps.get_model("applications", "TmpChoice")
@@ -13,7 +31,9 @@ def copy_area_choices(apps, schema_editor):
         TmpChoice.objects.create(
             id=choice.id,
             priority=choice.priority,
-            winter_storage_area=choice.winter_storage_area.resources_area,
+            winter_storage_area_id=old_winter_area_mapping[
+                choice.winter_storage_area_id
+            ],
             application=choice.application,
         )
 

--- a/applications/migrations/0034_replace_berthswitch_harbor_for_berth.py
+++ b/applications/migrations/0034_replace_berthswitch_harbor_for_berth.py
@@ -11,11 +11,12 @@ def fix_applications(apps, schema_editor):
 
     with transaction.atomic():
         for switch in BerthSwitch.objects.all():
+            identifier = switch.pier or "-"
             try:
                 # Assign the correct berth to the switch
                 berth = Berth.objects.get(
-                    harbor=switch.harbor,
-                    harbor__pier__identifier__iexact=switch.pier,
+                    pier__harbor=switch.harbor,
+                    pier__identifier__iexact=identifier,
                     number=switch.berth_number,
                 )
                 switch.berth = berth

--- a/scripts/delete_incomplete_switch_applications.py
+++ b/scripts/delete_incomplete_switch_applications.py
@@ -84,6 +84,9 @@ for application in BerthApplication.objects.filter(berth_switch__isnull=False):
                 switch.berth_number,
             ]
         )
+        # TODO: this has to be removed when run manually
+        # application.berth_switch.delete()
+        # application.delete()
 
 with open("customers.csv", mode="w+") as csvfile:
     writer = csv.writer(csvfile, delimiter=",", quotechar='"',)


### PR DESCRIPTION
## Description :sparkles:
During the process of removing the harbors app, some manual changes had to be made on the fly to complete the migration. This are the corresponding changes to the migrations and scripts.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1229](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1229)** 

### Related :handshake:
#511 

## Additional notes :spiral_notepad:
The `scripts/delete_incomplete_switch_applications.py` has to be run _before_ the migration process starts, since later the changes to the model will block running it.