### PR TITLE
Fix | Miscellaneous refund fixes

### DIFF
--- a/payments/admin.py
+++ b/payments/admin.py
@@ -271,18 +271,28 @@ class OrderRefundLogEntryInline(admin.StackedInline):
 class OrderRefundAdmin(admin.ModelAdmin):
     inlines = (OrderRefundLogEntryInline,)
     date_hierarchy = "created_at"
+    autocomplete_fields = ("order",)
     list_display = (
         "id",
-        "created_at",
         "refund_id",
+        "created_at",
+        "time_settled",
         "order",
         "status",
+        "amount",
     )
     list_filter = ("status",)
     search_fields = (
         "refund_id",
         "order__customer__id",
     )
+    readonly_fields = ("time_settled",)
+
+    def time_settled(self, obj):
+        entry = (
+            obj.log_entries.filter(from_status="pending").order_by("created_at").first()
+        )
+        return entry.created_at if entry else None
 
 
 class OrderRefundLogEntryAdmin(admin.ModelAdmin):

--- a/payments/providers/bambora_payform.py
+++ b/payments/providers/bambora_payform.py
@@ -82,7 +82,7 @@ class BamboraPaymentProductDetails:
 
 @dataclass
 class BamboraPaymentRefundDetails:
-    id: int
+    refund_id: int
     amount: int
     created_at: str
     order_number: str
@@ -412,6 +412,11 @@ class BamboraPayformProvider(PaymentProvider):
             hasattr(order, "lease") and order.lease.status != LeaseStatus.PAID
         ):
             raise ValidationError(_("Cannot refund an order that is not paid"))
+
+        if order.refunds.filter(status=OrderRefundStatus.PENDING).exists():
+            raise ValidationError(
+                _("Cannot refund an order that has another pending refund")
+            )
 
         email = order.customer_email or (
             order.lease.application.email


### PR DESCRIPTION
## Description :sparkles:
### Django Admin:
* Make `OrderRefund.order` as `autocomplete_fields` to improve loading time
* Add `time_settled` to `OrderRefund` to see easily when the refund was settled

### BamboraPayformProvider:
* Rename the `BamboraPaymentRefundDetails.id` to `refund_id` (as per VismaPay docs)
* Raise an error when creating a new refund if the order already has a pending refund

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_bambora_payform_refund.py::test_initiate_refund_another_pending_refund
```