### PR TITLE
Enable offer expiration cronjob in production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -96,7 +96,7 @@ jobs:
           K8S_SECRET_NOTIFICATION_SERVICE_SENDER_NAME: "Hel.fi"
           K8S_SECRET_NOTIFICATION_SERVICE_TOKEN: ${{ secrets.GH_PROD_SECRET_NOTIFICATION_SERVICE_TOKEN }}
           K8S_SECRET_ORDER_EXPIRATION_CRONJOB_ENABLED: "true"
-          K8S_SECRET_OFFER_EXPIRATION_CRONJOB_ENABLED: "false"
+          K8S_SECRET_OFFER_EXPIRATION_CRONJOB_ENABLED: "true"
 
       - name: Deploy Order Expiration Cronjob
         uses: City-of-Helsinki/setup-cronjob-action@main


### PR DESCRIPTION
## Description :sparkles:
Set K8S_SECRET_OFFER_EXPIRATION_CRONJOB_ENABLED to "true"

## Issues :bug:
### Closes :no_good_woman:
**[VEN-XXX](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
