### PR TITLE
Tech | Add names to order and offer cronjobs

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -106,6 +106,7 @@ jobs:
           secret_name: project-berth-reservations-secret
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STABLE }}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
+          name: "order-expiration-cronjob-prod"
           schedule: '30 1 * * *'
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
@@ -118,6 +119,7 @@ jobs:
           secret_name: project-berth-reservations-secret
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STABLE }}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
+          name: "offer-expiration-cronjob-prod"
           schedule: '30 2 * * *'
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_offers 2>&1}"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -80,6 +80,7 @@ jobs:
           target_namespace: ${{ env.K8S_NAMESPACE }}
           single_run: true
           secret_name: "-secret"
+          name: "order-expiration-cronjob-review"
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
 
@@ -92,5 +93,6 @@ jobs:
           target_namespace: ${{ env.K8S_NAMESPACE }}
           single_run: true
           secret_name: "-secret"
+          name: "offer-expiration-cronjob-review"
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_offers 2>&1}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -94,6 +94,7 @@ jobs:
           secret_name: project-staging-berth-reservations-secret
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
+          name: "order-expiration-cronjob-qa"
           schedule: '30 1 * * *'
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_unpaid_orders 2>&1}"
@@ -106,6 +107,7 @@ jobs:
           secret_name: project-staging-berth-reservations-secret
           kubeconfig_raw: ${{ secrets.KUBECONFIG_RAW_STAGING}}
           target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
+          name: "offer-expiration-cronjob-qa"
           schedule: '30 2 * * *'
           command: "{/bin/sh}"
           args: "{-c,cd /app && /usr/bin/timeout --kill-after=20m 19m python manage.py expire_too_old_offers 2>&1}"


### PR DESCRIPTION
## Description :sparkles:
According to the [cronjob action documentation](https://github.com/City-of-Helsinki/setup-cronjob-action):
> **Name:** name
> **Description:** Name to use in job. Mandatory if multiple cronjobs in one namespace
> **Default:** `action-cronjob`

So we need to explicitly set the names to allow all jobs to run.