### PR TITLE
VEN-1339: catch errors from update_order_from_profile while invoicing

### DIFF
--- a/leases/services/invoice/base.py
+++ b/leases/services/invoice/base.py
@@ -318,9 +318,8 @@ class BaseInvoicingService:
                 comment=f"{get_ts()}: {_('Cleanup the invoice to attempt resending')}\n",
             )
 
-            update_order_from_profile(order, profiles[order.customer.id])
-
             try:
+                update_order_from_profile(order, profiles[order.customer.id])
                 resend_order(order, self.due_date, self.request)
                 self.successful_orders.append(order.id)
             except (
@@ -329,5 +328,6 @@ class BaseInvoicingService:
                 Order.DoesNotExist,
                 ValidationError,
                 VenepaikkaGraphQLError,
+                KeyError,
             ) as e:
                 self.fail_order(order, f'{_("Failed resending invoice")} ({e})')


### PR DESCRIPTION
## Description :sparkles:
Currently, failure while communicating with the city profile service (missing profile?) results in all recurring invoices to fail

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1339](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1339):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
