### PR TITLE
VEN-877: When creating CustomerProfile, use UUID object as the id

### DIFF
--- a/customers/services/profile.py
+++ b/customers/services/profile.py
@@ -261,7 +261,7 @@ class ProfileService:
         """
         response = self.query(query=mutation, variables=variables)
         global_id = response.get("createProfile", {}).get("profile", {}).get("id")
-        profile_id = from_global_id(global_id)
+        profile_id = UUID(from_global_id(global_id))
         profile = CustomerProfile.objects.create(id=profile_id)
         return profile
 


### PR DESCRIPTION
This avoids issues when comparing object id and one has str and other has UUID

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-XXX](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
