### PR TITLE
VEN-1352 | Expire all berth applications along with orders

### DIFF
--- a/applications/tests/conftest.py
+++ b/applications/tests/conftest.py
@@ -12,21 +12,21 @@ from ..notifications import NotificationType
 from .factories import BerthApplicationFactory, WinterStorageApplicationFactory
 
 
-@pytest.fixture
-def berth_switch_info(request):
-    has_reason = request.param if hasattr(request, "param") else None
-
+def _generate_berth_switch_info():
     berth = BerthFactory()
     berth.pier.harbor.create_translation("fi", name="Nykyinen satama")
 
-    berth_switch_reason = (
-        BerthSwitchReason.objects.language("fi").create(title="Good reason")
-        if has_reason
-        else None
+    berth_switch_reason = BerthSwitchReason.objects.language("fi").create(
+        title="Good reason"
     )
 
     berth_switch = BerthSwitch.objects.create(berth=berth, reason=berth_switch_reason)
     return berth_switch
+
+
+@pytest.fixture
+def berth_switch_info():
+    return _generate_berth_switch_info()
 
 
 @pytest.fixture
@@ -38,9 +38,25 @@ def berth_switch_reason():
 
 
 @pytest.fixture
-def berth_application():
+def berth_application(request):
+    application_type = request.param if hasattr(request, "param") else None
+
+    if application_type == "switch":
+        berth_switch_application = BerthApplicationFactory(
+            berth_switch=_generate_berth_switch_info()
+        )
+        return berth_switch_application
+
     berth_application = BerthApplicationFactory()
     return berth_application
+
+
+@pytest.fixture
+def berth_switch_application():
+    berth_switch_application = BerthApplicationFactory(
+        berth_switch=_generate_berth_switch_info()
+    )
+    return berth_switch_application
 
 
 berth_application2 = berth_application

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -410,6 +410,8 @@ def get_application_status(new_status) -> ApplicationStatus:
     # return None if application status need not be changed
     if new_status == OrderStatus.REJECTED:
         return ApplicationStatus.REJECTED
+    if new_status == OrderStatus.EXPIRED:
+        return ApplicationStatus.EXPIRED
     elif new_status in OrderStatus.get_paid_statuses():
         return ApplicationStatus.HANDLED
     else:


### PR DESCRIPTION
## Description :sparkles:
* Set the correct expired status for "normal" applications when the order is expired

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1352](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1352):** Set application to EXPIRED when the lease&invoice are expired

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_order_expiration.py::test_expire_too_old_unpaid_orders
```

## Additional notes 📝 
Once the changes are released, the following script has to be run to expire the applications connected to already expired orders:

https://gist.github.com/a-rmz/92e0f90f1b89a33c90e026f4dfe9a872