### PR TITLE
VEN-1358: fix is_available calculation for berths

### DIFF
--- a/resources/models.py
+++ b/resources/models.py
@@ -29,7 +29,7 @@ from leases.consts import ACTIVE_LEASE_STATUSES
 from leases.enums import LeaseStatus
 from leases.utils import (
     calculate_berth_lease_end_date,
-    calculate_berth_lease_start_date,
+    calculate_season_start_date,
     calculate_winter_storage_lease_end_date,
 )
 from payments.enums import OfferStatus, PriceTier
@@ -615,7 +615,7 @@ class BerthManager(models.Manager):
         from leases.models import BerthLease
         from payments.models import BerthSwitchOffer
 
-        season_start = calculate_berth_lease_start_date()
+        season_start = calculate_season_start_date()
         season_end = calculate_berth_lease_end_date()
         current_date = today().date()
 


### PR DESCRIPTION
## Description :sparkles:
Fix berth is_available calculation when the summer season is ongoing

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1358](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1358):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
resources/tests/test_resources_models.py:test_berth_is_available_one_paid_lease
### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
