### PR TITLE
VEN-1320 | Add permission checks for BerthSwitchOffers

### DIFF
--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -1,6 +1,7 @@
 from os.path import devnull
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django_ilmoitin.models import NotificationTemplate
@@ -135,7 +136,10 @@ def municipality():
 
 @pytest.fixture
 def customer_profile():
-    return CustomerProfileFactory()
+    profile = CustomerProfileFactory()
+    group, _created = Group.objects.get_or_create(name=settings.CUSTOMER_GROUP_NAME)
+    profile.user.groups.set([group])
+    return profile
 
 
 @pytest.fixture

--- a/resources/schema/utils.py
+++ b/resources/schema/utils.py
@@ -33,7 +33,7 @@ def resolve_piers(info, **kwargs):
         if (
             user
             and user.is_authenticated
-            and user_has_view_permission(user, BerthApplication)
+            and user_has_view_permission(BerthApplication)(user)
         ):
             application = get_node_from_global_id(
                 info, application_global_id, only_type=BerthApplicationNode


### PR DESCRIPTION
## Description :sparkles:
* Add checks for `BerthSwitchOfferNode` to allow only authorized users to query

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1320](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1320):** Add permission checks to BerthSwitchOfferNode

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest payments/tests/test_payments_queries_berth_switch_offers.py
```
