### PR TITLE
VEN-1245 | Check owner permissions

### DIFF
--- a/applications/schema/types.py
+++ b/applications/schema/types.py
@@ -7,7 +7,10 @@ from graphql_relay import to_global_id
 
 from customers.models import CustomerProfile
 from leases.models import BerthLease, WinterStorageLease
-from utils.relay import return_node_if_user_has_permissions
+from utils.relay import (
+    return_node_if_user_has_permissions,
+    return_queryset_if_user_has_permissions,
+)
 from utils.schema import CountConnection
 
 from ..enums import ApplicationAreaType, ApplicationStatus, WinterStorageMethod
@@ -105,6 +108,14 @@ class BerthApplicationNode(DjangoObjectType):
 
     @classmethod
     @login_required
+    def get_queryset(cls, queryset, info):
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset, user, BerthApplication, BerthLease, CustomerProfile
+        )
+
+    @classmethod
+    @login_required
     def get_node(cls, info, id):
         node = super().get_node(info, id)
         return return_node_if_user_has_permissions(
@@ -164,6 +175,18 @@ class WinterStorageApplicationNode(DjangoObjectType):
         if self.winterstorageareachoice_set.count():
             return self.winterstorageareachoice_set.all()
         return None
+
+    @classmethod
+    @login_required
+    def get_queryset(cls, queryset, info):
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset,
+            user,
+            WinterStorageApplication,
+            WinterStorageLease,
+            CustomerProfile,
+        )
 
     @classmethod
     @login_required

--- a/contracts/schema/types.py
+++ b/contracts/schema/types.py
@@ -1,6 +1,9 @@
 import graphene
 from graphene import relay
 from graphene_django import DjangoObjectType
+from graphql_jwt.decorators import login_required
+
+from utils.relay import return_queryset_if_user_has_permissions
 
 from ..enums import ContractStatus
 from ..models import VismaBerthContract, VismaWinterStorageContract
@@ -17,8 +20,12 @@ class BerthContractNode(DjangoObjectType):
     status = ContractStatusEnum()
 
     @classmethod
+    @login_required
     def get_queryset(cls, queryset, info):
-        return super().get_queryset(queryset, info)
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset, user, VismaBerthContract,
+        )
 
 
 class WinterStorageContractNode(DjangoObjectType):
@@ -30,8 +37,12 @@ class WinterStorageContractNode(DjangoObjectType):
     status = ContractStatusEnum()
 
     @classmethod
+    @login_required
     def get_queryset(cls, queryset, info):
-        return super().get_queryset(queryset, info)
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset, user, VismaWinterStorageContract,
+        )
 
 
 class AuthMethod(graphene.ObjectType):

--- a/leases/schema/types.py
+++ b/leases/schema/types.py
@@ -7,7 +7,10 @@ from contracts.schema import WinterStorageContractNode
 from contracts.schema.types import BerthContractNode
 from customers.models import CustomerProfile
 from resources.schema import BerthNode, WinterStoragePlaceNode, WinterStorageSectionNode
-from utils.relay import return_node_if_user_has_permissions
+from utils.relay import (
+    return_node_if_user_has_permissions,
+    return_queryset_if_user_has_permissions,
+)
 from utils.schema import CountConnection
 
 from ..enums import LeaseStatus
@@ -36,6 +39,14 @@ class BerthLeaseNode(DjangoObjectType):
         model = BerthLease
         interfaces = (graphene.relay.Node,)
         connection_class = CountConnection
+
+    @classmethod
+    @login_required
+    def get_queryset(cls, queryset, info):
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset, user, BerthLease, BerthApplication, CustomerProfile
+        )
 
     @classmethod
     @login_required
@@ -74,6 +85,18 @@ class WinterStorageLeaseNode(DjangoObjectType):
     def resolve_sticker_season(self, info, **kwargs):
         season = get_ws_sticker_season(self.start_date)
         return season.replace("_", "/")
+
+    @classmethod
+    @login_required
+    def get_queryset(cls, queryset, info):
+        user = info.context.user
+        return return_queryset_if_user_has_permissions(
+            queryset,
+            user,
+            WinterStorageLease,
+            WinterStorageApplication,
+            CustomerProfile,
+        )
 
     @classmethod
     @login_required


### PR DESCRIPTION
## Description :sparkles:
* Add a util function to only return the resources that belong to the customer making the request
* Add the check for ownership to missing nodes and querysets

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1245](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1245):** Add authorisation for customers

### Related :handshake:
#540 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest
```