### PR TITLE
VEN-1245 | Remove additional permission checks

### DIFF
--- a/applications/schema/queries.py
+++ b/applications/schema/queries.py
@@ -1,10 +1,6 @@
 import graphene
 from graphene_django.filter import DjangoFilterConnectionField
 
-from customers.models import CustomerProfile
-from leases.models import BerthLease, WinterStorageLease
-from users.decorators import view_permission_required
-
 from ..models import BerthApplication, BerthSwitchReason, WinterStorageApplication
 from .types import (
     ApplicationAreaTypeEnum,
@@ -51,7 +47,6 @@ class Query:
     def resolve_berth_switch_reasons(self, info, **kwargs):
         return BerthSwitchReason.objects.all()
 
-    @view_permission_required(BerthApplication, BerthLease, CustomerProfile)
     def resolve_berth_applications(self, info, **kwargs):
         statuses = kwargs.pop("statuses", [])
 
@@ -76,9 +71,6 @@ class Query:
             .order_by("created_at")
         )
 
-    @view_permission_required(
-        WinterStorageApplication, WinterStorageLease, CustomerProfile
-    )
     def resolve_winter_storage_applications(self, info, **kwargs):
         statuses = kwargs.pop("statuses", [])
         area_types = kwargs.pop("area_types", [])

--- a/leases/schema/queries.py
+++ b/leases/schema/queries.py
@@ -2,8 +2,6 @@ import django_filters
 import graphene
 from graphene_django.filter import DjangoFilterConnectionField
 
-from applications.models import BerthApplication, WinterStorageApplication
-from customers.models import CustomerProfile
 from users.decorators import view_permission_required
 
 from ..models import BerthLease, WinterStorageLease
@@ -45,7 +43,6 @@ class Query:
         SendExistingInvoicesPreviewType
     )
 
-    @view_permission_required(BerthLease, BerthApplication, CustomerProfile)
     def resolve_berth_leases(self, info, statuses=None, start_year=None, **kwargs):
         qs = BerthLease.objects
         if statuses:
@@ -65,9 +62,6 @@ class Query:
             .order_by("created_at")
         )
 
-    @view_permission_required(
-        WinterStorageLease, WinterStorageApplication, CustomerProfile
-    )
     def resolve_winter_storage_leases(
         self, info, statuses=None, start_year=None, **kwargs
     ):

--- a/payments/tests/test_payments_queries_berth_switch_offers.py
+++ b/payments/tests/test_payments_queries_berth_switch_offers.py
@@ -1,13 +1,18 @@
 import pytest
 
 from applications.schema import BerthApplicationNode
-from berth_reservations.tests.utils import assert_not_enough_permissions
+from berth_reservations.tests.utils import (
+    assert_not_enough_permissions,
+    create_api_client,
+)
 from customers.schema import ProfileNode
 from leases.schema import BerthLeaseNode
 from resources.schema import BerthNode
 from utils.relay import to_global_id
 
+from ..models import BerthSwitchOffer
 from ..schema.types import BerthSwitchOfferNode
+from .factories import BerthSwitchOfferFactory
 
 BERTH_SWITCH_OFFERS_QUERY = """
 query BERTH_SWITCH_OFFERS_QUERY  {
@@ -120,4 +125,42 @@ def test_get_berth_switch_offer(berth_switch_offer, api_client):
         },
         "lease": {"id": to_global_id(BerthLeaseNode, berth_switch_offer.lease.id)},
         "berth": {"id": to_global_id(BerthNode, berth_switch_offer.berth.id)},
+    }
+
+
+CUSTOMER_OWN_BERTH_SWITCH_OFFERS_QUERY = """
+query ORDERS {
+    berthSwitchOffers {
+        edges {
+            node {
+                id
+                lease {
+                    customer {
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def test_get_customer_own_orders(customer_profile):
+    customer_order = BerthSwitchOfferFactory(
+        customer=customer_profile,
+        lease__customer=customer_profile,
+        application__customer=customer_profile,
+    )
+    BerthSwitchOfferFactory()
+
+    api_client = create_api_client(user=customer_profile.user)
+    executed = api_client.execute(CUSTOMER_OWN_BERTH_SWITCH_OFFERS_QUERY)
+
+    assert BerthSwitchOffer.objects.count() == 2
+
+    assert len(executed["data"]["berthSwitchOffers"]["edges"]) == 1
+    assert executed["data"]["berthSwitchOffers"]["edges"][0]["node"] == {
+        "id": to_global_id(BerthSwitchOfferNode, customer_order.id),
+        "lease": {"customer": {"id": to_global_id(ProfileNode, customer_profile.id)}},
     }

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -1,6 +1,8 @@
 import graphene
 from django.db.models import QuerySet
 
+from users.utils import is_customer
+
 
 def update_object(instance, input):
     if not input:
@@ -30,6 +32,11 @@ class CountConnection(graphene.Connection):
         return len(set(self.iterable))
 
     def resolve_total_count(self, info, **kwargs):
+        if is_customer(info.context.user):
+            # If the user querying for the total is a customer (i.e. not an authorized admin),
+            # we only show the items available for them, not the whole count
+            return self.resolve_count(info)
+
         if isinstance(self.iterable, QuerySet):
             return self.iterable.model.objects.count()
 


### PR DESCRIPTION
## Description :sparkles:
* Remove additional permission checks for some nodes

Some nodes had additional `view` permission checking, which was not allowing for customers to query their own information. This permissions are already being checked on the `Node` level on the `get_queryset`method, so this extra checks were redundant.

## Issues :bug:
### Related :handshake:
**[VEN-1245](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1245):** Add authorisation for customers
#540 
#598 

## Testing :alembic:
### Manual testing :construction_worker_man:
1. Login as a non-admin user
2. Execute one of the fixed queries (leases, applications), you should see only the nodes that belong to the logged in user
```graphql
query BerthLeases {
  berthLeases {
    count
    totalCount
    edges {
      node {
        id
      }
    }
  }
}
```