### PR TITLE
Fix calculation for renewable marked winter places

### DIFF
--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -815,6 +815,36 @@ def test_query_send_marked_winter_storage_invoice_preview(api_client):
     }
 
 
+# Test added specifically to be sure that the sending of invoices on 17.8.21 would work
+@freeze_time("2021-08-17")
+def test_query_send_marked_winter_storage_invoice_preview_2021_08_17(
+    superuser_api_client,
+):
+    lease = WinterStorageLeaseFactory(
+        boat=None,
+        status=LeaseStatus.PAID,
+        start_date="2020-09-15",
+        end_date="2021-06-10",
+    )
+    WinterStorageLeaseFactory(
+        boat=None,
+        status=LeaseStatus.REFUSED,
+        start_date="2020-09-15",
+        end_date="2021-06-10",
+    )
+    WinterStorageProductFactory(
+        winter_storage_area=lease.place.winter_storage_section.area
+    )
+
+    executed = superuser_api_client.execute(
+        QUERY_SEND_WINTER_STORAGE_LEASE_INVOICE_PREVIEW
+    )
+
+    assert executed["data"]["sendMarkedWinterStorageInvoicePreview"] == {
+        "expectedLeases": 1
+    }
+
+
 CUSTOMER_OWN_BERTH_LEASES_QUERY = """
 query BERTH_LEASES {
     berthLeases {

--- a/resources/tests/test_resources_models.py
+++ b/resources/tests/test_resources_models.py
@@ -57,11 +57,11 @@ def test_berth_is_available_last_season_invalid_status(
     assert Berth.objects.get(id=berth.id).is_available
 
 
+@freeze_time("2020-01-01")
 @pytest.mark.parametrize("status", ["drafted", "offered", "paid", "error"])
 def test_berth_is_not_available_ends_during_season_before_lease_ends(
     superuser_api_client, berth, status
 ):
-
     start_date = calculate_berth_lease_start_date()
     end_date = calculate_berth_lease_end_date() - relativedelta(month=6, day=29)
 
@@ -81,6 +81,7 @@ def test_berth_is_not_available_ends_during_season_before_lease_ends(
         assert not Berth.objects.get(id=berth.id).is_available
 
 
+@freeze_time("2020-01-01")
 def test_berth_is_available_ends_during_season_after_lease_ends(
     superuser_api_client, berth
 ):


### PR DESCRIPTION
## Description :sparkles:
The logic for determining which leases are renewable for the next season worked on a way that on certain dates (like today - 16.8.21) it was getting the wrong season for renewing.

The updated logic checks:
* If today is during the season, get the leases which start on the `season_start.year`
* If today is outside of the season, get the leases which start on the previous year from the following season start (i.e. `season_start.year - 1`)

## Testing :alembic:
### Automated tests :gear:️
```
pytest leases/tests/test_lease_queries.py::test_query_send_marked_winter_storage_invoice_preview_2021_08_17
```