### PR TITLE
VEN-1368 | Keep the status of renewed leases

### DIFF
--- a/leases/services/invoice/base.py
+++ b/leases/services/invoice/base.py
@@ -129,6 +129,7 @@ class BaseInvoicingService:
                     document_id=contract.document_id,
                     invitation_id=contract.invitation_id,
                     passphrase=contract.passphrase,
+                    status=contract.status,
                 )
             elif isinstance(lease, WinterStorageLease):
                 VismaWinterStorageContract.objects.create(
@@ -136,6 +137,7 @@ class BaseInvoicingService:
                     document_id=contract.document_id,
                     invitation_id=contract.invitation_id,
                     passphrase=contract.passphrase,
+                    status=contract.status,
                 )
 
         lease.refresh_from_db()


### PR DESCRIPTION
## Description :sparkles:
* When creating the copy of the contract for the renewed lease, we keep the status so that customers that have signed the contract don't have to sign it again
