### PR TITLE
VEN-1369 | Add ordering by name for Harbors

### DIFF
--- a/resources/schema/types.py
+++ b/resources/schema/types.py
@@ -162,6 +162,10 @@ class HarborFilter(django_filters.FilterSet):
             "piers__suitable_boat_types",
         )
 
+    order_by = django_filters.OrderingFilter(
+        fields=(("translations__name", "name"),),
+        label="Supports only `name` and `-name`, defaults to `name`.",
+    )
     max_width = django_filters.NumberFilter()
     max_length = django_filters.NumberFilter()
 


### PR DESCRIPTION
## Description :sparkles:
* Add an `orderBy` option to the `harbors` query, which supports `name` (A-Z) and `-name` (Z-A)
* Set the default as A-Z
* Takes the language from the request, so it automatically sorts based on the language

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1369](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1369):** Sort Harbors by name

### Related :handshake:

## Testing :alembic:
### Manual testing :construction_worker_man:
```
query Leases {
  harbors {
    edges {
      node {
        properties {
          name
        }
      }
    }
  }
}
```