### PR TITLE
VEN-1401 | Use Kanslia's test Tunnistamo and HKI Profile in staging env

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -86,14 +86,14 @@ jobs:
           K8S_SECRET_DATABASE_DB: ${{ env.K8S_NAMESPACE }}
           K8S_SECRET_DATABASE_USERNAME: ${{ secrets.K8S_SECRET_DATABASE_USERNAME_REVIEW }}
           K8S_SECRET_DATABASE_PASSWORD: ${{ secrets.K8S_SECRET_DATABASE_PASSWORD_REVIEW }}
-          K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
+          K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.hel.ninja/openid"
           K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
           K8S_SECRET_VENE_UI_RETURN_URL: "https://venepaikat.hel.ninja/{LANG}"
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_URL: "https://real-bambora-api-url/api"
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_KEY: "dummy-key"
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_SECRET: "dummy-secret"
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS: "dummy-bank"
-          K8S_SECRET_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
+          K8S_SECRET_PROFILE_API_URL: "https://profile-api.test.hel.ninja/graphql/"
           K8S_SECRET_VISMASIGN_API_URL: ${{ secrets.GH_TEST_VISMASIGN_API_URL }}
           K8S_SECRET_VISMASIGN_CLIENT_IDENTIFIER: ${{ secrets.GH_TEST_VISMASIGN_CLIENT_IDENTIFIER }}
           K8S_SECRET_VISMASIGN_SECRET: ${{ secrets.GH_TEST_VISMASIGN_SECRET }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,7 +58,7 @@ jobs:
           K8S_SECRET_ALLOWED_HOSTS: "*"
           K8S_SECRET_CORS_ORIGIN_ALLOW_ALL: 1
           K8S_SECRET_SECRET_KEY: ${{ secrets.GH_QA_DJANGO_SECRET_KEY }}
-          K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
+          K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.hel.ninja/openid"
           K8S_SECRET_MAIL_MAILGUN_KEY: ${{ secrets.GH_QA_SECRET_MAILGUN_API_KEY }}
           K8S_SECRET_MAIL_MAILGUN_DOMAIN: "hel.fi"
           K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
@@ -73,7 +73,7 @@ jobs:
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_KEY: ${{ secrets.GH_QA_BAMBORA_API_KEY }}
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_SECRET: ${{ secrets.GH_QA_BAMBORA_API_SECRET }}
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS: ${{ secrets.GH_QA_BAMBORA_PAYMENT_METHODS }}
-          K8S_SECRET_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
+          K8S_SECRET_PROFILE_API_URL: "https://profile-api.test.hel.ninja/graphql/"
           K8S_SECRET_ELASTIC_APM_ENVIRONMENT: "test"
           K8S_SECRET_ELASTIC_APM_SECRET_TOKEN: ${{ secrets.GH_QA_ELASTIC_APM_TOKEN }}
           K8S_SECRET_ELASTIC_APM_SERVER_URL: ${{ secrets.GH_QA_ELASTIC_APM_URL }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ VENE_PAYMENTS_BAMBORA_API_KEY=dummy-key
 VENE_PAYMENTS_BAMBORA_API_SECRET=dummy-secret
 VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS="dummy-bank"
 
-PROFILE_API_URL=https://profiili-api.test.kuva.hel.ninja/graphql/
+PROFILE_API_URL=https://profile-api.test.hel.ninja/graphql/
 PROFILE_TOKEN_SERVICE=https://api.hel.fi/auth/helsinkiprofile
 
 VISMASIGN_API_URL=http://fake-vismasign-api.com


### PR DESCRIPTION
## Description :sparkles:

Switch the staging and review environments to use Kanslia's test Tunnistamo and HKI Profile to be able to test Suomi.fi strong authentication.

## Issues :bug:
### Related :handshake:
**[VEN-1401](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1401)** 


## Testing :alembic:

### Manual testing :construction_worker_man:

It is not possible to fully test this before merging, but most parts can be tested locally. 

## Additional notes :spiral_notepad:

Currently it is not possible to get PR environments' authentication to actually work with Kanslia's Tunnistamo, but those envs are not working at the moment anyway, so we switch them to Kanslia's Tunnistamo to prevent confusion in the future.