### PR TITLE
VEN-1397 | Require customers to use strong authentication

### DIFF
--- a/applications/schema/types.py
+++ b/applications/schema/types.py
@@ -139,7 +139,12 @@ class BerthApplicationNode(DjangoObjectType):
     def get_queryset(cls, queryset, info):
         user = info.context.user
         return return_queryset_if_user_has_permissions(
-            queryset, user, BerthApplication, BerthLease, CustomerProfile
+            queryset,
+            user,
+            BerthApplication,
+            BerthLease,
+            CustomerProfile,
+            request=info.context,
         )
 
     @classmethod
@@ -224,6 +229,7 @@ class WinterStorageApplicationNode(DjangoObjectType):
             WinterStorageApplication,
             WinterStorageLease,
             CustomerProfile,
+            request=info.context,
         )
 
     @classmethod

--- a/berth_reservations/oidc.py
+++ b/berth_reservations/oidc.py
@@ -15,7 +15,7 @@ class GraphQLApiTokenAuthentication(ApiTokenAuthentication):
         user_auth_tuple = super().authenticate(request)
         if not user_auth_tuple:
             return None
-        user, auth = user_auth_tuple
+        user, request.auth = user_auth_tuple
         return user
 
     def __convert_amr_to_list(self, id_token):

--- a/berth_reservations/tests/conftest.py
+++ b/berth_reservations/tests/conftest.py
@@ -100,6 +100,14 @@ def berth_customer_api_client():
 
 
 @pytest.fixture
+def berth_customer_weak_auth_api_client():
+    user = UserFactory()
+    group = Group.objects.get(name="Berth customer")
+    user.groups.set([group])
+    return create_api_client(user=user, strong_auth=False)
+
+
+@pytest.fixture
 def api_client(
     request,
     user_api_client,

--- a/contracts/schema/types.py
+++ b/contracts/schema/types.py
@@ -27,6 +27,7 @@ class BerthContractNode(DjangoObjectType):
             queryset,
             user,
             VismaBerthContract,
+            request=info.context,
         )
 
 
@@ -46,6 +47,7 @@ class WinterStorageContractNode(DjangoObjectType):
             queryset,
             user,
             VismaWinterStorageContract,
+            request=info.context,
         )
 
 

--- a/customers/schema/types.py
+++ b/customers/schema/types.py
@@ -70,6 +70,7 @@ class BoatNode(DjangoObjectType):
             Boat,
             CustomerProfile,
             customer_queryset=queryset.filter(owner__user=user),
+            request=info.context,
         )
 
     @classmethod

--- a/customers/tests/test_customers_queries.py
+++ b/customers/tests/test_customers_queries.py
@@ -581,7 +581,8 @@ def test_query_berth_profile(api_client, customer_profile):
     }
 
 
-def test_query_berth_profile_self_user(customer_profile):
+@pytest.mark.parametrize("has_strong_auth", (True, False))
+def test_query_berth_profile_self_user(customer_profile, has_strong_auth):
     berth_profile_id = to_global_id(ProfileNode, customer_profile.id)
 
     boat = BoatFactory(owner=customer_profile)
@@ -601,8 +602,14 @@ def test_query_berth_profile_self_user(customer_profile):
 
     query = QUERY_BERTH_PROFILE % berth_profile_id
 
-    api_client = create_api_client(user=customer_profile.user)
+    api_client = create_api_client(
+        user=customer_profile.user, strong_auth=has_strong_auth
+    )
     executed = api_client.execute(query)
+
+    if not has_strong_auth:
+        assert_not_enough_permissions(executed)
+        return
 
     boat_id = to_global_id(BoatNode, boat.id)
     berth_application_id = to_global_id(BerthApplicationNode, berth_application.id)

--- a/leases/schema/types.py
+++ b/leases/schema/types.py
@@ -45,7 +45,12 @@ class BerthLeaseNode(DjangoObjectType):
     def get_queryset(cls, queryset, info):
         user = info.context.user
         return return_queryset_if_user_has_permissions(
-            queryset, user, BerthLease, BerthApplication, CustomerProfile
+            queryset,
+            user,
+            BerthLease,
+            BerthApplication,
+            CustomerProfile,
+            request=info.context,
         )
 
     @classmethod
@@ -96,6 +101,7 @@ class WinterStorageLeaseNode(DjangoObjectType):
             WinterStorageLease,
             WinterStorageApplication,
             CustomerProfile,
+            request=info.context,
         )
 
     @classmethod

--- a/leases/tests/test_lease_queries.py
+++ b/leases/tests/test_lease_queries.py
@@ -865,12 +865,19 @@ query BERTH_LEASES {
 """
 
 
-def test_get_customer_own_berth_leases(customer_profile):
+@pytest.mark.parametrize("has_strong_auth", (True, False))
+def test_get_customer_own_berth_leases(customer_profile, has_strong_auth):
     customer_lease = BerthLeaseFactory(customer=customer_profile)
     BerthLeaseFactory()
 
-    api_client = create_api_client(user=customer_profile.user)
+    api_client = create_api_client(
+        user=customer_profile.user, strong_auth=has_strong_auth
+    )
     executed = api_client.execute(CUSTOMER_OWN_BERTH_LEASES_QUERY)
+
+    if not has_strong_auth:
+        assert_not_enough_permissions(executed)
+        return
 
     assert BerthLease.objects.count() == 2
 

--- a/payments/schema/types.py
+++ b/payments/schema/types.py
@@ -246,6 +246,7 @@ class OrderNode(DjangoObjectType):
             BerthLease,
             WinterStorageLease,
             CustomerProfile,
+            request=info.context,
         )
 
     @classmethod
@@ -282,6 +283,7 @@ class OrderRefundNode(DjangoObjectType):
             user,
             Order,
             OrderRefund,
+            request=info.context,
         )
 
 
@@ -317,6 +319,7 @@ class BerthSwitchOfferNode(DjangoObjectType, AbstractOfferNode):
             BerthSwitchOffer,
             BerthLease,
             BerthApplication,
+            request=info.context,
         )
 
     @classmethod

--- a/payments/tests/test_payments_queries.py
+++ b/payments/tests/test_payments_queries.py
@@ -941,12 +941,19 @@ query ORDERS {
 """
 
 
-def test_get_customer_own_orders(customer_profile):
+@pytest.mark.parametrize("has_strong_auth", (True, False))
+def test_get_customer_own_orders(customer_profile, has_strong_auth):
     customer_order = OrderFactory(customer=customer_profile)
     OrderFactory()
 
-    api_client = create_api_client(user=customer_profile.user)
+    api_client = create_api_client(
+        user=customer_profile.user, strong_auth=has_strong_auth
+    )
     executed = api_client.execute(CUSTOMER_OWN_ORDERS_QUERY)
+
+    if not has_strong_auth:
+        assert_not_enough_permissions(executed)
+        return
 
     assert Order.objects.count() == 2
 

--- a/users/decorators.py
+++ b/users/decorators.py
@@ -4,7 +4,12 @@ from typing import Callable, List, Optional
 from graphql_jwt.decorators import permission_required, user_passes_test
 from graphql_jwt.exceptions import PermissionDenied
 
-from .utils import is_customer, user_has_models_perms, user_is_linked_to_node
+from .utils import (
+    has_strong_authentication,
+    is_customer,
+    user_has_models_perms,
+    user_is_linked_to_node,
+)
 
 
 def view_permission_required(*models):
@@ -54,6 +59,7 @@ def check_user_is_authorised(
 
             if (
                 is_customer(user)
+                and has_strong_authentication(info.context)
                 and all([user_is_linked_to_node(user, node) for node in nodes_to_check])
             ) or all([check(user) for check in model_checks]):
                 return f(cls, root, info, **input)

--- a/users/utils.py
+++ b/users/utils.py
@@ -73,3 +73,10 @@ def user_is_linked_to_node(user, node):
 def validate_user_is_linked_to_node(user, node):
     if not user_is_linked_to_node(user, node):
         raise PermissionDenied(_("You do not have permission to perform this action."))
+
+
+def has_strong_authentication(request):
+    if not (auth := getattr(request, "auth", None)):
+        return False
+
+    return auth.data.get("loa") in ("substantial", "high")


### PR DESCRIPTION
## Description :sparkles:

Require that all queries and mutations executed by customers are carried out under strong authentication by checking the `loa` claim of the API token.

 🚧 **WIP:** It is still a bit unclear whether this is the way we want to address the need.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1397](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1397): Only allow users with strong authentication** 
