### PR TITLE
VEN-1416 | Fix createMyBerthProfile mutation

### DIFF
--- a/customers/services/profile.py
+++ b/customers/services/profile.py
@@ -167,24 +167,24 @@ class ProfileService:
 
     def get_my_profile(self) -> Optional[HelsinkiProfileUser]:
         query = """
-            query MyProfile {{
-                my_profile: myProfile {{
+            query MyProfile {
+                my_profile: myProfile {
                     id
                     first_name: firstName
                     last_name: lastName
-                    primary_email: primaryEmail {{
+                    primary_email: primaryEmail {
                         email
-                    }}
-                    primary_phone: primaryPhone {{
+                    }
+                    primary_phone: primaryPhone {
                         phone
-                    }}
-                    primary_address: primaryAddress {{
+                    }
+                    primary_address: primaryAddress {
                         address
                         postal_code: postalCode
                         city
-                    }}
-                }}
-            }}
+                    }
+                }
+            }
         """
 
         response = self.query(query)


### PR DESCRIPTION
## Description :sparkles:

Fixed two issues related to `createMyBerthProfile` mutation:

* `myProfile` query to HKI profile which the mutation executes was broken.
* the mutation returned an error if the user already had a profile. Changed it to always return a valid `ProfileNode` and a boolean field `created` that tells if a new profile was created or not.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1416](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1416): createMyBerthProfile mutation call fails with unclear reason** 

