### PR TITLE
Update Profile service API URL

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_KEY: ${{ secrets.GH_PROD_BAMBORA_API_KEY }}
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_API_SECRET: ${{ secrets.GH_PROD_BAMBORA_API_SECRET }}
           K8S_SECRET_VENE_PAYMENTS_BAMBORA_PAYMENT_METHODS: ${{ secrets.GH_PROD_BAMBORA_PAYMENT_METHODS }}
-          K8S_SECRET_PROFILE_API_URL: "https://profiili-api.prod.kuva.hel.ninja/graphql/"
+          K8S_SECRET_PROFILE_API_URL: "https://api.hel.fi/profiili/graphql/"
           K8S_SECRET_ELASTIC_APM_ENVIRONMENT: "production"
           K8S_SECRET_ELASTIC_APM_SECRET_TOKEN: ${{ secrets.GH_PROD_ELASTIC_APM_TOKEN }}
           K8S_SECRET_ELASTIC_APM_SERVER_URL: ${{ secrets.GH_PROD_ELASTIC_APM_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY --chown=appuser:appuser requirements.txt /app/
 # just extras.
 RUN apt-install.sh \
   gdal-bin \
-  python-gdal \
   python3-gdal \
   gettext \
   build-essential \


### PR DESCRIPTION
## Description :sparkles:
* Replace the `ProfileService` url

### Related :handshake:
* [2.0.12-hotfix](https://github.com/City-of-Helsinki/berth-reservations/releases/tag/release-2.0.12-hotfix)

## Additional notes :spiral_notepad:
This was already fixed as a hotfix on [2.0.12-hotfix](https://github.com/City-of-Helsinki/berth-reservations/releases/tag/release-2.0.12-hotfix), but this PR is to bring this changes properly to `master`