### PR TITLE
VEN-1420 | Resolve annotated props on single node calls

### DIFF
--- a/applications/schema/types.py
+++ b/applications/schema/types.py
@@ -43,6 +43,9 @@ class HarborChoiceType(DjangoObjectType):
         model = HarborChoice
         exclude = ("id", "application")
 
+    def resolve_harbor(self, info, **kwargs):
+        return info.context.harbor_loader.load(self.harbor_id)
+
 
 class BerthSwitchReasonType(DjangoObjectType):
     title = graphene.String()
@@ -127,9 +130,7 @@ class BerthApplicationNode(DjangoObjectType):
         return None
 
     def resolve_harbor_choices(self, info, **kwargs):
-        if self.harborchoice_set.count():
-            return self.harborchoice_set.all()
-        return None
+        return self.harborchoice_set.all()
 
     def resolve_changes(self, info, **kwargs):
         return self.changes.all()
@@ -152,7 +153,9 @@ class BerthApplicationNode(DjangoObjectType):
 
 
 class WinterStorageAreaChoiceType(DjangoObjectType):
-    harbor = graphene.Field("resources.schema.HarborNode", required=True)
+    winter_storage_area = graphene.Field(
+        "resources.schema.WinterStorageAreaNode", required=True
+    )
     winter_storage_section_ids = graphene.List(graphene.ID)
 
     class Meta:
@@ -164,6 +167,9 @@ class WinterStorageAreaChoiceType(DjangoObjectType):
             to_global_id("WinterStorageSectionNode", section.id)
             for section in self.winter_storage_area.sections.all()
         )
+
+    def resolve_winter_storage_area(self, info, **kwargs):
+        return info.context.ws_area_loader.load(self.winter_storage_area_id)
 
 
 class WinterStorageApplicationFilter(django_filters.FilterSet):
@@ -207,9 +213,7 @@ class WinterStorageApplicationNode(DjangoObjectType):
         return None
 
     def resolve_winter_storage_area_choices(self, info, **kwargs):
-        if self.winterstorageareachoice_set.count():
-            return self.winterstorageareachoice_set.all()
-        return None
+        return self.winterstorageareachoice_set.all()
 
     def resolve_changes(self, info, **kwargs):
         return self.changes.all()

--- a/berth_reservations/middlewares.py
+++ b/berth_reservations/middlewares.py
@@ -5,9 +5,11 @@ from leases.schema import BerthLeaseForBerthLoader
 from resources.schema import (
     BerthLoader,
     BerthTypeLoader,
+    HarborLoader,
     PierLoader,
     PiersForHarborLoader,
     SuitableBoatTypeLoader,
+    WSAreaLoader,
 )
 
 __all__ = ["HostFixupMiddleware", "GQLDataLoaders"]
@@ -16,6 +18,8 @@ LOADERS = {
     "leases_for_berth_loader": BerthLeaseForBerthLoader,
     "piers_for_harbor_loader": PiersForHarborLoader,
     "customer_loader": CustomerProfileLoader,
+    "harbor_loader": HarborLoader,
+    "ws_area_loader": WSAreaLoader,
     "pier_loader": PierLoader,
     "berth_loader": BerthLoader,
     "suitable_boat_type_loader": SuitableBoatTypeLoader,

--- a/customers/schema/loaders.py
+++ b/customers/schema/loaders.py
@@ -1,18 +1,5 @@
-from collections import defaultdict
-
-from promise import Promise
-from promise.dataloader import DataLoader
+from utils.dataloaders import model_loader
 
 from ..models import CustomerProfile
 
-
-class CustomerProfileLoader(DataLoader):
-    def batch_load_fn(self, customer_ids):
-        customers = defaultdict(CustomerProfile)
-
-        for customer in CustomerProfile.objects.filter(id__in=customer_ids).iterator():
-            customers[customer.id] = customer
-
-        return Promise.resolve(
-            [customers.get(customer_id) for customer_id in customer_ids]
-        )
+CustomerProfileLoader = model_loader(CustomerProfile)

--- a/resources/schema/__init__.py
+++ b/resources/schema/__init__.py
@@ -1,9 +1,11 @@
 from .loaders import (
     BerthLoader,
     BerthTypeLoader,
+    HarborLoader,
     PierLoader,
     PiersForHarborLoader,
     SuitableBoatTypeLoader,
+    WSAreaLoader,
 )
 from .mutations import Mutation
 from .queries import Query
@@ -30,6 +32,7 @@ __all__ = [
     "BerthTypeLoader",
     "BoatTypeType",
     "HarborFilter",
+    "HarborLoader",
     "HarborNode",
     "Mutation",
     "PierLoader",
@@ -37,6 +40,7 @@ __all__ = [
     "PiersForHarborLoader",
     "Query",
     "SuitableBoatTypeLoader",
+    "WSAreaLoader",
     "WinterStorageAreaFilter",
     "WinterStorageAreaNode",
     "WinterStoragePlaceNode",

--- a/resources/schema/loaders.py
+++ b/resources/schema/loaders.py
@@ -3,7 +3,13 @@ from collections import defaultdict
 from promise import Promise
 from promise.dataloader import DataLoader
 
-from ..models import Berth, BerthType, BoatType, Pier
+from utils.dataloaders import model_loader
+
+from ..models import Berth, BerthType, BoatType, Harbor, Pier, WinterStorageArea
+
+BerthTypeLoader = model_loader(BerthType)
+HarborLoader = model_loader(Harbor)
+WSAreaLoader = model_loader(WinterStorageArea)
 
 
 class PierLoader(DataLoader):
@@ -59,16 +65,4 @@ class SuitableBoatTypeLoader(DataLoader):
 
         return Promise.resolve(
             [boat_types.get(boat_type_id) for boat_type_id in boat_type_ids]
-        )
-
-
-class BerthTypeLoader(DataLoader):
-    def batch_load_fn(self, berth_type_ids):
-        berth_types = defaultdict(BerthType)
-
-        for berth_type in BerthType.objects.filter(id__in=berth_type_ids).iterator():
-            berth_types[berth_type.id] = berth_type
-
-        return Promise.resolve(
-            [berth_types.get(berth_type_id) for berth_type_id in berth_type_ids]
         )

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1,0 +1,19 @@
+from collections import defaultdict
+from typing import Type
+
+from django.db.models import Model
+from promise import Promise
+from promise.dataloader import DataLoader
+
+
+def model_loader(model: Type[Model]):
+    class ModelLoader(DataLoader):
+        def batch_load_fn(self, object_ids):
+            objects = defaultdict(model)
+
+            for object in model.objects.filter(id__in=object_ids).iterator():
+                objects[object.id] = object
+
+            return Promise.resolve([objects.get(object_id) for object_id in object_ids])
+
+    return ModelLoader


### PR DESCRIPTION
## Description :sparkles:
* Add an explicit resolver for Harbor/Area properties that are only annotated by the manager, so they have to be explicitly queried

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1420](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1420):** Querying harbours through berthApplication results in an error

## Testing :alembic:
### Manual testing :construction_worker_man:
```graphql
query Applications {
  berthApplications {
    edges {
      node {
        id
        harborChoices {
          harbor {
            id
            properties {
              name
              electricity
              gate
              lighting
              wasteCollection
              water
            }
          }
        }
      }
    }
  }
}
```
Should then include the values for the selected harbor.
```json
{
    "properties": {
        "name": "Airorannan venesatama",
        "electricity": false,
        "gate": false,
        "lighting": false,
        "wasteCollection": false,
        "water": false
    }
}
```