### PR TITLE
VEN-1422 | Fix marked winter storage order price rounding

### DIFF
--- a/leases/tests/test_lease_mutations.py
+++ b/leases/tests/test_lease_mutations.py
@@ -1539,9 +1539,7 @@ def test_create_winter_storage_lease_with_order(
     assert Order.objects.count() == 1
     sqm = winter_storage_place.place_type.width * winter_storage_place.place_type.length
     expected_price = product.price_value
-    expected_price = rounded(
-        expected_price * sqm, decimals=2, as_string=True, round_to_nearest=1
-    )
+    expected_price = rounded(expected_price * sqm, decimals=2, as_string=True)
 
     assert (
         executed["data"]["createWinterStorageLease"]["winterStorageLease"].pop("id")

--- a/payments/models.py
+++ b/payments/models.py
@@ -707,9 +707,7 @@ class Order(UUIDModel, TimeStampedModel, SerializableMixin):
                         self.lease.place.place_type.width
                         * self.lease.place.place_type.length
                     )
-                    price = round_to_nearest(
-                        price * place_sqm, round_to_nearest=1, decimals=2
-                    )
+                    price = round_to_nearest(price * place_sqm, decimals=2)
                 elif self.lease.boat:
                     # If the lease is only associated to an section,
                     # calculate the price based on the boat dimensions

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -69,7 +69,6 @@ def test_initiate_refund_success(provider_base_config: dict, order: Order):
             order.product.price_value
             * order.lease.place.place_type.width
             * order.lease.place.place_type.length,
-            round_to_nearest=1,
         )
         area = order.lease.place.winter_storage_section.area
 
@@ -137,7 +136,6 @@ def test_initiate_refund_no_order_email(provider_base_config: dict, order: Order
             order.product.price_value
             * order.lease.place.place_type.width
             * order.lease.place.place_type.length,
-            round_to_nearest=1,
         )
         area = order.lease.place.winter_storage_section.area
 

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -226,9 +226,7 @@ def test_order_retrieves_winter_storage_lease(winter_storage_lease):
         winter_storage_lease.place.place_type.width
         * winter_storage_lease.place.place_type.length
     )
-    expected_price = rounded(
-        order.product.price_value * sqm, decimals=2, round_to_nearest=1
-    )
+    expected_price = rounded(order.product.price_value * sqm, decimals=2)
 
     assert order.lease.id == winter_storage_lease.id
     assert order._lease_content_type.name == winter_storage_lease._meta.verbose_name
@@ -259,7 +257,6 @@ def test_order_winter_storage_product_price(winter_storage_lease):
         * winter_storage_lease.place.place_type.width
         * winter_storage_lease.place.place_type.length,
         decimals=2,
-        round_to_nearest=1,
     )
     assert order.product == expected_product
     assert order.price == expected_price
@@ -347,7 +344,7 @@ def test_order_winter_storage_lease_right_price_for_full_season(winter_storage_a
     assert order.lease.end_date == calculate_winter_storage_lease_end_date()
     sqm = order.lease.place.place_type.width * order.lease.place.place_type.length
 
-    expected_price = rounded(Decimal("100.00") * sqm, decimals=2, round_to_nearest=1)
+    expected_price = rounded(Decimal("100.00") * sqm, decimals=2)
     assert order.price == expected_price
 
     for service, created in services.items():
@@ -1089,27 +1086,20 @@ def test_berth_switch_offer_lease_changed_status():
 @pytest.mark.parametrize(
     "width,length,expected_price",
     [
-        (2.4, 6, 164),
-        (2.5, 6, 171),
-        (3.5, 12, 479),
-        (3, 10, 342),
-        (3, 8, 274),
-        (4, 12, 547),
-        (3.5, 10, 399),
-        (4.5, 12, 616),
+        ("2.4", "6", "164.16"),
+        ("2.5", "6", "171"),
+        ("3.5", "12", "478.80"),
+        ("3", "10", "342"),
+        ("3", "8", "273.60"),
+        ("4", "12", "547.20"),
+        ("3.5", "10", "399"),
+        ("4.5", "12", "615.60"),
     ],
 )
 def test_marked_winter_storage_price_rounded(width, length, expected_price):
-    """For a place of 2,4 x 6,0, with the regular price of 11,4e the actual
-    price would be 164,16e.
-    According to the pricing rules, the prices are "rounded" to the nearest integer,
-    in this case 164,00e.
-
-    Testing all the possible width-length-price combinations according to the pricing table.
-    """
     lease = WinterStorageLeaseFactory(
-        place__place_type__width=width,
-        place__place_type__length=length,
+        place__place_type__width=Decimal(width),
+        place__place_type__length=Decimal(length),
         create_product=False,
     )
     WinterStorageProductFactory(

--- a/payments/tests/test_payments_mutations.py
+++ b/payments/tests/test_payments_mutations.py
@@ -795,7 +795,6 @@ def test_create_order_winter_storage_lease(api_client, winter_storage_lease):
         winter_storage_lease.place.place_type.width
         * winter_storage_lease.place.place_type.length
         * expected_product.price_value,
-        round_to_nearest=1,
         as_string=True,
     )
 

--- a/payments/tests/test_payments_mutations_refunds.py
+++ b/payments/tests/test_payments_mutations_refunds.py
@@ -73,7 +73,6 @@ def test_refund_order(
             order.product.price_value
             * order.lease.place.place_type.width
             * order.lease.place.place_type.length,
-            round_to_nearest=1,
         )
         area = order.lease.place.winter_storage_section.area
 


### PR DESCRIPTION
## Description :sparkles:

Earlier marked winter storage order prices were rounded to the nearest one euro, now they are rounded to the nearest one cent.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1422](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1422): Price rounding wrong** 
