### PR TITLE
VEN-1411 | Fix Order payload not built correctly

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -631,6 +631,16 @@ class Order(UUIDModel, TimeStampedModel, SerializableMixin):
     def total_tax_value(self):
         return self.total_price - self.total_pretax_price
 
+    @property
+    def has_customer_information(self):
+        return all(
+            [
+                self.customer_first_name,
+                self.customer_last_name,
+                self.customer_email,
+            ]
+        )
+
     def _check_valid_products(self) -> None:
         if self.product and not isinstance(
             self.product, (BerthProduct, WinterStorageProduct)

--- a/payments/tests/test_talpa_ecom.py
+++ b/payments/tests/test_talpa_ecom.py
@@ -357,6 +357,11 @@ def test_payload_add_place_products(
 def test_payload_add_customer_order_with_application(
     talpa_ecom_payment_provider: TalpaEComProvider, order: Order
 ):
+    order.customer_first_name = None
+    order.customer_last_name = None
+    order.customer_email = None
+    order.save()
+
     payload = {}
     talpa_ecom_payment_provider.payload_add_customer(payload, order)
     application = order.lease.application


### PR DESCRIPTION
## Description :sparkles:
* Parse the `vatPercentage` as string
* Give higher priority to order customer fields rather than application
