### PR TITLE
Fix migration that populates boat for applications

### DIFF
--- a/applications/migrations/0037_add_application_boat_relation.py
+++ b/applications/migrations/0037_add_application_boat_relation.py
@@ -14,8 +14,9 @@ def populate_application_boat(apps, schema_editor):
     )
     Boat = apps.get_model("customers", "Boat")
 
-    for application in chain(
-        BerthApplication.objects.all(), WinterStorageApplication.objects.all()
+    for application in sorted(
+        chain(BerthApplication.objects.all(), WinterStorageApplication.objects.all()),
+        key=lambda a: a.created_at,
     ):
 
         def prop_or_none(prop):
@@ -24,27 +25,45 @@ def populate_application_boat(apps, schema_editor):
                 value = None
             return value
 
-        boat = Boat.objects.update_or_create(
-            owner=application.customer,
-            registration_number=application.boat_registration_number,
-            defaults={
-                "boat_type_id": application.boat_type_id or OTHER_BOAT_TYPE_ID,
-                "length": application.boat_length,
-                "width": application.boat_width,
-                "registration_number": getattr(
-                    application, "boat_registration_number", ""
-                ),
-                "name": getattr(application, "boat_name", ""),
-                "model": getattr(application, "boat_model", ""),
-                "draught": prop_or_none("boat_draught"),
-                "weight": prop_or_none("boat_weight"),
-                "propulsion": getattr(application, "boat_propulsion", ""),
-                "hull_material": getattr(application, "boat_hull_material", ""),
-                "intended_use": getattr(application, "boat_intended_use", ""),
-                "is_inspected": prop_or_none("boat_is_inspected"),
-                "is_insured": prop_or_none("boat_is_insured"),
-            },
-        )[0]
+        boat = None
+
+        if application.customer and application.boat_registration_number:
+            try:
+                # Use an existing Boat if there is exactly one that matches with the
+                # application's customer and registration number
+                boat = Boat.objects.get(
+                    owner=application.customer,
+                    registration_number=application.boat_registration_number,
+                )
+            except (Boat.DoesNotExist, Boat.MultipleObjectsReturned):
+                pass
+
+        if not boat:
+            # If there is no exact match a new Boat will be created
+            boat = Boat(
+                owner=application.customer,
+                registration_number=application.boat_registration_number,
+            )
+
+        boat_data = {
+            "boat_type_id": application.boat_type_id or OTHER_BOAT_TYPE_ID,
+            "length": application.boat_length,
+            "width": application.boat_width,
+            "registration_number": getattr(application, "boat_registration_number", ""),
+            "name": getattr(application, "boat_name", ""),
+            "model": getattr(application, "boat_model", ""),
+            "draught": prop_or_none("boat_draught"),
+            "weight": prop_or_none("boat_weight"),
+            "propulsion": getattr(application, "boat_propulsion", ""),
+            "hull_material": getattr(application, "boat_hull_material", ""),
+            "intended_use": getattr(application, "boat_intended_use", ""),
+            "is_inspected": prop_or_none("boat_is_inspected"),
+            "is_insured": prop_or_none("boat_is_insured"),
+        }
+        for key, value in boat_data.items():
+            setattr(boat, key, value)
+
+        boat.save()
 
         # use queryset.update() instead of instance.save() to avoid creating a change entry
         type(application).objects.filter(pk=application.pk).update(boat=boat)


### PR DESCRIPTION
## Description :sparkles:

Now we use an existing boat only if the application has a related `CustomerProfile` instance and a `boat_registration_number`, and there is exactly one `Boat` that matches those.

Also, applications are now handled in creation order.
