### PR TITLE
Fix docker environment related conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ VISMASIGN_TEST_SSN=dummy-vismasign-test-ssn
 NOTIFICATION_SERVICE_API_URL=http://fake-notification-api.example.com/v1
 NOTIFICATION_SERVICE_TOKEN=dummy-notification-token
 NOTIFICATION_SERVICE_SENDER_NAME=Hel.fi
+
+# For local Tunnistamo use
+# TOKEN_AUTH_AUTHSERVER_URL=http://tunnistamo-backend:8000/openid
 ```
 
 2. Run `docker-compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             POSTGRES_PASSWORD: berth_reservations
             POSTGRES_DB: berth_reservations
         ports:
-            - "5432:5432"
+            - "5434:5432"
         volumes:
             - berth-postgres-data-volume:/var/lib/postgresql/data
         container_name: berth-db
@@ -26,7 +26,7 @@ services:
             - .:/app
             - berth-django-media-volume:/var/media/
         ports:
-            - "8000:8000"
+            - "8081:8000"
         depends_on:
             - postgres
         container_name: berth


### PR DESCRIPTION
## Description :sparkles:

With the current default settings it was impossible to run berth-reservations along with tunnistamo and open-city-profile.