### PR TITLE
Merge filters to berthProfiles

### DIFF
--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -1,6 +1,6 @@
 import graphene
 import graphene_django_optimizer as gql_optimizer
-from django.db.models import Count, Q
+from django.db.models import Count, Q, Case, When
 from graphene_django.filter import DjangoFilterConnectionField
 
 from applications.enums import ApplicationAreaType
@@ -225,7 +225,8 @@ class Query:
                     "Cannot filter by Helsinki Profile fields without API Token"
                 )
             ids = _get_ids_from_profile_service(kwargs, profile_token)
-            qs = qs.in_bulk(id_list=[ids])
+            preserved = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(ids)])
+            qs = qs.filter(id__in=ids).order_by(preserved)
 
         # General filters
         qs = _general_filters(kwargs, qs)

--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -170,16 +170,21 @@ class Query:
         address=graphene.String(),
         sort_by=graphene.String(),
         api_token=graphene.String(),
-        description="The `invoicingTypes` filter takes a list of `InvoicingType` values "
-        "representing the desired invoicing types of the customers. If an empty list is "
-        "passed, no filter will be applied and all the results will be returned."
-        "\n\nThe `customerGroups` filter takes a list of `CustomerGroup` values "
-        "representing the desired groups of the customers. If an empty list is "
-        "passed, no filter will be applied and all the results will be returned."
-        "\n\n**Requires permissions** to access customer profiles."
-        "\n\nErrors:"
-        "\n* A value passed is not a valid invoicing type"
-        "\n* A value passed is not a valid customer group",
+        description=""" The `invoicingTypes` filter takes a list of `InvoicingType` values
+         representing the desired invoicing types of the customers. If an empty list is
+         passed, no filter will be applied and all the results will be returned.
+        \n\nThe `customerGroups` filter takes a list of `CustomerGroup` values
+         representing the desired groups of the customers. If an empty list is passed,
+         no filter will be applied and all the results will be returned.
+        \n\n When there is any HKI profiles filters (defined in `HELSINKI_PROFILES_FILTERS`) used in the query,
+         the API will ask for `apiToken`. Otherwise `apiToken` is not needed
+        \n\nThe `leaseStatus` filter take a list of `LeaseStatus` values representing the desired status of the lease
+        \n\n**Requires permissions** to access customer profiles.
+        \n\nErrors:
+        \n* A value passed is not a valid invoicing type
+        \n* A value passed is not a valid customer group
+        \n* Cannot filter by Helsinki Profile fields without API Token,
+        """,
     )
 
     @view_permission_required(CustomerProfile, BerthApplication, BerthLease)

--- a/customers/schema/queries.py
+++ b/customers/schema/queries.py
@@ -164,12 +164,20 @@ class Query:
         unmarked_winter_storage_lease_customer=graphene.Boolean(),
         unmarked_winter_storage_areas=graphene.List(graphene.String),
         sticker_number=graphene.String(),
-        first_name=graphene.String(),
-        last_name=graphene.String(),
-        email=graphene.String(),
-        address=graphene.String(),
-        sort_by=graphene.String(),
-        api_token=graphene.String(),
+        first_name=graphene.String(
+            description="Filter by Helsinki Profile `first_name` field"
+        ),
+        last_name=graphene.String(
+            description="Filter by Helsinki Profile `last_name` field"
+        ),
+        email=graphene.String(description="Filter by Helsinki Profile `email` field"),
+        address=graphene.String(
+            description="Filter by Helsinki Profile `address_Address` field"
+        ),
+        sort_by=graphene.String(description="Order by Helsinki Profile fields"),
+        api_token=graphene.String(
+            description="API Token is required when using Helsinki Profile filters"
+        ),
         description=""" The `invoicingTypes` filter takes a list of `InvoicingType` values
          representing the desired invoicing types of the customers. If an empty list is
          passed, no filter will be applied and all the results will be returned.
@@ -217,7 +225,7 @@ class Query:
                     "Cannot filter by Helsinki Profile fields without API Token"
                 )
             ids = _get_ids_from_profile_service(kwargs, profile_token)
-            qs = qs.filter(id__in=ids)
+            qs = qs.in_bulk(id_list=[ids])
 
         # General filters
         qs = _general_filters(kwargs, qs)

--- a/customers/services/profile.py
+++ b/customers/services/profile.py
@@ -197,6 +197,8 @@ class ProfileService:
         last_name: str = "",
         email: str = "",
         phone: str = "",
+        address: str = "",
+        order_by: str = "",
         force_only_one: bool = True,
     ) -> Union[List[HelsinkiProfileUser], HelsinkiProfileUser]:
         """
@@ -212,7 +214,9 @@ class ProfileService:
                     firstName: "{first_name}",
                     lastName: "{last_name}",
                     emails_Email: "{email}",
-                    phones_Phone: "{phone}"
+                    phones_Phone: "{phone}",
+                    addresses_Address: "{address}",
+                    orderBy: "{order_by}",
                 ) {{
                     edges {{
                         node {{

--- a/customers/tests/test_customers_queries.py
+++ b/customers/tests/test_customers_queries.py
@@ -1,5 +1,6 @@
 import random
 from datetime import date
+from unittest.mock import patch
 
 import pytest
 from dateutil.parser import isoparse
@@ -13,6 +14,7 @@ from applications.tests.factories import (
 )
 from berth_reservations.tests.factories import CustomerProfileFactory
 from berth_reservations.tests.utils import (
+    assert_in_errors,
     assert_not_enough_permissions,
     create_api_client,
 )
@@ -41,6 +43,7 @@ from utils.relay import to_global_id
 
 from ..enums import InvoicingType, OrganizationType
 from ..schema import BoatCertificateNode, BoatNode, ProfileNode
+from ..services import HelsinkiProfileUser
 from .factories import BoatFactory, OrganizationFactory
 
 FEDERATED_SCHEMA_QUERY = """
@@ -1301,3 +1304,85 @@ def test_filter_profile_by_sticker_number(superuser_api_client):
     executed = superuser_api_client.execute(query)
     assert to_global_id(ProfileNode, profile_1.id) in str(executed["data"])
     assert to_global_id(ProfileNode, profile_2.id) not in str(executed["data"])
+
+
+def test_filter_by_hki_profile_filters_without_profile_token(superuser_api_client):
+    query = """
+        {
+                berthProfiles(email: "example@email.com") {
+                    edges{
+                        node{
+                           id
+                        }
+                    }
+                }
+        }
+    """
+    executed = superuser_api_client.execute(query)
+    assert_in_errors("API Token", executed)
+
+
+@patch("customers.services.profile.ProfileService.find_profile")
+def test_filter_by_hki_profile_filters(mock_find_profile, superuser_api_client):
+    profile_1 = WinterStorageLeaseFactory(
+        application=WinterStorageApplicationFactory(
+            area_type=ApplicationAreaType.UNMARKED
+        ),
+        sticker_number="1",
+    ).customer
+    profile_2 = CustomerProfileFactory()
+    profile_3 = CustomerProfileFactory()
+    mock_find_profile.return_value = [
+        HelsinkiProfileUser(
+            profile_1.id,
+            email=profile_1.user.email,
+            first_name=profile_1.user.first_name,
+            last_name="Last Name",
+        ),
+        HelsinkiProfileUser(
+            profile_2.id,
+            email=profile_2.user.email,
+            first_name=profile_2.user.first_name,
+            last_name="Last Name",
+        ),
+        HelsinkiProfileUser(
+            profile_3.id,
+            email=profile_3.user.email,
+            first_name=profile_3.user.first_name,
+            last_name="Last Name",
+        ),
+    ]
+    # First query should return all mock profiles
+    query = """
+        {
+                berthProfiles(lastName: "Last Name", apiToken: "Sample token") {
+                    edges{
+                        node{
+                           id
+                        }
+                    }
+                }
+        }
+    """
+
+    executed = superuser_api_client.execute(query)
+    assert len(executed["data"]["berthProfiles"]["edges"]) == 3
+    assert to_global_id(ProfileNode, profile_1.id) in str(executed["data"])
+    assert to_global_id(ProfileNode, profile_2.id) in str(executed["data"])
+    assert to_global_id(ProfileNode, profile_3.id) in str(executed["data"])
+    # Second query will filter profiles by Berth Profile fields
+    query = """
+            {
+                    berthProfiles(lastName: "Last Name", apiToken: "Sample token", stickerNumber: "1") {
+                        edges{
+                            node{
+                               id
+                            }
+                        }
+                    }
+            }
+        """
+    executed = superuser_api_client.execute(query)
+    assert to_global_id(ProfileNode, profile_1.id) in str(executed["data"])
+    assert to_global_id(ProfileNode, profile_2.id) not in str(executed["data"])
+    assert to_global_id(ProfileNode, profile_3.id) not in str(executed["data"])

--- a/payments/tests/test_talpa_ecom.py
+++ b/payments/tests/test_talpa_ecom.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import List
 from unittest import mock
 from uuid import uuid4
 
@@ -48,7 +49,7 @@ from utils.numbers import rounded
 def test_initiate_payment_success(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
     rf,
 ):
     """Test the request creator constructs the payload base and returns a url that contains a token"""
@@ -73,7 +74,7 @@ def test_initiate_payment_success(
 def test_initiate_payment_validation_errors(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
     rf,
 ):
     """Test the request creator raises service unavailable if request doesn't go through"""
@@ -102,7 +103,7 @@ def test_initiate_payment_validation_errors(
 def test_initiate_payment_error_unavailable(
     talpa_ecom_provider_base_config: dict,
     order: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
     rf,
 ):
     """Test the request creator raises service unavailable if request doesn't go through"""
@@ -131,7 +132,7 @@ def test_initiate_payment_error_unavailable(
 def test_handle_initiate_payment_success(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
 ):
     """Test the response handler recognizes success and adds token as part of the returned url"""
     r = mocked_talpa_ecom_order_response(order)
@@ -186,7 +187,7 @@ def test_handle_initiate_payment_error_missing_id(
 def test_payload_add_products_success(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order_with_products: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
 ):
     """Test the products and total order price data is added correctly into payload"""
     payload = {}
@@ -238,7 +239,7 @@ def test_payload_add_products_success(
 def test_payload_add_additional_product_order(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
     settings,
 ):
     payload = {"items": []}
@@ -269,7 +270,7 @@ def test_payload_add_additional_product_order(
 def test_payload_add_place_products(
     talpa_ecom_payment_provider: TalpaEComProvider,
     order_with_products: Order,
-    default_talpa_product_accounting: list[TalpaProductAccounting],
+    default_talpa_product_accounting: List[TalpaProductAccounting],
     settings,
 ):
     payload = {"items": []}


### PR DESCRIPTION
## Description :sparkles:
- Merged two filters from HKI `profiles` query and Vene `berthProfiles` query
- Basically, when there is any HKI `profiles` filters (`HELSINKI_PROFILES_FILTERS `) used in the query, the API will ask for `apiToken`. Otherwise `apiToken` is not needed
- When `profiles` filter is used and `apiToken` is provided, Vene API will first send a GraphQL query to HKI profile GraphQL to get the ids of filtered `profiles` first. After that it'll filter Vene `berthProfiles` by these ids (because berthProfile ids are referred to HKI Profile ids)
## Issues :bug:
### Closes :no_good_woman:
**[VEN-1469](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1469):** 

### Related :handshake:

## Testing :alembic:
- Tested in my local env with some simple query
```
query ProfileQuery($apiToken: String){
  berthProfiles(lastName: "M", apiToken: $apiToken, sortBy: "name"){
    edges{
      node{
        id
        boats{
          edges{
            node{
              id
            }
          }
        }
      }
    }
  }
}
```
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
