### PR TITLE
VEN-1465 | Customer excel export fetches information from Helsinki profile

### DIFF
--- a/applications/tests/test_applications_utils.py
+++ b/applications/tests/test_applications_utils.py
@@ -1,7 +1,9 @@
+import io
+
 import pytest
-import xlrd
 from django.conf import settings
 from freezegun import freeze_time
+from openpyxl import load_workbook
 
 from customers.tests.factories import BoatFactory
 from resources.tests.factories import (
@@ -83,15 +85,15 @@ def test_exporting_berth_applications_to_excel(
 
     queryset = BerthApplication.objects.all()
     xlsx_bytes = export_berth_applications_as_xlsx(queryset)
-    wb = xlrd.open_workbook(file_contents=xlsx_bytes)
+    xlsx_file = io.BytesIO(xlsx_bytes)
 
-    assert "berth_applications" in wb.sheet_names()
+    wb = load_workbook(filename=xlsx_file, read_only=True)
+    assert "berth_applications" in wb.sheetnames
 
-    xl_sheet = wb.sheet_by_name("berth_applications")
-    row = xl_sheet.row(1)
+    xl_sheet = wb["berth_applications"]
 
-    expected_berth_switch_reason = ""
-    expected_berth_switch_str = ""
+    expected_berth_switch_reason = None
+    expected_berth_switch_str = None
     if berth_switch:
         switch_harbor_name = (
             berth_switch_info.berth.pier.harbor.safe_translation_getter(
@@ -112,43 +114,43 @@ def test_exporting_berth_applications_to_excel(
         "name", language_code=EXCEL_FILE_LANG
     )
 
-    assert xl_sheet.ncols == 35
+    assert xl_sheet.max_column == 35
 
-    assert row[0].value == "2019-01-14 10:00"
-    assert row[1].value == "1: {}".format(harbor_name)
-    assert row[2].value == expected_berth_switch_str
-    assert row[3].value == expected_berth_switch_reason
-    assert row[4].value == ("" if customer_private else "ACME Inc.")
-    assert row[5].value == ("" if customer_private else "123123-000")
-    assert row[6].value == "Kyösti"
-    assert row[7].value == "Testaaja"
-    assert row[8].value == "kyosti.testaaja@example.com"
-    assert row[9].value == "Mariankatu 2"
-    assert row[10].value == "00170"
-    assert row[11].value == "Helsinki"
-    assert row[12].value == "0411234567"
-    assert row[13].value == boat_type_name
-    assert row[14].value == 2.0
-    assert row[15].value == 3.5
-    assert row[16].value == 1
-    assert row[17].value == 20000
-    assert row[18].value == "B0A7"
-    assert row[19].value == "Vene"
-    assert row[20].value == "BMW S 12"
-    assert row[21].value == "Yes"
-    assert row[22].value == ""
-    assert row[23].value == ""
-    assert row[24].value == ""
-    assert row[25].value == "Yes"
-    assert row[26].value == "wood"
-    assert row[27].value == "cafe"
-    assert row[28].value == "a while"
-    assert row[29].value == "01.02.2019"
-    assert row[30].value == "01.03.2019"
-    assert row[31].value == "Yes"
-    assert row[32].value == "Yes"
-    assert row[33].value == "Yes"
-    assert row[34].value == "1234567890"
+    assert xl_sheet.cell(2, 1).value == "2019-01-14 10:00"
+    assert xl_sheet.cell(2, 2).value == "1: {}".format(harbor_name)
+    assert xl_sheet.cell(2, 3).value == expected_berth_switch_str
+    assert xl_sheet.cell(2, 4).value == expected_berth_switch_reason
+    assert xl_sheet.cell(2, 5).value == (None if customer_private else "ACME Inc.")
+    assert xl_sheet.cell(2, 6).value == (None if customer_private else "123123-000")
+    assert xl_sheet.cell(2, 7).value == "Kyösti"
+    assert xl_sheet.cell(2, 8).value == "Testaaja"
+    assert xl_sheet.cell(2, 9).value == "kyosti.testaaja@example.com"
+    assert xl_sheet.cell(2, 10).value == "Mariankatu 2"
+    assert xl_sheet.cell(2, 11).value == "00170"
+    assert xl_sheet.cell(2, 12).value == "Helsinki"
+    assert xl_sheet.cell(2, 13).value == "0411234567"
+    assert xl_sheet.cell(2, 14).value == boat_type_name
+    assert xl_sheet.cell(2, 15).value == 2.0
+    assert xl_sheet.cell(2, 16).value == 3.5
+    assert xl_sheet.cell(2, 17).value == 1
+    assert xl_sheet.cell(2, 18).value == 20000
+    assert xl_sheet.cell(2, 19).value == "B0A7"
+    assert xl_sheet.cell(2, 20).value == "Vene"
+    assert xl_sheet.cell(2, 21).value == "BMW S 12"
+    assert xl_sheet.cell(2, 22).value == "Yes"
+    assert xl_sheet.cell(2, 23).value is None
+    assert xl_sheet.cell(2, 24).value is None
+    assert xl_sheet.cell(2, 25).value is None
+    assert xl_sheet.cell(2, 26).value == "Yes"
+    assert xl_sheet.cell(2, 27).value == "wood"
+    assert xl_sheet.cell(2, 28).value == "cafe"
+    assert xl_sheet.cell(2, 29).value == "a while"
+    assert xl_sheet.cell(2, 30).value == "01.02.2019"
+    assert xl_sheet.cell(2, 31).value == "01.03.2019"
+    assert xl_sheet.cell(2, 32).value == "Yes"
+    assert xl_sheet.cell(2, 33).value == "Yes"
+    assert xl_sheet.cell(2, 34).value == "Yes"
+    assert xl_sheet.cell(2, 35).value == "1234567890"
 
 
 @freeze_time("2019-01-14T08:00:00Z")
@@ -194,12 +196,12 @@ def test_exporting_winter_storage_applications_to_excel(customer_private):
 
     queryset = WinterStorageApplication.objects.all()
     xlsx_bytes = export_winter_storage_applications_as_xlsx(queryset)
-    wb = xlrd.open_workbook(file_contents=xlsx_bytes)
+    xlsx_file = io.BytesIO(xlsx_bytes)
 
-    assert "winter_storage_applications" in wb.sheet_names()
+    wb = load_workbook(filename=xlsx_file, read_only=True)
+    assert "winter_storage_applications" in wb.sheetnames
 
-    xl_sheet = wb.sheet_by_name("winter_storage_applications")
-    row = xl_sheet.row(1)
+    xl_sheet = wb["winter_storage_applications"]
 
     winter_area_name = winter_area.safe_translation_getter(
         "name", language_code=EXCEL_FILE_LANG
@@ -208,29 +210,29 @@ def test_exporting_winter_storage_applications_to_excel(customer_private):
         "name", language_code=EXCEL_FILE_LANG
     )
 
-    assert xl_sheet.ncols == 24
+    assert xl_sheet.max_column == 24
 
-    assert row[0].value == "2019-01-14 10:00"
-    assert row[1].value == "1: {}".format(winter_area_name)
-    assert row[2].value == ("" if customer_private else "ACME Inc.")
-    assert row[3].value == ("" if customer_private else "123123-000")
-    assert row[4].value == "Kyösti"
-    assert row[5].value == "Testaaja"
-    assert row[6].value == "kyosti.testaaja@example.com"
-    assert row[7].value == "Mariankatu 2"
-    assert row[8].value == "00170"
-    assert row[9].value == "Helsinki"
-    assert row[10].value == "0411234567"
-    assert row[11].value == WinterStorageMethod.ON_TRESTLES.label
-    assert row[12].value == "hel001"
-    assert row[13].value == boat_type_name
-    assert row[14].value == 2.0
-    assert row[15].value == 3.5
-    assert row[16].value == "B0A7"
-    assert row[17].value == "Vene"
-    assert row[18].value == "BMW S 12"
-    assert row[19].value == ""
-    assert row[20].value == ""
-    assert row[21].value == ""
-    assert row[22].value == "Yes"
-    assert row[23].value == "1234567890"
+    assert xl_sheet.cell(2, 1).value == "2019-01-14 10:00"
+    assert xl_sheet.cell(2, 2).value == "1: {}".format(winter_area_name)
+    assert xl_sheet.cell(2, 3).value == (None if customer_private else "ACME Inc.")
+    assert xl_sheet.cell(2, 4).value == (None if customer_private else "123123-000")
+    assert xl_sheet.cell(2, 5).value == "Kyösti"
+    assert xl_sheet.cell(2, 6).value == "Testaaja"
+    assert xl_sheet.cell(2, 7).value == "kyosti.testaaja@example.com"
+    assert xl_sheet.cell(2, 8).value == "Mariankatu 2"
+    assert xl_sheet.cell(2, 9).value == "00170"
+    assert xl_sheet.cell(2, 10).value == "Helsinki"
+    assert xl_sheet.cell(2, 11).value == "0411234567"
+    assert xl_sheet.cell(2, 12).value == WinterStorageMethod.ON_TRESTLES.label
+    assert xl_sheet.cell(2, 13).value == "hel001"
+    assert xl_sheet.cell(2, 14).value == boat_type_name
+    assert xl_sheet.cell(2, 15).value == 2.0
+    assert xl_sheet.cell(2, 16).value == 3.5
+    assert xl_sheet.cell(2, 17).value == "B0A7"
+    assert xl_sheet.cell(2, 18).value == "Vene"
+    assert xl_sheet.cell(2, 19).value == "BMW S 12"
+    assert xl_sheet.cell(2, 20).value is None
+    assert xl_sheet.cell(2, 21).value is None
+    assert xl_sheet.cell(2, 22).value is None
+    assert xl_sheet.cell(2, 23).value == "Yes"
+    assert xl_sheet.cell(2, 24).value == "1234567890"

--- a/exports/tests/test_customer_export.py
+++ b/exports/tests/test_customer_export.py
@@ -1,8 +1,12 @@
+import datetime
+import io
+
 import pytest
-import xlrd
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from freezegun import freeze_time
+from openpyxl import load_workbook
 from rest_framework import status
 
 from berth_reservations.tests.factories import CustomerProfileFactory
@@ -62,32 +66,37 @@ def test_export_view_produces_an_excel(superuser_api_client):
 
     assert response.status_code == status.HTTP_200_OK
     xlsx_bytes = response.content
-    wb = xlrd.open_workbook(file_contents=xlsx_bytes)
-    assert "Customers" in wb.sheet_names()
-    xl_sheet = wb.sheet_by_name("Customers")
-    for row_number, identifier in enumerate(ids, 1):
-        row = xl_sheet.row(row_number)
-        assert row[0].value == str(identifier)
+    xlsx_file = io.BytesIO(xlsx_bytes)
+    wb = load_workbook(filename=xlsx_file, read_only=True)
+    assert "Customers" in wb.sheetnames
+    xl_sheet = wb["Customers"]
+    for row_number, identifier in enumerate(ids, 2):
+        assert xl_sheet.cell(row_number, 1).value == str(identifier)
 
 
+@freeze_time("2020-01-01T10:00:00+02:00")
 def test_customer_excel_fields():
+    expected_datetime_format = "YYYY-MM-DD HH:MM:SS"
     cp = CustomerProfileFactory()
     exporter = CustomerXlsx(CustomerProfile.objects.all())
 
     xlsx_bytes = exporter.serialize()
 
-    wb = xlrd.open_workbook(file_contents=xlsx_bytes)
-    assert "Customers" in wb.sheet_names()
-    xl_sheet = wb.sheet_by_name("Customers")
-    assert xl_sheet.ncols == 8
-    row = xl_sheet.row(1)
-    assert row[0].value == str(cp.id)
-    assert row[1].value == cp.user.first_name
-    assert row[2].value == cp.user.last_name
-    assert row[3].value == str(InvoicingType(cp.invoicing_type).label)
-    assert row[4].value == "private"
-    assert row[5].value == cp.comment
+    xlsx_file = io.BytesIO(xlsx_bytes)
+    wb = load_workbook(filename=xlsx_file, read_only=True)
+    assert "Customers" in wb.sheetnames
+    xl_sheet = wb["Customers"]
 
-    # Excel internally presents datetimes as floats
-    float(row[6].value)
-    float(row[7].value)
+    assert xl_sheet.max_column == 8
+
+    assert xl_sheet.cell(2, 1).value == str(cp.id)
+    assert xl_sheet.cell(2, 2).value == cp.user.first_name
+    assert xl_sheet.cell(2, 3).value == cp.user.last_name
+    assert xl_sheet.cell(2, 4).value == str(InvoicingType(cp.invoicing_type).label)
+    assert xl_sheet.cell(2, 5).value == "private"
+    assert xl_sheet.cell(2, 6).value == cp.comment
+
+    assert xl_sheet.cell(2, 7).value == datetime.datetime(2020, 1, 1, 10)
+    assert xl_sheet.cell(2, 7).number_format == expected_datetime_format
+    assert xl_sheet.cell(2, 8).value == datetime.datetime(2020, 1, 1, 10)
+    assert xl_sheet.cell(2, 8).number_format == expected_datetime_format

--- a/exports/tests/test_customer_export.py
+++ b/exports/tests/test_customer_export.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import Permission
@@ -13,6 +14,7 @@ from berth_reservations.tests.factories import CustomerProfileFactory
 from customers.enums import InvoicingType
 from customers.models import CustomerProfile
 from customers.schema import ProfileNode
+from customers.services import HelsinkiProfileUser
 from exports.xlsx_writer import CustomerXlsx
 from utils.relay import to_global_id
 
@@ -21,19 +23,45 @@ def to_global_profile_node_ids(ids):
     return map(lambda x: to_global_id(ProfileNode, x), ids)
 
 
+def get_mock_data_for_profiles(profiles):
+    # Parse the users received from the Profile Service
+    users = {}
+
+    for profile in profiles:
+        user = HelsinkiProfileUser(
+            profile.id,
+            email=profile.user.email if profile.user else "user@example.com",
+            first_name=profile.user.first_name if profile.user else "First",
+            last_name=profile.user.last_name if profile.user else "Last",
+            address="Kaivokatu 1",
+            postal_code="00100",
+            city="Helsinki",
+            phone="0501234567",
+        )
+        users[user.id] = user
+
+    return users
+
+
+@patch("customers.services.profile.ProfileService.get_all_profiles")
 @pytest.mark.parametrize("has_permission", [True, False])
-def test_admin_credentials_are_required(user_api_client, has_permission):
+def test_admin_credentials_are_required(
+    mock_get_all_profiles, user_api_client, has_permission
+):
     if has_permission:
         permission = Permission.objects.get(
             content_type=ContentType.objects.get_for_model(CustomerProfile),
             codename="view_customerprofile",
         )
         user_api_client.user.user_permissions.add(permission)
-    CustomerProfileFactory()
+    profile = CustomerProfileFactory()
+    mock_get_all_profiles.return_value = get_mock_data_for_profiles([profile])
     ids = CustomerProfile.objects.all().values_list("id", flat=True)
     global_ids = to_global_profile_node_ids(ids)
 
-    response = user_api_client.post(reverse("customer_xlsx"), data={"ids": global_ids})
+    response = user_api_client.post(
+        reverse("customer_xlsx"), data={"ids": global_ids, "profile_token": "token"}
+    )
 
     if has_permission:
         assert response.status_code == status.HTTP_200_OK
@@ -41,27 +69,37 @@ def test_admin_credentials_are_required(user_api_client, has_permission):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_amount_of_queries(superuser_api_client, django_assert_max_num_queries):
+@patch("customers.services.profile.ProfileService.get_all_profiles")
+def test_amount_of_queries(
+    mock_get_all_profiles, superuser_api_client, django_assert_max_num_queries
+):
     CustomerProfileFactory.create_batch(2)
     CustomerProfileFactory.create_batch(2, user=None)
+    mock_get_all_profiles.return_value = get_mock_data_for_profiles(
+        CustomerProfile.objects.all()
+    )
     ids = CustomerProfile.objects.all().values_list("id", flat=True)
     global_ids = to_global_profile_node_ids(ids)
 
     with django_assert_max_num_queries(2):
         response = superuser_api_client.post(
-            reverse("customer_xlsx"), data={"ids": global_ids}
+            reverse("customer_xlsx"), data={"ids": global_ids, "profile_token": "token"}
         )
 
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_export_view_produces_an_excel(superuser_api_client):
+@patch("customers.services.profile.ProfileService.get_all_profiles")
+def test_export_view_produces_an_excel(mock_get_all_profiles, superuser_api_client):
     CustomerProfileFactory.create_batch(2)
+    mock_get_all_profiles.return_value = get_mock_data_for_profiles(
+        CustomerProfile.objects.all()
+    )
     ids = CustomerProfile.objects.all().values_list("id", flat=True)
     global_ids = to_global_profile_node_ids(ids)
 
     response = superuser_api_client.post(
-        reverse("customer_xlsx"), data={"ids": global_ids}
+        reverse("customer_xlsx"), data={"ids": global_ids, "profile_token": "token"}
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -74,11 +112,23 @@ def test_export_view_produces_an_excel(superuser_api_client):
         assert xl_sheet.cell(row_number, 1).value == str(identifier)
 
 
-@freeze_time("2020-01-01T10:00:00+02:00")
-def test_customer_excel_fields():
+@patch("customers.services.profile.ProfileService.get_all_profiles")
+def test_customer_excel_fields(mock_get_all_profiles):
+
+    with freeze_time("2020-01-01T10:00:00+02:00") as frozen_datetime:
+        profile_1 = CustomerProfileFactory()
+        frozen_datetime.tick()
+        CustomerProfileFactory()
+        frozen_datetime.tick()
+        CustomerProfileFactory(user=None)
+
+    mock_get_all_profiles.return_value = get_mock_data_for_profiles([profile_1])
+
     expected_datetime_format = "YYYY-MM-DD HH:MM:SS"
-    cp = CustomerProfileFactory()
-    exporter = CustomerXlsx(CustomerProfile.objects.all())
+    exporter = CustomerXlsx(
+        CustomerProfile.objects.all().order_by("created_at"),
+        profile_token="profile_token",
+    )
 
     xlsx_bytes = exporter.serialize()
 
@@ -87,16 +137,27 @@ def test_customer_excel_fields():
     assert "Customers" in wb.sheetnames
     xl_sheet = wb["Customers"]
 
-    assert xl_sheet.max_column == 8
+    assert xl_sheet.max_column == 14
 
-    assert xl_sheet.cell(2, 1).value == str(cp.id)
-    assert xl_sheet.cell(2, 2).value == cp.user.first_name
-    assert xl_sheet.cell(2, 3).value == cp.user.last_name
-    assert xl_sheet.cell(2, 4).value == str(InvoicingType(cp.invoicing_type).label)
+    assert xl_sheet.cell(2, 1).value == str(profile_1.id)
+    assert xl_sheet.cell(2, 2).value == profile_1.user.first_name
+    assert xl_sheet.cell(2, 3).value == profile_1.user.last_name
+    assert xl_sheet.cell(2, 4).value == str(
+        InvoicingType(profile_1.invoicing_type).label
+    )
     assert xl_sheet.cell(2, 5).value == "private"
-    assert xl_sheet.cell(2, 6).value == cp.comment
+    assert xl_sheet.cell(2, 6).value == profile_1.user.email
+    assert xl_sheet.cell(2, 7).value == "0501234567"
+    assert xl_sheet.cell(2, 8).value == "Kaivokatu 1"
+    assert xl_sheet.cell(2, 9).value == "00100"
+    assert xl_sheet.cell(2, 10).value == "Helsinki"
+    assert xl_sheet.cell(2, 11).value == profile_1.comment
+    assert xl_sheet.cell(2, 12).value == datetime.datetime(2020, 1, 1, 10)
+    assert xl_sheet.cell(2, 12).number_format == expected_datetime_format
+    assert xl_sheet.cell(2, 13).value == datetime.datetime(2020, 1, 1, 10)
+    assert xl_sheet.cell(2, 13).number_format == expected_datetime_format
 
-    assert xl_sheet.cell(2, 7).value == datetime.datetime(2020, 1, 1, 10)
-    assert xl_sheet.cell(2, 7).number_format == expected_datetime_format
-    assert xl_sheet.cell(2, 8).value == datetime.datetime(2020, 1, 1, 10)
-    assert xl_sheet.cell(2, 8).number_format == expected_datetime_format
+    # User source
+    assert xl_sheet.cell(2, 14).value == "Helsinki profile"
+    assert xl_sheet.cell(3, 14).value == "Local"
+    assert xl_sheet.cell(4, 14).value == "Local"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,5 +11,5 @@ pytest
 pytest-cov
 pytest-django
 requests-mock
-xlrd<2.0.0
+openpyxl
 gql

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,6 +32,8 @@ coverage[toml]==6.3.1
     # via pytest-cov
 distlib==0.3.4
     # via virtualenv
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.4.2
     # via virtualenv
 flake8==4.0.1
@@ -64,6 +66,8 @@ mypy-extensions==0.4.3
     # via black
 nodeenv==1.6.0
     # via pre-commit
+openpyxl==3.0.9
+    # via -r requirements-dev.in
 packaging==21.0
     # via
     #   -c requirements.txt
@@ -162,8 +166,6 @@ virtualenv==20.13.0
     # via pre-commit
 wheel==0.37.1
     # via pip-tools
-xlrd==1.2.0
-    # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
This PR adds Helsinki profile related information to the customer excel export.

Customer excel exporter view now requires a new `profile_token` (API key for the Helsinki profile GraphQL API) argument, which is used to fetch customer related information from Helsinki profile into the exported excel.

Additionally `xlrd` is changed to `openpyxl` since new versions of xlrd are only intended for reading old `.xls` files.

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1465](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1465):** BE: backend resolves the names of the customer profile
