### PR TITLE
Remove ids filter from berth profiles query

### DIFF
--- a/customers/tests/test_customers_queries.py
+++ b/customers/tests/test_customers_queries.py
@@ -1346,7 +1346,6 @@ def test_filter_by_hki_profile_filters(mock_find_profile, superuser_api_client):
         address="",
         order_by="",
         first=100,
-        ids=[str(profile_1.id)],
         force_only_one=False,
         recursively_fetch_all=True,
         ids_only=True,


### PR DESCRIPTION
VEN-1481. The ids filter was denied by Open City Profile API, so it can be removed from Berth API. When resolving the berth profiles, first fetch all the profiles with given filters, then query from berth db. 

The Open city profile now responds with` 413 Request Entity Too Large` when there are ~3500 ids. This differs from what we have investigated when we implemented the current version of customer query.