### PR TITLE
PT-1436 PT-533 | Patch graphene.Decimal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_language_version:
-    python: python3    
+    python: python3
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/applications/schema/inputs.py
+++ b/applications/schema/inputs.py
@@ -40,8 +40,8 @@ class BaseApplicationInput(graphene.InputObjectType):
 
 
 class BerthApplicationInput(BaseApplicationInput):
-    boat_draught = graphene.Float()
-    boat_weight = graphene.Float()
+    boat_draught = graphene.Decimal()
+    boat_weight = graphene.Decimal()
     accessibility_required = graphene.Boolean()
     boat_propulsion = graphene.String()
     boat_hull_material = graphene.String()

--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -6,6 +6,8 @@ import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from utils.patch import monkeypatch_graphene_decimal
+
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
 
@@ -342,3 +344,8 @@ if os.path.exists(local_settings_path):
     exec(code, globals(), locals())
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+#########################################
+# MONKEY-PATCHING A THIRD-PARTY LIBRARY #
+#########################################
+monkeypatch_graphene_decimal()

--- a/resources/schema/mutations.py
+++ b/resources/schema/mutations.py
@@ -83,9 +83,9 @@ class BerthInput(AbstractBoatPlaceInput):
     comment = graphene.String()
     is_accessible = graphene.Boolean()
     is_invoiceable = graphene.Boolean()
-    width = graphene.Float(description=_("width (m)"))
-    length = graphene.Float(description=_("length (m)"))
-    depth = graphene.Float(description=_("depth (m)"))
+    width = graphene.Decimal(description=_("width (m)"))
+    length = graphene.Decimal(description=_("length (m)"))
+    depth = graphene.Decimal(description=_("depth (m)"))
     mooring_type = BerthMooringTypeEnum()
 
 
@@ -93,8 +93,8 @@ class CreateBerthMutation(graphene.ClientIDMutation):
     class Input(BerthInput):
         number = graphene.String(required=True)
         pier_id = graphene.ID(required=True)
-        width = graphene.Float(description=_("width (m)"), required=True)
-        length = graphene.Float(description=_("length (m)"), required=True)
+        width = graphene.Decimal(description=_("width (m)"), required=True)
+        length = graphene.Decimal(description=_("length (m)"), required=True)
         mooring_type = BerthMooringTypeEnum(required=True)
 
     berth = graphene.Field(BerthNode)
@@ -394,8 +394,8 @@ class UpdateWinterStorageAreaMutation(graphene.ClientIDMutation, AbstractAreaMix
 
 
 class AbstractPlaceTypeInput:
-    width = graphene.Float(description=_("width (m)"))
-    length = graphene.Float(description=_("length (m)"))
+    width = graphene.Decimal(description=_("width (m)"))
+    length = graphene.Decimal(description=_("length (m)"))
 
 
 class WinterStoragePlaceTypeInput(AbstractPlaceTypeInput):
@@ -405,8 +405,8 @@ class WinterStoragePlaceTypeInput(AbstractPlaceTypeInput):
 class CreateWinterStoragePlaceTypeMutation(graphene.ClientIDMutation):
     class Input(WinterStoragePlaceTypeInput):
         pass
-        # width = graphene.Float(description=_("width (m)"), required=True)
-        # length = graphene.Float(description=_("length (m)"), required=True)
+        # width = graphene.Decimal(description=_("width (m)"), required=True)
+        # length = graphene.Decimal(description=_("length (m)"), required=True)
 
     winter_storage_place_type = graphene.Field(WinterStoragePlaceTypeNode)
 
@@ -687,15 +687,15 @@ class WinterStoragePlaceInput(AbstractBoatPlaceInput):
     number = graphene.String()
     winter_storage_section_id = graphene.ID()
     comment = graphene.String()
-    width = graphene.Float(description=_("width (m)"))
-    length = graphene.Float(description=_("length (m)"))
+    width = graphene.Decimal(description=_("width (m)"))
+    length = graphene.Decimal(description=_("length (m)"))
 
 
 class CreateWinterStoragePlaceMutation(graphene.ClientIDMutation):
     class Input(WinterStoragePlaceInput):
         number = graphene.String(required=True)
         winter_storage_section_id = graphene.ID(required=True)
-        width = graphene.Float(description=_("width (m)"), required=True)
+        width = graphene.Decimal(description=_("width (m)"), required=True)
 
     winter_storage_place = graphene.Field(WinterStoragePlaceNode)
 

--- a/utils/patch.py
+++ b/utils/patch.py
@@ -1,0 +1,20 @@
+from decimal import Decimal as _Decimal
+
+import graphene
+from graphene.types import Decimal
+
+
+def monkeypatch_graphene_decimal():
+    if graphene.__version__ != "2.1.9":
+        raise Exception(
+            "Graphene version changed. Check if graphene.Decimal still needs patching."
+        )
+
+    def parse_value(value):
+        try:
+            # Turn value to string first to handle possible floats gracefully.
+            return _Decimal(str(value))
+        except ValueError:
+            return None
+
+    Decimal.parse_value = parse_value

--- a/utils/tests/test_patch.py
+++ b/utils/tests/test_patch.py
@@ -1,0 +1,11 @@
+from decimal import Decimal as PythonDecimal
+
+import pytest
+from graphene import Decimal
+
+
+@pytest.mark.parametrize(
+    "value,expected", [(2.05, "2.05"), (5.3, "5.3"), (1, "1"), ("12.34", "12.34")]
+)
+def test_graphene_decimal_is_patched(value, expected):
+    assert Decimal.parse_value(value) == PythonDecimal(expected)


### PR DESCRIPTION
## Description :sparkles:

This PR patches `graphene.Decimal.parse_value` with improved float handling. Also we replace all explicit Float types in mutation inputs.

## Issues :bug:
**[VEN-1436](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1436):** BE: Unmarked winter storage notification has floats instead of decimals
**[VEN-533](https://helsinkisolutionoffice.atlassian.net/browse/VEN-533):** Backend: passing floats for DecimalFields does not always pass validation
