### PR TITLE
VEN-1462 | Add information about the offered berth to the switch offer SMS

### DIFF
--- a/payments/notifications/dummy_context.py
+++ b/payments/notifications/dummy_context.py
@@ -202,9 +202,6 @@ def load_dummy_context():
             NotificationType.RENEW_BERTH_ORDER_APPROVED: _get_berth_order_context(
                 get_email_subject(NotificationType.RENEW_BERTH_ORDER_APPROVED)
             ),
-            NotificationType.BERTH_SWITCH_OFFER_APPROVED: _get_berth_order_context(
-                get_email_subject(NotificationType.BERTH_SWITCH_OFFER_APPROVED)
-            ),
             NotificationType.NEW_WINTER_STORAGE_ORDER_APPROVED: _get_winter_storage_order_context(
                 get_email_subject(NotificationType.NEW_WINTER_STORAGE_ORDER_APPROVED)
             ),
@@ -230,9 +227,8 @@ def load_dummy_context():
                 "due_date": format_date(today(), locale="fi"),
                 "payment_url": "https://foo.bar/payment",
             },
-            NotificationType.SMS_BERTH_SWITCH_NOTICE: {
-                "due_date": format_date(today(), locale="fi"),
-                "accept_url": "https://foo.bar/payment",
-            },
+            NotificationType.SMS_BERTH_SWITCH_NOTICE: _get_berth_switch_offer_context(
+                get_email_subject(NotificationType.BERTH_SWITCH_OFFER_APPROVED)
+            ),
         }
     )

--- a/templates/sms/berth_switch_notice_en.txt
+++ b/templates/sms/berth_switch_notice_en.txt
@@ -1,2 +1,6 @@
 Dear Customer. We are offering you a new boat berth. Here's a link to accept or cancel the berth offer. Please make your choice by {{ due_date }}.
 {{ accept_url }}
+
+Harbor: {{ offer.berth.pier.harbor.name }}
+Pier: {{ offer.berth.pier.identifier }}
+Berth: {{ offer.berth.number }}

--- a/templates/sms/berth_switch_notice_fi.txt
+++ b/templates/sms/berth_switch_notice_fi.txt
@@ -1,2 +1,6 @@
 Hyvä asiakas. Tarjoamme sinulle venepaikkaa. Tässä linkki jolla voit hyväksyä tai hylätä uuden venepaikkasi. Tee valintasi {{ due_date }} mennessä.
 {{ accept_url }}
+
+Satama: {{ offer.berth.pier.harbor.name }}
+Laituri: {{ offer.berth.pier.identifier }}
+Paikka: {{ offer.berth.number }}

--- a/templates/sms/berth_switch_notice_sv.txt
+++ b/templates/sms/berth_switch_notice_sv.txt
@@ -1,2 +1,6 @@
 Kära kund. Vi bjuder dig en båtplats. Med den här länken kan du acceptera eller avslå erbjudandet. Vänligen gör ditt val före {{ due_date }}.
  {{ accept_url }}
+
+Hamn: {{ offer.berth.pier.harbor.name }}
+Kaj: {{ offer.berth.pier.identifier }}
+Plats: {{ offer.berth.number }}


### PR DESCRIPTION
## Description :sparkles:

Adds more information to the berth swtich offer SMS and updates the dummy context for the notification preview.

## Closes :no_good_woman:
**[VEN-1462](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1462):** Addition to SMS berth offer notification
