### PR TITLE
Reject payment notification sending when order has paper invoice customer

### DIFF
--- a/berth_reservations/tests/factories.py
+++ b/berth_reservations/tests/factories.py
@@ -28,7 +28,7 @@ class MunicipalityFactory(factory.django.DjangoModelFactory):
 
 class CustomerProfileFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
-    invoicing_type = factory.Faker("random_element", elements=list(InvoicingType))
+    invoicing_type = InvoicingType.ONLINE_PAYMENT
     comment = factory.Faker("text")
 
     class Meta:

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -51,3 +51,7 @@ class MissingOrderIDError(VenepaikkaPaymentError):
 
 class UnknownWebhookEventError(VenepaikkaPaymentError):
     """When the payment webhooks are called with an unknown event type"""
+
+
+class InvoicingRejectedForPaperInvoiceCustomersError(VenepaikkaPaymentError):
+    """The paper invoice customers should not receive any digital invoicing"""


### PR DESCRIPTION
VEN-1175. Raise the InvoicingRejectedForPaperInvoiceCustomersError when payment notification is being sent to a paper customer. Catch the exception on order approving so the changes to the order are still persisted. Fixed the tests for paper invoice customer testing.

When the customer has selected paper invoicing, all the order handling should be done as when the invoicing type would be something else (only digital invoicing currently available), but the payment notification should not be sent, because a paper document should be used instead.

Investigation of the payment notification process is done in the Jira ticket comments: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1175?focusedCommentId=61250