### PR TITLE
VEN-1462 | Include berth information in SMS

### DIFF
--- a/payments/notifications/dummy_context.py
+++ b/payments/notifications/dummy_context.py
@@ -226,7 +226,7 @@ def load_dummy_context():
                 **_get_berth_order_context(
                     get_email_subject(NotificationType.NEW_BERTH_ORDER_APPROVED)
                 ),
-                **{"product_name": "Berth", "new_berth_order": True},
+                **{"product_name": "Berth", "include_berth": True},
             },
             NotificationType.SMS_BERTH_SWITCH_NOTICE: _get_berth_switch_offer_context(
                 get_email_subject(NotificationType.BERTH_SWITCH_OFFER_APPROVED)

--- a/payments/tests/test_payments_mutations_approve_ap_order.py
+++ b/payments/tests/test_payments_mutations_approve_ap_order.py
@@ -108,7 +108,7 @@ def test_approve_ap_order(
         "order": order,
         "product_name": product_name,
         "payment_url": payment_url,
-        "include_berth": False,
+        "include_berth": True,
     }
 
     mock_send_sms.assert_called_with(

--- a/payments/tests/test_payments_mutations_approve_ap_order.py
+++ b/payments/tests/test_payments_mutations_approve_ap_order.py
@@ -108,7 +108,7 @@ def test_approve_ap_order(
         "order": order,
         "product_name": product_name,
         "payment_url": payment_url,
-        "new_berth_order": False,
+        "include_berth": False,
     }
 
     mock_send_sms.assert_called_with(

--- a/payments/tests/test_payments_mutations_approve_order.py
+++ b/payments/tests/test_payments_mutations_approve_order.py
@@ -103,7 +103,7 @@ def test_approve_order(
         "order": order,
         "product_name": order.product.name,
         "payment_url": payment_url,
-        "new_berth_order": order.lease_order_type == LeaseOrderType.NEW_BERTH_ORDER,
+        "include_berth": order.lease_order_type == LeaseOrderType.NEW_BERTH_ORDER,
     }
 
     mock_send_sms.assert_called_with(

--- a/payments/tests/test_payments_mutations_resend_order.py
+++ b/payments/tests/test_payments_mutations_resend_order.py
@@ -157,7 +157,7 @@ def test_resend_order(
             "order": order,
             "product_name": order.product.name,
             "payment_url": payment_url,
-            "new_berth_order": True,
+            "include_berth": True,
         }
 
         mock_send_sms.assert_called_with(
@@ -244,7 +244,7 @@ def test_resend_order_in_error(
         "order": order,
         "product_name": order.product.name,
         "payment_url": payment_url,
-        "new_berth_order": True,
+        "include_berth": True,
     }
 
     mock_send_sms.assert_called_with(

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -665,8 +665,8 @@ def send_payment_notification(
             "order": order,
             "product_name": product_name,
             "payment_url": payment_url,
-            "include_berth": notification_type
-            == NotificationType.NEW_BERTH_ORDER_APPROVED,
+            "include_berth": hasattr(order, "lease")
+            and isinstance(order.lease, BerthLease),
         }
 
         sms_service = SMSNotificationService()

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -665,7 +665,7 @@ def send_payment_notification(
             "order": order,
             "product_name": product_name,
             "payment_url": payment_url,
-            "new_berth_order": notification_type
+            "include_berth": notification_type
             == NotificationType.NEW_BERTH_ORDER_APPROVED,
         }
 

--- a/templates/sms/invoice_notice_en.txt
+++ b/templates/sms/invoice_notice_en.txt
@@ -1,6 +1,6 @@
 Dear Customer. Here's a link to pay or cancel {{ product_name }} for the next season. Please pay the bill by {{ order.due_date.strftime("%d.%m.%Y") }}.
 {{ payment_url }}
-{% if new_berth_order %}
+{% if include_berth %}
 
 Harbor: {{ order.lease.berth.pier.harbor.name }}
 Pier: {{ order.lease.berth.pier.identifier }}

--- a/templates/sms/invoice_notice_fi.txt
+++ b/templates/sms/invoice_notice_fi.txt
@@ -1,6 +1,6 @@
 Hyvä asiakas. Tässä linkki tuotteen {{ product_name }} maksamiseen tai sen irtisanomiseen seuraavalle kaudelle. Maksathan laskun {{ order.due_date.strftime("%d.%m.%Y") }} mennessä.
 {{ payment_url }}
-{% if new_berth_order %}
+{% if include_berth %}
 
 Satama: {{ order.lease.berth.pier.harbor.name }}
 Laituri: {{ order.lease.berth.pier.identifier }}

--- a/templates/sms/invoice_notice_sv.txt
+++ b/templates/sms/invoice_notice_sv.txt
@@ -1,6 +1,6 @@
 Kära kund. Här är en länk för att betala för eller avbryta {{ product_name }} för nästa säsong. Vänligen betala räkningen senast {{ order.due_date.strftime("%d.%m.%Y") }}.
 {{ payment_url }}
-{% if new_berth_order %}
+{% if include_berth %}
 
 Hamn: {{ order.lease.berth.pier.harbor.name }}
 Kaj: {{ order.lease.berth.pier.identifier }}


### PR DESCRIPTION
Berth information will be included in `SMS_INVOICE_NOTICE` notification if it's available.

## Issues :bug:
**[VEN-1462](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1462):** Addition to SMS berth offer notification
