### PR TITLE
VEN-1511 | Add management command for fetching customer email

### DIFF
--- a/customers/management/commands/fetch_customer_emails.py
+++ b/customers/management/commands/fetch_customer_emails.py
@@ -1,0 +1,55 @@
+import csv
+import logging
+
+from django.core.management import BaseCommand
+
+from customers.services import ProfileService
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Fetch emails the given list of profile ids."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--profile-token",
+            required=True,
+            type=str,
+            help="[Required] The API token for Profile",
+        )
+        parser.add_argument(
+            "--input-file",
+            required=True,
+            type=str,
+            help="[Required] Input file containing the list of profile ids to fetch separated by newline",
+        )
+        parser.add_argument(
+            "--output-file",
+            required=True,
+            type=str,
+            help="[Required] Filename for the output",
+        )
+
+    def handle(
+        self,
+        profile_token,
+        input_file,
+        output_file,
+        *args,
+        **options,
+    ):
+        with open(input_file, "r") as ids_file:
+            ids = ids_file.read().splitlines()
+
+        profile_service = ProfileService(profile_token=profile_token)
+        profiles = profile_service.get_all_profiles(ids)
+
+        with open(output_file, "w") as out_file:
+            writer = csv.writer(out_file)
+            for profile in profiles.values():
+                writer.writerow(
+                    [f"{profile.first_name} {profile.last_name}", profile.email]
+                )
+
+        self.stdout.write(self.style.SUCCESS(f"Exported Processed {len(ids)} profiles"))

--- a/customers/services/profile.py
+++ b/customers/services/profile.py
@@ -47,7 +47,7 @@ class ProfileService:
         }
 
     def get_all_profiles(
-        self, profile_ids: List[UUID] = None
+        self, profile_ids: List[Union[str, UUID]] = None
     ) -> Dict[UUID, HelsinkiProfileUser]:
         query = """
             query GetProfiles {{
@@ -102,7 +102,7 @@ class ProfileService:
         returned_users = []
         end_cursor = ""
         has_next = True
-        next_batch_ids = []
+        next_batch_ids = None
         id_batches = (
             [
                 profile_ids[x : x + BATCH_SIZE]


### PR DESCRIPTION
This PR adds a management command for fetching emails for a given list of profile ids from Helsinki profile. Also this fixes a bug where `ProfileService.get_all_profiles` ended up into an infinite query loop when fetching profiles without the `profile_ids` argument.

## Issues :bug:
- **[VEN-1511](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1511)** 
## Usage
    ./manage.py fetch_customer_emails --profile-token helsinki-profile-jwt-token-here --input-file customer_ids.txt --output-file customer_emails.csv