### PR TITLE
VEN-1524 | Add management command get_customer_emails & tests

### DIFF
--- a/payments/management/commands/get_customer_emails.py
+++ b/payments/management/commands/get_customer_emails.py
@@ -1,0 +1,240 @@
+from calendar import month_name
+from datetime import date
+from itertools import chain
+from typing import Optional, Tuple, Union
+
+from django.core.management import BaseCommand
+from django.db.models import QuerySet
+
+from payments.models import Order
+
+BERTH_ORDERS_START_DAY = 10
+BERTH_ORDERS_START_MONTH = 6
+BERTH_ORDERS_END_DAY = 9  # Inclusive range
+BERTH_ORDERS_END_MONTH = 6  # Inclusive range
+BERTH_ORDERS_END_NEXT_YEAR = True
+
+
+WINTER_STORAGE_ORDERS_START_DAY = 15
+WINTER_STORAGE_ORDERS_START_MONTH = 9
+WINTER_STORAGE_ORDERS_END_DAY = 9  # Inclusive range
+WINTER_STORAGE_ORDERS_END_MONTH = 6  # Inclusive range
+WINTER_STORAGE_ORDERS_END_NEXT_YEAR = True
+
+
+def is_valid_email(email: Optional[str]) -> bool:
+    return email is not None and "@" in email
+
+
+def get_order_email(order: Order) -> Optional[str]:
+    email = order.customer_email
+    if not email:
+        if order.lease and order.lease.application:
+            email = order.lease.application.email
+    return email.strip() if email and email.strip() else None
+
+
+def get_output_filename(today: Union[str, date]) -> str:
+    return f"customer_emails_{today}.txt"
+
+
+def get_orders_date_range(
+    today: date,
+    start_day: int,
+    start_month: int,
+    end_day: int,  # Inclusive range
+    end_month: int,  # Inclusive range
+    end_next_year: bool,
+) -> Tuple[date, date]:
+    end_year_start_year_difference: int = 1 if end_next_year else 0
+    start_year = (
+        today.year - end_year_start_year_difference
+        if (today.month, today.day) < (start_month, start_day)
+        else today.year
+    )
+    return (
+        date(start_year, start_month, start_day),
+        date(start_year + end_year_start_year_difference, end_month, end_day),
+    )
+
+
+def get_berth_orders_date_range(today: date) -> Tuple[date, date]:
+    return get_orders_date_range(
+        today=today,
+        start_day=BERTH_ORDERS_START_DAY,
+        start_month=BERTH_ORDERS_START_MONTH,
+        end_day=BERTH_ORDERS_END_DAY,
+        end_month=BERTH_ORDERS_END_MONTH,
+        end_next_year=BERTH_ORDERS_END_NEXT_YEAR,
+    )
+
+
+def get_winter_storage_orders_date_range(today: date) -> Tuple[date, date]:
+    return get_orders_date_range(
+        today=today,
+        start_day=WINTER_STORAGE_ORDERS_START_DAY,
+        start_month=WINTER_STORAGE_ORDERS_START_MONTH,
+        end_day=WINTER_STORAGE_ORDERS_END_DAY,
+        end_month=WINTER_STORAGE_ORDERS_END_MONTH,
+        end_next_year=WINTER_STORAGE_ORDERS_END_NEXT_YEAR,
+    )
+
+
+def get_help_text():
+    return f"""
+        Get customer emails from berth and winter storage orders active on given date
+        <TODAY> and save them to {get_output_filename("<TODAY>")}.
+        TODAY is determined by the parameters YEAR, MONTH and DAY.
+
+        Emails are included from berth orders (venepaikkatilaukset) created between
+        {month_name[BERTH_ORDERS_START_MONTH]} {BERTH_ORDERS_START_DAY} –
+        {month_name[BERTH_ORDERS_END_MONTH]} {BERTH_ORDERS_END_DAY}
+        {" next year" if BERTH_ORDERS_END_NEXT_YEAR else " the same year"}
+        for such a time period which contains <TODAY>.
+
+        Emails are included from winter storage orders (talvisäilytystilaukset) created between
+        {month_name[WINTER_STORAGE_ORDERS_START_MONTH]} {WINTER_STORAGE_ORDERS_START_DAY} –
+        {month_name[WINTER_STORAGE_ORDERS_END_MONTH]} {WINTER_STORAGE_ORDERS_END_DAY}
+        {" next year" if WINTER_STORAGE_ORDERS_END_NEXT_YEAR else " the same year"}
+        for such a time period which contains <TODAY>.
+    """.strip()
+
+
+class Command(BaseCommand):
+    help = get_help_text()
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--year",
+            "-y",
+            metavar="Y",
+            dest="year",
+            type=int,
+            default=date.today().year,
+            help="Year for which to gather customer emails. Default: Current year",
+        )
+        parser.add_argument(
+            "--month",
+            "-m",
+            metavar="M",
+            dest="month",
+            type=int,
+            default=date.today().month,
+            help="Month for which to gather customer emails. Default: Current month",
+        )
+        parser.add_argument(
+            "--day",
+            "-d",
+            metavar="D",
+            dest="day",
+            type=int,
+            default=date.today().day,
+            help="Day for which to gather customer emails. Default: Current day",
+        )
+        parser.add_argument(
+            "--encoding",
+            "-e",
+            metavar="E",
+            dest="encoding",
+            type=str,
+            default="utf-8",
+            help="Output encoding. Default: %(default)s",
+        )
+        parser.add_argument(
+            "--exclude-berth-orders",
+            dest="exclude_berth_orders",
+            action="store_true",
+            default=False,
+            help="Exclude berth orders (venepaikkatilaukset). Default: %(default)s",
+        )
+        parser.add_argument(
+            "--exclude-winter-storage-orders",
+            dest="exclude_winter_storage_orders",
+            action="store_true",
+            default=False,
+            help="Exclude winter storage orders (talvisäilytystilaukset). Default: %(default)s",
+        )
+        parser.add_argument(
+            "--use-posix-line-separator",
+            dest="use_posix_line_separator",
+            action="store_true",
+            default=False,
+            help=(
+                "Use POSIX line separator \\n in output? "
+                "If not, use Windows line separator \\r\\n. Default: %(default)s"
+            ),
+        )
+
+    def handle(
+        self,
+        *args,
+        year: int,
+        month: int,
+        day: int,
+        encoding: str,
+        exclude_berth_orders: bool,
+        exclude_winter_storage_orders: bool,
+        use_posix_line_separator: bool,
+        **options,
+    ):
+        today: date = date(year=year, month=month, day=day)
+        berth_orders: QuerySet[Order] = Order.objects.none()
+        winter_storage_orders: QuerySet[Order] = Order.objects.none()
+
+        if exclude_berth_orders:
+            self.stdout.write(self.style.WARNING("Excluding berth orders"))
+        else:
+            min_date, max_date = get_berth_orders_date_range(today)
+            berth_orders = Order.objects.berth_orders().filter(
+                created_at__date__gte=min_date, created_at__date__lte=max_date
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Found {len(berth_orders)} berth orders "
+                    f"created between {min_date} – {max_date}"
+                )
+            )
+
+        if exclude_winter_storage_orders:
+            self.stdout.write(self.style.WARNING("Excluding winter storage orders"))
+        else:
+            min_date, max_date = get_winter_storage_orders_date_range(today)
+            winter_storage_orders = Order.objects.winter_storage_orders().filter(
+                created_at__date__gte=min_date, created_at__date__lte=max_date
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Found {len(winter_storage_orders)} winter storage orders "
+                    f"created between {min_date} – {max_date}"
+                )
+            )
+
+        emails = sorted(
+            set(
+                filter(
+                    is_valid_email,
+                    (
+                        get_order_email(order)
+                        for order in chain(berth_orders, winter_storage_orders)
+                    ),
+                )
+            )
+        )
+
+        if emails:
+            output_filename = get_output_filename(today)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Writing {len(emails)} unique emails to {output_filename}"
+                )
+            )
+            with open(
+                output_filename,
+                mode="w",
+                encoding=encoding,
+                newline="\n" if use_posix_line_separator else "\r\n",
+            ) as file:
+                # \n are converted to open call's newline
+                file.write("\n".join(emails) + "\n")
+        else:
+            self.stdout.write(self.style.WARNING(f"No emails found for date {today}"))

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest.mock import mock_open
 from uuid import UUID
 
 import pytest
@@ -441,3 +442,8 @@ def default_talpa_product_accounting():
             region=AreaRegion.WEST, product_type=TalpaProductType.WINTER
         ),
     ]
+
+
+@pytest.fixture
+def open_mock():
+    return mock_open()

--- a/payments/tests/test_get_customer_emails_command.py
+++ b/payments/tests/test_get_customer_emails_command.py
@@ -1,0 +1,288 @@
+from datetime import date, datetime
+from typing import List, Optional
+from unittest.mock import patch
+
+import pytest
+import pytz
+from django.conf import settings
+from django.core.management import call_command
+from factory.django import DjangoModelFactory
+from freezegun import freeze_time
+
+from applications.tests.factories import (
+    BerthApplicationFactory,
+    WinterStorageApplicationFactory,
+)
+from customers.tests.factories import BoatFactory
+from leases.tests.factories import BerthLeaseFactory, WinterStorageLeaseFactory
+from payments.tests.factories import OrderFactory
+
+
+def _local_date_noon(value: date) -> datetime:
+    return datetime(
+        year=value.year,
+        month=value.month,
+        day=value.day,
+        hour=12,
+        minute=0,
+        second=0,
+        microsecond=0,
+        tzinfo=pytz.timezone(settings.TIME_ZONE),
+    )
+
+
+def _create_test_order(
+    order_email: Optional[str],
+    lease_factory: DjangoModelFactory,
+    application_factory: Optional[DjangoModelFactory] = None,
+    application_email: Optional[str] = None,
+):
+    boat = BoatFactory()
+    application = None
+    if application_factory:
+        application = application_factory(
+            customer=boat.owner, boat=boat, email=application_email
+        )
+    lease = lease_factory(customer=boat.owner, boat=boat, application=application)
+    return OrderFactory(lease=lease, customer_email=order_email)
+
+
+def _create_get_customer_emails_minimal_test_data():
+    _create_test_order(lease_factory=BerthLeaseFactory, order_email="test@example.org")
+
+
+def _create_get_customer_emails_full_test_data():
+    _create_test_order(lease_factory=BerthLeaseFactory, order_email=None)
+    _create_test_order(lease_factory=WinterStorageLeaseFactory, order_email=None)
+    for _ in range(2):  # Create a duplicate on purpose
+        _create_test_order(
+            lease_factory=BerthLeaseFactory, order_email="berth_1_primary@example.org"
+        )
+    _create_test_order(
+        lease_factory=WinterStorageLeaseFactory,
+        order_email="winter_storage_1_primary@example.org",
+    )
+    _create_test_order(
+        application_factory=BerthApplicationFactory,
+        lease_factory=BerthLeaseFactory,
+        order_email=None,
+        application_email="berth_fallback@example.org",
+    )
+    _create_test_order(
+        application_factory=WinterStorageApplicationFactory,
+        lease_factory=WinterStorageLeaseFactory,
+        order_email=None,
+        application_email="winter_storage_fallback@example.org",
+    )
+    _create_test_order(
+        application_factory=BerthApplicationFactory,
+        lease_factory=BerthLeaseFactory,
+        order_email="berth_2_primary@example.org",
+        application_email="berth_unused_fallback@example.org",
+    )
+    _create_test_order(
+        application_factory=WinterStorageApplicationFactory,
+        lease_factory=WinterStorageLeaseFactory,
+        order_email="winter_storage_2_primary@example.org",
+        application_email="winter_storage_unused_fallback@example.org",
+    )
+
+
+@freeze_time(_local_date_noon(date(2021, 1, 9)))
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "command_args,expected_output",
+    [
+        (
+            [],
+            (
+                "berth_1_primary@example.org\n"
+                "berth_2_primary@example.org\n"
+                "berth_fallback@example.org\n"
+                "winter_storage_1_primary@example.org\n"
+                "winter_storage_2_primary@example.org\n"
+                "winter_storage_fallback@example.org\n"
+            ),
+        ),
+        (
+            ["--exclude-winter-storage-orders"],
+            (
+                "berth_1_primary@example.org\n"
+                "berth_2_primary@example.org\n"
+                "berth_fallback@example.org\n"
+            ),
+        ),
+        (
+            ["--exclude-berth-orders"],
+            (
+                "winter_storage_1_primary@example.org\n"
+                "winter_storage_2_primary@example.org\n"
+                "winter_storage_fallback@example.org\n"
+            ),
+        ),
+        (["--exclude-berth-orders", "--exclude-winter-storage-orders"], None),
+    ],
+)
+def test_get_customer_emails_output(open_mock, capsys, command_args, expected_output):
+    _create_get_customer_emails_full_test_data()
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        call_command("get_customer_emails", *command_args)
+
+    captured = capsys.readouterr()
+    if expected_output is None:
+        open_mock.assert_not_called()
+        assert "No emails found for date 2021-01-09" in captured.out
+    else:
+        open_mock.assert_called_once_with(
+            "customer_emails_2021-01-09.txt", mode="w", encoding="utf-8", newline="\r\n"
+        )
+        open_mock.return_value.write.assert_called_once_with(expected_output)
+
+
+@freeze_time(_local_date_noon(date(2021, 1, 9)))
+@pytest.mark.django_db
+@pytest.mark.parametrize("encoding", ["utf-8", "cp437", "cp1252"])
+def test_get_customer_emails_encoding(open_mock, encoding):
+    _create_get_customer_emails_minimal_test_data()
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        call_command("get_customer_emails", encoding=encoding)
+
+    open_mock.assert_called_with(
+        "customer_emails_2021-01-09.txt", mode="w", encoding=encoding, newline="\r\n"
+    )
+
+
+@freeze_time(_local_date_noon(date(2021, 1, 9)))
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "use_posix_line_separator,expected_newline", [(False, "\r\n"), (True, "\n")]
+)
+def test_get_customer_emails_use_posix_line_separator(
+    open_mock, use_posix_line_separator: bool, expected_newline: str
+):
+    _create_get_customer_emails_minimal_test_data()
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        call_command(
+            "get_customer_emails", use_posix_line_separator=use_posix_line_separator
+        )
+
+    open_mock.assert_called_with(
+        "customer_emails_2021-01-09.txt",
+        mode="w",
+        encoding="utf-8",
+        newline=expected_newline,
+    )
+
+
+@freeze_time(_local_date_noon(date(2022, 6, 30)))
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "expected_today_date,command_args",
+    [
+        (date(2022, 6, 30), []),
+        (date(2020, 6, 30), ["--year=2020"]),
+        (date(2020, 6, 30), ["-y2020"]),
+        (date(2022, 9, 30), ["--month=9"]),
+        (date(2022, 9, 30), ["-m9"]),
+        (date(2022, 6, 25), ["--day=25"]),
+        (date(2022, 6, 25), ["-d25"]),
+        (date(2019, 12, 31), ["--year=2019", "--month=12", "--day=31"]),
+        (date(2019, 12, 31), ["-y2019", "-m12", "-d31"]),
+    ],
+)
+def test_get_customer_emails_year_month_day(
+    open_mock, expected_today_date: date, command_args: List[str]
+):
+    with freeze_time(_local_date_noon(expected_today_date)):
+        _create_get_customer_emails_minimal_test_data()
+
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        call_command("get_customer_emails", *command_args)
+
+    open_mock.assert_called_once_with(
+        f"customer_emails_{expected_today_date}.txt",
+        mode="w",
+        encoding="utf-8",
+        newline="\r\n",
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "order_creation_date,today,expect_output",
+    [
+        # At the inclusive end of berth orders date range
+        (date(2021, 6, 9), date(2022, 6, 9), False),
+        (date(2021, 6, 10), date(2022, 6, 9), True),
+        (date(2022, 6, 9), date(2022, 6, 9), True),
+        (date(2022, 6, 10), date(2022, 6, 9), False),
+        # At the inclusive start of berth orders' date range
+        (date(2022, 6, 9), date(2022, 6, 10), False),
+        (date(2022, 6, 10), date(2022, 6, 10), True),
+        (date(2023, 6, 9), date(2022, 6, 10), True),
+        (date(2023, 6, 10), date(2022, 6, 10), False),
+    ],
+)
+def test_get_customer_emails_berth_order_date_range(
+    open_mock,
+    capsys,
+    order_creation_date: Optional[date],
+    today: date,
+    expect_output: bool,
+):
+    with freeze_time(_local_date_noon(order_creation_date)):
+        _create_test_order(
+            lease_factory=BerthLeaseFactory, order_email="test@example.org"
+        )
+
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        with freeze_time(_local_date_noon(today)):
+            call_command("get_customer_emails")
+
+    if expect_output:
+        open_mock.assert_called_once()
+    else:
+        open_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "order_creation_date,today,expect_output",
+    [
+        # At the inclusive end of winter storage orders' date range
+        (date(2021, 9, 14), date(2022, 6, 9), False),
+        (date(2021, 9, 15), date(2022, 6, 9), True),
+        (date(2022, 6, 9), date(2022, 6, 9), True),
+        (date(2022, 6, 10), date(2022, 6, 9), False),
+        # Just before the inclusive start of winter storage orders' date range
+        (date(2021, 9, 14), date(2022, 9, 14), False),
+        (date(2021, 9, 15), date(2022, 9, 14), True),
+        (date(2022, 6, 9), date(2022, 9, 14), True),
+        (date(2022, 6, 10), date(2022, 9, 14), False),
+        # At the inclusive start of winter storage orders' date range
+        (date(2022, 9, 14), date(2022, 9, 15), False),
+        (date(2022, 9, 15), date(2022, 9, 15), True),
+        (date(2023, 6, 9), date(2022, 9, 15), True),
+        (date(2023, 6, 10), date(2022, 9, 15), False),
+    ],
+)
+def test_get_customer_emails_winter_storage_order_date_range(
+    open_mock,
+    capsys,
+    order_creation_date: Optional[date],
+    today: date,
+    expect_output: bool,
+):
+    with freeze_time(_local_date_noon(order_creation_date)):
+        _create_test_order(
+            lease_factory=WinterStorageLeaseFactory, order_email="test@example.org"
+        )
+
+    with patch("payments.management.commands.get_customer_emails.open", open_mock):
+        with freeze_time(_local_date_noon(today)):
+            call_command("get_customer_emails")
+
+    if expect_output:
+        open_mock.assert_called_once()
+    else:
+        open_mock.assert_not_called()


### PR DESCRIPTION
## Description :sparkles:

get_customer_emails management command help:
  - usage: manage.py get_customer_emails
    [-h] [--year Y] [--month M] [--day D] [--encoding E]
    [--exclude-berth-orders] [--exclude-winter-storage-orders]
    [--use-posix-line-separator]

"Get customer emails from berth and winter storage orders active on
given date \<TODAY\> and save them to customer_emails_\<TODAY\>.txt.
TODAY is determined by the parameters YEAR, MONTH and DAY.

Emails are included from berth orders (venepaikkatilaukset) created
between June 10 – June 9 next year for such a time period which
contains \<TODAY\>.

Emails are included from winter storage orders (talvisäilytystilaukset)
created between September 15 – June 9 next year for such a time period
which contains \<TODAY\>."

## Issues :bug:
**[VEN-1524](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1524)** 

### Closes
**[VEN-1524](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1524)** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
### Manual testing :construction_worker_man:

You need [kubectl](https://kubernetes.io/docs/reference/kubectl/) command line tool for testing.
 - Checkout this PR's branch locally so you have the get_customer_emails.py locally
 - Get access to QA environment using https://into.test.kuva.hel.ninja/ (See [Accessing Kubernetes](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/1279295535/Accessing+Kubernetes))
 - Open terminal
   - `kubectl get pods --namespace=berth-reservations-qa`
   - Pick one of the project-berth-reservations-staging-* pods, e.g. `project-berth-reservations-staging-7778d45996-m9wp8`, let's call it `<POD>`
   - Go to the root of directory of this PR's checked out git repository locally
   - Copy the get_customer_emails.py from local filesystem to the pod's filesystem so we can run it there
     - `kubectl cp ./payments/management/commands/get_customer_emails.py <POD>:/app/payments/management/commands/get_customer_emails.py`
   - `kubectl exec --stdin --tty <POD> -- /bin/bash`
     - `python manage.py get_customer_emails -y2021 -m10 -d1` (i.e. run for 2021-10-01)
     - Voilà! [1] You should have a `customer_emails_2021-10-01.txt` file with the customer emails

[1] Example test console output:
```
appuser@project-berth-reservations-staging-7778d45996-4zwzv:/app$ python manage.py get_customer_emails -y2021 -m10 -d1
Found 89 berth orders created between 2021-06-10 – 2022-06-09
Found 16 winter storage orders created between 2021-09-15 – 2022-06-09
Writing 19 unique emails to customer_emails_2021-10-01.txt
```

NOTE: You may get this error after running the command:
```
Failed to submit message: 'HTTP 503: {"accepted":0,"errors":[{"message":"queue is full"}]}\n'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/elasticapm/transport/base.py", line 263, in _flush
    self.send(data)
  File "/usr/local/lib/python3.9/site-packages/elasticapm/transport/http.py", line 110, in send
    raise TransportException(message, data, print_trace=print_trace)
elasticapm.transport.exceptions.TransportException: HTTP 503: {"accepted":0,"errors":[{"message":"queue is full"}]}

Sentry is attempting to send 2 pending error messages
Waiting up to 2 seconds
Press Ctrl-C to quit
```
AFAIK This has to do with Elastic Search server not being able to receive data. I have not checked which part of the code tries to send something to Elastic Search server but IMO it is not important for the sole purpose of testing this management command's functionality.

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
