### PR TITLE
VEN-1524 | Update get_customer_emails command's order date ranges

### DIFF
--- a/payments/management/commands/get_customer_emails.py
+++ b/payments/management/commands/get_customer_emails.py
@@ -8,15 +8,20 @@ from django.db.models import QuerySet
 
 from payments.models import Order
 
-BERTH_ORDERS_START_DAY = 10
-BERTH_ORDERS_START_MONTH = 6
-BERTH_ORDERS_END_DAY = 9  # Inclusive range
-BERTH_ORDERS_END_MONTH = 6  # Inclusive range
+# Invoices for the next season's berth orders
+# (i.e. "seuraavan kauden venepaikkojen laskut") start to be sent during December
+# (e.g. 7th of December), relaxed lower bound is 1st of December.
+BERTH_ORDERS_START_DAY = 1
+BERTH_ORDERS_START_MONTH = 12
+BERTH_ORDERS_END_DAY = 14  # Inclusive range
+BERTH_ORDERS_END_MONTH = 9  # Inclusive range
 BERTH_ORDERS_END_NEXT_YEAR = True
 
-
-WINTER_STORAGE_ORDERS_START_DAY = 15
-WINTER_STORAGE_ORDERS_START_MONTH = 9
+# Invoices for the next season's winter storage orders
+# (i.e. "seuraavan kauden talvisäilytyspaikkojen laskut") start to be sent during August
+# (e.g. 15th of August), relaxed lower bound is 1st of August.
+WINTER_STORAGE_ORDERS_START_DAY = 1
+WINTER_STORAGE_ORDERS_START_MONTH = 8
 WINTER_STORAGE_ORDERS_END_DAY = 9  # Inclusive range
 WINTER_STORAGE_ORDERS_END_MONTH = 6  # Inclusive range
 WINTER_STORAGE_ORDERS_END_NEXT_YEAR = True

--- a/payments/tests/test_get_customer_emails_command.py
+++ b/payments/tests/test_get_customer_emails_command.py
@@ -182,8 +182,8 @@ def test_get_customer_emails_use_posix_line_separator(
         (date(2022, 6, 30), []),
         (date(2020, 6, 30), ["--year=2020"]),
         (date(2020, 6, 30), ["-y2020"]),
-        (date(2022, 9, 30), ["--month=9"]),
-        (date(2022, 9, 30), ["-m9"]),
+        (date(2022, 8, 30), ["--month=8"]),
+        (date(2022, 8, 30), ["-m8"]),
         (date(2022, 6, 25), ["--day=25"]),
         (date(2022, 6, 25), ["-d25"]),
         (date(2019, 12, 31), ["--year=2019", "--month=12", "--day=31"]),
@@ -211,16 +211,21 @@ def test_get_customer_emails_year_month_day(
 @pytest.mark.parametrize(
     "order_creation_date,today,expect_output",
     [
-        # At the inclusive end of berth orders date range
-        (date(2021, 6, 9), date(2022, 6, 9), False),
-        (date(2021, 6, 10), date(2022, 6, 9), True),
-        (date(2022, 6, 9), date(2022, 6, 9), True),
-        (date(2022, 6, 10), date(2022, 6, 9), False),
+        # At the inclusive end of berth orders' date range
+        (date(2021, 11, 30), date(2022, 9, 14), False),
+        (date(2021, 12, 1), date(2022, 9, 14), True),
+        (date(2022, 9, 14), date(2022, 9, 14), True),
+        (date(2022, 9, 15), date(2022, 9, 14), False),
+        # Just before the inclusive start of berth orders' date range
+        (date(2021, 11, 30), date(2022, 11, 30), False),
+        (date(2021, 12, 1), date(2022, 11, 30), True),
+        (date(2022, 9, 14), date(2022, 11, 30), True),
+        (date(2022, 9, 15), date(2022, 11, 30), False),
         # At the inclusive start of berth orders' date range
-        (date(2022, 6, 9), date(2022, 6, 10), False),
-        (date(2022, 6, 10), date(2022, 6, 10), True),
-        (date(2023, 6, 9), date(2022, 6, 10), True),
-        (date(2023, 6, 10), date(2022, 6, 10), False),
+        (date(2022, 11, 30), date(2022, 12, 1), False),
+        (date(2022, 12, 1), date(2022, 12, 1), True),
+        (date(2023, 9, 14), date(2022, 12, 1), True),
+        (date(2023, 9, 15), date(2022, 12, 1), False),
     ],
 )
 def test_get_customer_emails_berth_order_date_range(
@@ -250,20 +255,20 @@ def test_get_customer_emails_berth_order_date_range(
     "order_creation_date,today,expect_output",
     [
         # At the inclusive end of winter storage orders' date range
-        (date(2021, 9, 14), date(2022, 6, 9), False),
-        (date(2021, 9, 15), date(2022, 6, 9), True),
+        (date(2021, 7, 31), date(2022, 6, 9), False),
+        (date(2021, 8, 1), date(2022, 6, 9), True),
         (date(2022, 6, 9), date(2022, 6, 9), True),
         (date(2022, 6, 10), date(2022, 6, 9), False),
         # Just before the inclusive start of winter storage orders' date range
-        (date(2021, 9, 14), date(2022, 9, 14), False),
-        (date(2021, 9, 15), date(2022, 9, 14), True),
-        (date(2022, 6, 9), date(2022, 9, 14), True),
-        (date(2022, 6, 10), date(2022, 9, 14), False),
+        (date(2021, 7, 31), date(2022, 7, 31), False),
+        (date(2021, 8, 1), date(2022, 7, 31), True),
+        (date(2022, 6, 9), date(2022, 7, 31), True),
+        (date(2022, 6, 10), date(2022, 7, 31), False),
         # At the inclusive start of winter storage orders' date range
-        (date(2022, 9, 14), date(2022, 9, 15), False),
-        (date(2022, 9, 15), date(2022, 9, 15), True),
-        (date(2023, 6, 9), date(2022, 9, 15), True),
-        (date(2023, 6, 10), date(2022, 9, 15), False),
+        (date(2022, 7, 31), date(2022, 8, 1), False),
+        (date(2022, 8, 1), date(2022, 8, 1), True),
+        (date(2023, 6, 9), date(2022, 8, 1), True),
+        (date(2023, 6, 10), date(2022, 8, 1), False),
     ],
 )
 def test_get_customer_emails_winter_storage_order_date_range(


### PR DESCRIPTION
## Description :sparkles:

Update the get_customer_emails management command's date ranges for the
berth orders and winter storage orders based on discussion with the
Venepaikka / berth reservations service's product owner:
 - **Berth orders'** date range changed (**DAY/MONTH** format):
   - Old range: 10/6 – 9/6
   - New range: **1/12 – 14/9**
 - **Winter storage orders'** date range changed (**DAY/MONTH** format):
   - Old range: 15/9 – 9/6
   - New range: **1/8 – 9/6**

The orders are not filtered by status at the moment and for the current
use case that should be fine although it may produce false positives.
For the service's product owner this was fine for the moment.

The current help text for get_customer_emails management command:
```
usage: manage.py get_customer_emails
[-h] [--year Y] [--month M] [--day D] [--encoding E]
[--exclude-berth-orders] [--exclude-winter-storage-orders]
[--use-posix-line-separator]

Get customer emails from berth and winter storage orders active on given
date <TODAY> and save them to customer_emails_<TODAY>.txt. TODAY is
determined by the parameters YEAR, MONTH and DAY.

Emails are included from berth orders (venepaikkatilaukset) created
between December 1 – September 14 next year for such a time period which
contains <TODAY>.

Emails are included from winter storage orders (talvisäilytystilaukset)
created between August 1 – June 9 next year for such a time period which
contains <TODAY>.
```

## Issues :bug:
**[VEN-1524](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1524)** 

### Closes :no_good_woman:
**[VEN-1524](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1524)** 

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

See manual testing instructions from PR #696. The date to find enough test data may vary from the PR #696's instructions.

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
