### PR TITLE
VEN-1541 Update previous berth lease date handling

### DIFF
--- a/leases/models.py
+++ b/leases/models.py
@@ -11,13 +11,9 @@ from helsinki_gdpr.models import SerializableMixin
 
 from applications.models import BerthApplication, WinterStorageApplication
 from customers.models import Boat, CustomerProfile
-from payments.enums import OrderType
-from resources.models import Berth, WinterStoragePlace, WinterStorageSection
-from utils.models import TimeStampedModel, UUIDModel
-
-from .consts import ACTIVE_LEASE_STATUSES
-from .enums import LeaseStatus
-from .utils import (
+from leases.consts import ACTIVE_LEASE_STATUSES
+from leases.enums import LeaseStatus
+from leases.utils import (
     calculate_berth_lease_end_date,
     calculate_berth_lease_start_date,
     calculate_prev_season_end_date,
@@ -28,6 +24,9 @@ from .utils import (
     calculate_winter_storage_lease_end_date,
     calculate_winter_storage_lease_start_date,
 )
+from payments.enums import OrderType
+from resources.models import Berth, WinterStoragePlace, WinterStorageSection
+from utils.models import TimeStampedModel, UUIDModel
 
 
 class AbstractLease(TimeStampedModel, UUIDModel):
@@ -175,6 +174,8 @@ class BerthLeaseManager(SerializableMixin.SerializableManager):
             end_date__gte=prev_season_start,
             # Check the lease ends latest at the end of the season
             end_date__lte=prev_season_end,
+            # Only include paid leases, ie. the ones that were actually active
+            status=LeaseStatus.PAID,
         )
         return qs.filter(in_prev_season)
 

--- a/leases/utils.py
+++ b/leases/utils.py
@@ -13,11 +13,10 @@ from django_ilmoitin.utils import send_notification
 
 from berth_reservations.exceptions import VenepaikkaGraphQLError
 from customers.services import ProfileService
+from leases.consts import TERMINABLE_STATUSES
+from leases.enums import LeaseStatus
 from payments.enums import OrderStatus
 from utils.email import is_valid_email
-
-from .consts import TERMINABLE_STATUSES
-from .enums import LeaseStatus
 
 if TYPE_CHECKING:
     from leases.models import BerthLease, WinterStorageLease
@@ -68,11 +67,21 @@ def calculate_season_end_date(lease_end: date = None) -> date:
 
 def calculate_prev_season_start_date() -> date:
     today = date.today()
+    # If today is between 15.9 and 31.12, the start date is 10.6 of the current year
+    autumn_start = date(day=15, month=9, year=today.year)
+    autumn_end = date(day=31, month=12, year=today.year)
+    if today >= autumn_start and today <= autumn_end:
+        return date(day=10, month=6, year=today.year)
     return date(day=10, month=6, year=today.year - 1)
 
 
 def calculate_prev_season_end_date() -> date:
     today = date.today()
+    # If today is between 15.9 and 31.12, the end date is 14.9 of the current year
+    autumn_start = date(day=15, month=9, year=today.year)
+    autumn_end = date(day=31, month=12, year=today.year)
+    if today >= autumn_start and today <= autumn_end:
+        return date(day=14, month=9, year=today.year)
     return date(day=14, month=9, year=today.year - 1)
 
 


### PR DESCRIPTION
For deciding what is the previous lease, this updates the handling to take into account the autumn time after the lease has expired, but before the year changes. Currently `previousLease` is decided by simply today.year - 1, but this adds a condition so that if today falls between 15.9 - 31.12, the previousLease is the one from this summer, not last years summer.

Also, only paid - so activated - leases are considered as previous.

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1541](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1541):** 

### Related :handshake:
https://github.com/City-of-Helsinki/berth-reservations-admin/pull/495
## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
