### PR TITLE
VEN-1539 Exclude internal organisations from tax

### DIFF
--- a/payments/utils.py
+++ b/payments/utils.py
@@ -53,6 +53,13 @@ from leases.utils import (
     calculate_winter_season_end_date,
     calculate_winter_season_start_date,
 )
+from payments.enums import (
+    OfferStatus,
+    OrderStatus,
+    OrderType,
+    PricingCategory,
+    ProductServiceType,
+)
 from resources.enums import AreaRegion, BerthMooringType
 from resources.models import (
     Berth,
@@ -64,14 +71,6 @@ from resources.models import (
 from utils.email import is_valid_email
 from utils.messaging import get_email_subject
 from utils.numbers import rounded as rounded_decimal
-
-from .enums import (
-    OfferStatus,
-    OrderStatus,
-    OrderType,
-    PricingCategory,
-    ProductServiceType,
-)
 
 
 def fetch_order_profile(order, profile_token):
@@ -223,9 +222,13 @@ def calculate_product_percentage_price(base_price, percentage):
 
 
 @rounded
-def calculate_organization_price(price, organization_type: OrganizationType) -> Decimal:
+def calculate_organization_price(
+    price, organization_type: OrganizationType, tax: Decimal = None
+) -> Decimal:
     if organization_type == OrganizationType.COMPANY:
         return price * 2
+    if organization_type == OrganizationType.INTERNAL:
+        return convert_aftertax_to_pretax(price, tax)
     elif organization_type == OrganizationType.NON_BILLABLE:
         return Decimal("0.00")
     else:


### PR DESCRIPTION
## Description :sparkles:
Currently all prices are set with tax, and tax is calculated seperately as `totalPretaxPrice` and `totalTaxPercentage` from the  original price. However, internal customers should receive their invoices without tax (as per ticket van-1539). This adds a case to price calculation that returns a pretax value for the price for internal customers. 

## Issues :bug:
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1539
### Closes :no_good_woman:
**[VEN-1539](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1539):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
