### PR TITLE
mailer lockfile to tmp directory PLAENH-546

### DIFF
--- a/berth_reservations/settings.py
+++ b/berth_reservations/settings.py
@@ -35,6 +35,7 @@ env = environ.Env(
     DATABASE_CONN_MAX_AGE=(int, 60 * 60),  # 60 min
     CACHE_URL=(str, "locmemcache://"),
     MAILER_EMAIL_BACKEND=(str, "django.core.mail.backends.console.EmailBackend"),
+    MAILER_LOCK_PATH=(str, "/tmp/mailer_lockfile"),
     DEFAULT_FROM_EMAIL=(str, "venepaikkavaraukset@hel.fi"),
     MAIL_MAILGUN_KEY=(str, ""),
     MAIL_MAILGUN_DOMAIN=(str, ""),
@@ -119,6 +120,8 @@ if env("MAIL_MAILGUN_KEY"):
 
 EMAIL_BACKEND = "mailer.backend.DbBackend"
 MAILER_EMAIL_BACKEND = env.str("MAILER_EMAIL_BACKEND")
+if env("MAILER_LOCK_PATH"):
+    MAILER_LOCK_PATH = env.str("MAILER_LOCK_PATH")
 
 try:
     version = subprocess.check_output(


### PR DESCRIPTION
## Description :sparkles:
Reminder cronjob has failed on Platta because it could not write mailer lock file to /app -directory.

Use variable MAILER_LOCK_PATH to write mailer lock file to /tmp -directory.

## Issues :bug:
### Closes :no_good_woman:
**[VPLAENH-546](https://helsinkisolutionoffice.atlassian.net/browse/PLAENH-546):** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
