### PR TITLE
build(docker): fix building with Docker by using netcat-traditional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=appuser:appuser requirements.txt /app/
 RUN apt-install.sh \
   build-essential \
   libpq-dev \
-  netcat \
+  netcat-traditional \
   gdal-bin \
   python3-gdal \
   gettext \


### PR DESCRIPTION
## Description :sparkles:

### build(docker): fix building with Docker by using netcat-traditional 

Fix building with Docker by using netcat-traditional package instead of
netcat. See error message below:

`docker compose up --build` failed with:
```bash
2.384 Package netcat is a virtual package provided by:
2.384   netcat-openbsd 1.219-1
2.384   netcat-traditional 1.10-47
2.384
2.390 E: Package 'netcat' has no installation candidate
------
failed to solve: process "/bin/sh -c apt-install.sh build-essential
libpq-dev netcat gdal-bin python3-gdal gettext pkg-config && pip install
-U pip && pip install --no-cache-dir -r /app/requirements.txt &&
apt-cleanup.sh build-essential pkg-config"
did not complete successfully: exit code: 100
```

Using netcat-traditional fixes the issue.

refs VEN-1558 (found backend not building in docker when testing this)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

**[VEN-1558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558)** 

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1558]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ