### PR TITLE
VEN-1577 | fix(docker): use Amazon ECR as source, remove helsinkitest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # Build a base image for development and production stages.
 # Note that this stage won't get thrown out so we need to think about
 # layer sizes from this point on.
-FROM helsinkitest/python:3.9-slim as appbase
+FROM public.ecr.aws/docker/library/python:3.9-slim AS appbase
+
+USER root
+WORKDIR /app
+
+# Make sure appuser group and user exist
+COPY ./setup_user.sh /setup_user.sh
+RUN chmod a+x /setup_user.sh && /bin/sh -c /setup_user.sh && rm -f /setup_user.sh
 
 # Copy requirement files.
 COPY --chown=appuser:appuser requirements.txt /app/
@@ -10,38 +17,42 @@ COPY --chown=appuser:appuser requirements.txt /app/
 # Note that production dependencies are installed here as well since
 # that is the default state of the image and development stages are
 # just extras.
-RUN apt-install.sh \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
+  gdal-bin \
+  gettext \
   libpq-dev \
   netcat-traditional \
-  gdal-bin \
-  python3-gdal \
-  gettext \
   pkg-config \
+  python3-gdal \
   && pip install -U pip \
   && pip install --no-cache-dir -r /app/requirements.txt \
-  && apt-cleanup.sh build-essential pkg-config
-
+  && apt-get remove -y build-essential pkg-config \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/cache/apt/archives
 
 # Copy and set the entrypoint.
 COPY --chown=appuser:appuser docker-entrypoint.sh /app
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-ENV STATIC_ROOT /var/berth/static
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV STATIC_ROOT=/var/berth/static
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
-RUN mkdir -p /var/berth/static
-RUN chown appuser:appuser /var/berth/static
+RUN mkdir -p /var/berth/static && chown appuser:appuser /var/berth/static
 
 # Build development image using the previous stage as base. This is used
 # for local development with docker-compose.
-FROM appbase as development
+FROM appbase AS development
 
 # Install additional dependencies.
 COPY --chown=appuser:appuser requirements-dev.txt /app/requirements-dev.txt
 RUN pip install --no-cache-dir  -r /app/requirements-dev.txt \
-  && apt-install.sh postgresql-client
+  && apt-get update && apt-get install -y --no-install-recommends postgresql-client \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/cache/apt/archives
 
 # Set environment variables for development.
 ENV DEV_SERVER=1
@@ -62,20 +73,20 @@ EXPOSE 8000/tcp
 
 # Build production image using the appbase stage as base. This should always
 # be the last stage of Dockerfile.
-FROM appbase as production
+FROM appbase AS production
 
 # Copy application code.
 COPY --chown=appuser:appuser . /app/
 
 # OpenShift write access to email templates for generated -folder
 USER root
-RUN chgrp -R 0 /app/templates/email && chmod g+w -R /app/templates/email
-RUN chgrp -R 0 /var/berth && chmod g+w -R /var/berth
-# /app/data needs write access for Django management commands to work
-RUN mkdir -p /app/data
-RUN chgrp -R 0 /app/data && chmod g+w -R /app/data
-# required to make compilemessages command work in OpenShift
-RUN chmod -R g+w /app/locale && chgrp -R root /app/locale
+RUN chgrp -R 0 /app/templates/email && chmod g+w -R /app/templates/email \
+  && chgrp -R 0 /var/berth && chmod g+w -R /var/berth \
+  # /app/data needs write access for Django management commands to work
+  && mkdir -p /app/data \
+  && chgrp -R 0 /app/data && chmod g+w -R /app/data \
+  # required to make compilemessages command work in OpenShift
+  && chmod -R g+w /app/locale && chgrp -R root /app/locale
 
 # Set user and document the port.
 USER appuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
     postgres:
         build: ./docker/postgres/

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,12 +1,11 @@
-FROM postgres:11-buster
+FROM public.ecr.aws/docker/library/postgres:11-buster
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        postgis postgresql-11-postgis-2.5 postgresql-11-postgis-2.5-scripts
+        postgis postgresql-11-postgis-2.5 postgresql-11-postgis-2.5-scripts \
+    && localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 
-RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
-
-ENV LANG fi_FI.UTF-8
+ENV LANG=fi_FI.UTF-8
 
 # Openshift 
 ENV PGDATA=/opt/app-root

--- a/setup_user.sh
+++ b/setup_user.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+existing_group=$(getent group 1000 | cut -d: -f1)
+if [[ -z "${existing_group}" ]]; then
+    # Create appuser group
+   groupadd --gid 1000 appuser
+elif [[ "${existing_group}" != "appuser" ]]; then
+   # Change group name to appuser
+   groupmod -n appuser "${existing_group}"
+fi
+
+
+existing_user=$(id -nu 1000 2>/dev/null)
+if [[ -z "${existing_user}" ]]; then
+    # Add an application user
+    useradd --uid 1000 --gid appuser --create-home --shell /bin/bash appuser
+else
+    # Change user name to appuser
+    usermod -l appuser "${existing_user}"
+
+    # Add user to appuser group
+    gpasswd -a appuser appuser
+fi


### PR DESCRIPTION
## Description :sparkles:

### fix(docker): use Amazon ECR as source, remove helsinkitest

fixes:
 - building docker containers reliably with the recent docker hub rate
   limits (i.e. by not using docker hub's images we don't need to worry
   about their rate limiting)

also:
 - remove deprecated version number from docker-compose.yml
 - use new style ENV settings in Dockerfiles i.e. `ENV VAR=VAL` instead
   of old style `ENV VAR VAL`
 - remove SonarCloud code smells from Dockerfiles
   - docker:S6587: "Cache should be cleaned after package installation"
	 - https://rules.sonarsource.com/docker/RSPEC-6587/
   - docker:S7018: "Arguments in long RUN instructions should be sorted"
	 - https://rules.sonarsource.com/docker/RSPEC-7018/
   - docker:S7031: "Reduce the amount of consecutive RUN instructions"
	 - https://rules.sonarsource.com/docker/RSPEC-7031/

refs VEN-1577

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

[VEN-1577](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1577)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1577]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ