### PR TITLE
VEN-1575 | fix(tests): set OIDC settings, mock SMS sending, fix translation use

### DIFF
--- a/customers/tests/test_gdpr_api.py
+++ b/customers/tests/test_gdpr_api.py
@@ -26,7 +26,18 @@ from .keys import rsa_key
 
 User = get_user_model()
 
+TEST_OIDC_SETTINGS = {
+    "OIDC_API_TOKEN_AUTH": {
+        "AUDIENCE": "https://api.hel.fi/auth/berthsapitest",
+        "API_SCOPE_PREFIX": "berthsapitest",
+        "ISSUER": "https://tunnistamo.test.hel.ninja/openid",
+        "API_AUTHORIZATION_FIELD": "https://api.hel.fi/auth",
+        "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": False,
+    }
+}
 
+
+@override_settings(**TEST_OIDC_SETTINGS)
 def get_api_token_for_user_with_scopes(user, scopes, requests_mock):
     """Build a proper auth token with desired scopes."""
 
@@ -63,7 +74,10 @@ def get_api_token_for_user_with_scopes(user, scopes, requests_mock):
     return auth_header
 
 
-@override_settings(GDPR_API_QUERY_SCOPE="berthsapidev.gdprquery")
+@override_settings(
+    **TEST_OIDC_SETTINGS,
+    GDPR_API_QUERY_SCOPE="berthsapidev.gdprquery",
+)
 def test_get_profile_information_from_gdpr_api(
     rest_api_client, requests_mock, settings
 ):
@@ -107,7 +121,10 @@ def test_get_profile_information_from_gdpr_api(
     }
 
 
-@override_settings(GDPR_API_QUERY_SCOPE="berthsapidev.gdprquery")
+@override_settings(
+    **TEST_OIDC_SETTINGS,
+    GDPR_API_QUERY_SCOPE="berthsapidev.gdprquery",
+)
 def test_get_full_profile_information_from_gdpr_api(
     rest_api_client, requests_mock, settings
 ):
@@ -648,7 +665,10 @@ def test_get_full_profile_information_from_gdpr_api(
     )
 
 
-@override_settings(GDPR_API_DELETE_SCOPE="berthsapidev.gdprdelete")
+@override_settings(
+    **TEST_OIDC_SETTINGS,
+    GDPR_API_DELETE_SCOPE="berthsapidev.gdprdelete",
+)
 def test_delete_profile(rest_api_client, requests_mock, settings):
     customer_profile = CustomerProfileFactory()
 
@@ -665,7 +685,10 @@ def test_delete_profile(rest_api_client, requests_mock, settings):
     assert User.objects.count() == 0
 
 
-@override_settings(GDPR_API_DELETE_SCOPE="berthsapidev.gdprdelete")
+@override_settings(
+    **TEST_OIDC_SETTINGS,
+    GDPR_API_DELETE_SCOPE="berthsapidev.gdprdelete",
+)
 def test_delete_profile_with_lease(rest_api_client, requests_mock, settings):
     """For now, if the profile has resources connected to it, they will prevent
     the deletion of the profile

--- a/exports/tests/test_winter_storage_application_export.py
+++ b/exports/tests/test_winter_storage_application_export.py
@@ -139,6 +139,10 @@ def test_exporting_winter_storage_applications_to_excel(customer_private):
     boat_type_name = boat_type.safe_translation_getter(
         "name", language_code=EXCEL_FILE_LANG
     )
+    with translation.override(EXCEL_FILE_LANG):
+        # Force evaluation of gettext_lazy by using str()
+        # so that the translation gets evaluated in the correct language
+        winter_storage_method = str(WinterStorageMethod.ON_TRESTLES.label)
 
     assert xl_sheet.max_column == 24
 
@@ -156,7 +160,7 @@ def test_exporting_winter_storage_applications_to_excel(customer_private):
     assert xl_sheet.cell(2, 9).value == "00170"
     assert xl_sheet.cell(2, 10).value == "Helsinki"
     assert xl_sheet.cell(2, 11).value == "0411234567"
-    assert xl_sheet.cell(2, 12).value == WinterStorageMethod.ON_TRESTLES.label
+    assert xl_sheet.cell(2, 12).value == winter_storage_method
     assert xl_sheet.cell(2, 13).value == "hel001"
     assert xl_sheet.cell(2, 14).value == boat_type_name
     assert xl_sheet.cell(2, 15).value == 2.0

--- a/leases/tests/test_send_berth_invoice_service.py
+++ b/leases/tests/test_send_berth_invoice_service.py
@@ -43,8 +43,11 @@ def _send_invoices(data):
         request=RequestFactory().request(), profile_token="token"
     )
     with mock.patch("customers.services.profile.requests.Session") as mock_session:
-        mock_session().post.side_effect = mocked_response_profile(count=0, data=data)
-        invoicing_service.send_invoices()
+        with mock.patch("customers.services.sms_notification_service.requests.post"):
+            mock_session().post.side_effect = mocked_response_profile(
+                count=0, data=data
+            )
+            invoicing_service.send_invoices()
     return invoicing_service
 
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -923,8 +923,8 @@ msgid "service"
 msgstr "palvelu"
 
 #, python-brace-format
-msgid "Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}€"
-msgstr "Kiinteillä palveluilla tulee olla ALV {DEFAULT_TAX_PERCENTAGE}€"
+msgid "Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}%"
+msgstr "Kiinteillä palveluilla tulee olla ALV {DEFAULT_TAX_PERCENTAGE}%"
 
 msgid "Fixed services are only valid for season"
 msgstr "Kiinteät palvelut ovat voimassa vain kaudella"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -922,8 +922,8 @@ msgid "service"
 msgstr "tjänst"
 
 #, python-brace-format
-msgid "Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}€"
-msgstr "Fasta tjänster måste ha en moms på {DEFAULT_TAX_PERCENTAGE}€"
+msgid "Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}%"
+msgstr "Fasta tjänster måste ha en moms på {DEFAULT_TAX_PERCENTAGE}%"
 
 msgid "Fixed services are only valid for season"
 msgstr "Fasta tjänster gäller endast för en säsong"

--- a/payments/models.py
+++ b/payments/models.py
@@ -282,7 +282,7 @@ class AdditionalProduct(AbstractBaseProduct, SerializableMixin):
         if self.service in ProductServiceType.FIXED_SERVICES():
             if self.tax_percentage != DEFAULT_TAX_PERCENTAGE:
                 raise ValidationError(
-                    _(f"Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}€")
+                    _(f"Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}%")
                 )
             if self.period != PeriodType.SEASON:
                 raise ValidationError(_("Fixed services are only valid for season"))

--- a/payments/tests/test_payments_models.py
+++ b/payments/tests/test_payments_models.py
@@ -155,7 +155,7 @@ def test_additional_product_fixed_service_tax_value():
         )
 
     errors = str(exception.value)
-    assert f"Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}€" in errors
+    assert f"Fixed services must have VAT of {DEFAULT_TAX_PERCENTAGE}%" in errors
 
 
 def test_order_berth_product_winter_storage_lease_raise_error():

--- a/payments/tests/test_payments_mutations_approve_order.py
+++ b/payments/tests/test_payments_mutations_approve_order.py
@@ -202,9 +202,10 @@ def test_approve_order_default_due_date(
         "post",
         side_effect=mocked_response_profile(count=1, data=None, use_edges=False),
     ):
-        api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+        with mock.patch("customers.services.sms_notification_service.requests.post"):
+            api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
 
-    order = Order.objects.get(id=order.id)
+    order.refresh_from_db()
 
     assert order.due_date == expected_due_date
 
@@ -336,7 +337,10 @@ def test_approve_order_one_success_one_failure(
         "post",
         side_effect=mocked_response_profile(count=1, data=None, use_edges=False),
     ):
-        executed = superuser_api_client.execute(APPROVE_ORDER_MUTATION, input=variables)
+        with mock.patch("customers.services.sms_notification_service.requests.post"):
+            executed = superuser_api_client.execute(
+                APPROVE_ORDER_MUTATION, input=variables
+            )
 
     payment_url = bambora_payment_provider.get_payment_email_url(
         order, lang=order.lease.application.language


### PR DESCRIPTION
## Description :sparkles:

### fix(tests): set OIDC settings, mock SMS sending, fix translation use

fixes running tests locally, in the CI/CD pipeline there were
environment variables set in a specific way that the tests passed there

also:
 - fix incorrect VAT percentage translation using `€` instead of `%`

refs VEN-1575

## Issues :bug:
### Closes :no_good_woman:
**[VEN-XXX](https://helsinkisolutionoffice.atlassian.net/browse/VEN-XXX):** 

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ