### PR TITLE
VEN-1575 | fix: TalpaEComPaymentDetails int -> Decimal price/tax fields

### DIFF
--- a/berth_reservations/tests/utils.py
+++ b/berth_reservations/tests/utils.py
@@ -40,13 +40,9 @@ def create_api_client(user=None):
     return client
 
 
-class MockResponse:
-    def __init__(self, data, status_code=200):
-        self.json_data = data
+class MockResponseBase:
+    def __init__(self, status_code):
         self.status_code = status_code
-
-    def json(self):
-        return self.json_data
 
     def raise_for_status(self):
         if self.status_code != 200:
@@ -54,7 +50,21 @@ class MockResponse:
                 "Mock request error with status_code {}.".format(self.status_code),
                 response=self,
             )
-        pass
+
+
+class MockTextResponse(MockResponseBase):
+    def __init__(self, text, status_code=200):
+        self.text = text
+        super().__init__(status_code)
+
+
+class MockJsonResponse(MockResponseBase):
+    def __init__(self, data, status_code=200):
+        self.json_data = data
+        super().__init__(status_code)
+
+    def json(self):
+        return self.json_data
 
 
 def assert_not_enough_permissions(executed):

--- a/customers/tests/conftest.py
+++ b/customers/tests/conftest.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 
 from berth_reservations.tests.conftest import *  # noqa
 from berth_reservations.tests.factories import CustomerProfileFactory
-from berth_reservations.tests.utils import MockResponse
+from berth_reservations.tests.utils import MockJsonResponse
 from customers.schema import ProfileNode
 from payments.notifications import NotificationType
 from resources.tests.conftest import berth, boat_type  # noqa
@@ -76,7 +76,7 @@ def mocked_response_profile(count=3, data=None, use_edges=True, *args, **kwargs)
 
         if use_edges:
             edges = [{"node": node} for node in profiles]
-            return MockResponse(
+            return MockJsonResponse(
                 data={
                     "data": {
                         "profiles": {"edges": edges},
@@ -86,7 +86,7 @@ def mocked_response_profile(count=3, data=None, use_edges=True, *args, **kwargs)
             )
 
         profiles = {"profile": profiles[0]}
-        return MockResponse(data={"data": profiles})
+        return MockJsonResponse(data={"data": profiles})
 
     return wrapper
 
@@ -98,7 +98,7 @@ def mocked_response_my_profile(data="", *args, **kwargs):
         else:
             profile_dict = get_customer_profile_dict()
         my_profile = {"my_profile": profile_dict}
-        return MockResponse(data={"data": my_profile})
+        return MockJsonResponse(data={"data": my_profile})
 
     return wrapper
 

--- a/customers/tests/test_sms_notification_service.py
+++ b/customers/tests/test_sms_notification_service.py
@@ -3,7 +3,7 @@ from unittest import mock
 from faker import Faker
 from freezegun import freeze_time
 
-from berth_reservations.tests.utils import MockResponse
+from berth_reservations.tests.utils import MockJsonResponse
 from customers.services.sms_notification_service import SMSNotificationService
 from payments.notifications import NotificationType
 
@@ -26,7 +26,7 @@ def test_send_plain_text_message():
 
     with mock.patch(
         "customers.services.sms_notification_service.requests.post",
-        side_effect=lambda *args, **kwargs: MockResponse(mock_response),
+        side_effect=lambda *args, **kwargs: MockJsonResponse(mock_response),
     ) as mock_exec:
         notification_service = SMSNotificationService(token="fake_token")
         response = notification_service.send_plain_text(
@@ -70,7 +70,7 @@ def test_send_message(notification_template_sms_invoice_notice):
 
     with mock.patch(
         "customers.services.sms_notification_service.requests.post",
-        side_effect=lambda *args, **kwargs: MockResponse(mock_response),
+        side_effect=lambda *args, **kwargs: MockJsonResponse(mock_response),
     ) as mock_exec:
         notification_service = SMSNotificationService(token="fake_token")
         response = notification_service.send(notification_type, context, phone)

--- a/payments/providers/talpa_ecom.py
+++ b/payments/providers/talpa_ecom.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Optional, Union
 
 import requests
@@ -59,9 +60,9 @@ class TalpaEComPaymentDetails:
     status: str
     payment_method: str
     payment_type: str
-    total_excl_tax: int
-    total: int
-    tax_amount: int
+    total_excl_tax: Decimal
+    total: Decimal
+    tax_amount: Decimal
     description: Optional[str]
     additional_info: str
     token: str
@@ -80,9 +81,9 @@ class TalpaEComPaymentDetails:
         self.status = payment_dict.get("status", "")
         self.payment_method = payment_dict.get("paymentMethod", "")
         self.payment_type = payment_dict.get("paymentType", "")
-        self.total_excl_tax = int(payment_dict.get("totalExclTax", 0))
-        self.total = int(payment_dict.get("total", 0))
-        self.tax_amount = int(payment_dict.get("taxAmount", 0))
+        self.total_excl_tax = Decimal(payment_dict.get("totalExclTax", 0))
+        self.total = Decimal(payment_dict.get("total", 0))
+        self.tax_amount = Decimal(payment_dict.get("taxAmount", 0))
         self.additional_info = payment_dict.get("additionalInfo", "")
         self.description = payment_dict.get("description", None)
         self.token = payment_dict.get("token", "")
@@ -434,7 +435,7 @@ class TalpaEComProvider(PaymentProvider):
             timeout=60,
         )
         r.raise_for_status()
-        response = r.json()
+        response = json.loads(r.text, parse_float=Decimal)
 
         return TalpaEComPaymentDetails(payment_dict=response)
 

--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -12,7 +12,7 @@ from applications.tests.factories import (
     WinterStorageApplicationFactory,
 )
 from berth_reservations.tests.conftest import *  # noqa
-from berth_reservations.tests.utils import MockResponse
+from berth_reservations.tests.utils import MockJsonResponse
 from customers.enums import OrganizationType
 from customers.services import HelsinkiProfileUser
 from customers.tests.factories import CustomerProfileFactory, OrganizationFactory
@@ -282,9 +282,9 @@ def create_talpa_ecom_provider(talpa_ecom_provider_base_config, request):
 def mocked_bambora_response_create(*args, **kwargs):
     """Mock Bambora auth token responses based on provider url"""
     if args[0].startswith(FAKE_BAMBORA_API_URL):
-        return MockResponse(data={}, status_code=500)
+        return MockJsonResponse(data={}, status_code=500)
     else:
-        return MockResponse(
+        return MockJsonResponse(
             data={"result": 0, "token": "token123", "type": "e-payment"}
         )
 
@@ -346,9 +346,9 @@ def mocked_response_talpa_ecom_order(order):
         if (
             args[0] and args[0].startswith(FAKE_TALPA_ECOM_ORDER_API_URL)
         ) or not hasattr(order, "product"):
-            return MockResponse(data={}, status_code=500)
+            return MockJsonResponse(data={}, status_code=500)
         else:
-            return MockResponse(data=mocked_talpa_ecom_order_response(order))
+            return MockJsonResponse(data=mocked_talpa_ecom_order_response(order))
 
     return wrapper
 
@@ -367,16 +367,18 @@ def mocked_response_talpa_ecom_errors(errors: dict = None, status_code: int = 40
                 else errors
             ]
         }
-        return MockResponse(data=response_errors, status_code=status_code)
+        return MockJsonResponse(data=response_errors, status_code=status_code)
 
     return wrapper
 
 
 def mocked_refund_response_create(*args, **kwargs):
     if any([arg.startswith(FAKE_BAMBORA_API_URL) for arg in args]):
-        return MockResponse(data={"result": 10})
+        return MockJsonResponse(data={"result": 10})
     else:
-        return MockResponse(data={"result": 0, "refund_id": 123456, "type": "instant"})
+        return MockJsonResponse(
+            data={"result": 0, "refund_id": 123456, "type": "instant"}
+        )
 
 
 def mocked_refund_payment_details(*args, products=None, **kwargs):
@@ -388,7 +390,7 @@ def mocked_refund_payment_details(*args, products=None, **kwargs):
 
     def wrapper(*args, **kwargs):
         if any([arg.startswith(FAKE_BAMBORA_API_URL) for arg in args]):
-            return MockResponse(data={"result": 10})
+            return MockJsonResponse(data={"result": 10})
         else:
             from ..providers.bambora_payform import BamboraPaymentDetails
 

--- a/payments/tests/test_bambora_payform_refund.py
+++ b/payments/tests/test_bambora_payform_refund.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from django.test.client import RequestFactory
 from django.utils.timezone import now
 
-from berth_reservations.tests.utils import MockResponse
+from berth_reservations.tests.utils import MockJsonResponse
 from leases.enums import LeaseStatus
 from payments.enums import OrderRefundStatus, OrderStatus
 from payments.exceptions import RefundPriceError
@@ -470,7 +470,7 @@ def test_handle_initiate_refund_error_validation(order, bambora_provider_base_co
 
     with mock.patch(
         "payments.providers.bambora_payform.requests.post",
-        side_effect=[MockResponse(data=r)],
+        side_effect=[MockJsonResponse(data=r)],
     ):
         with pytest.raises(PayloadValidationError):
             payment_provider.initiate_refund(order)


### PR DESCRIPTION
## Description :sparkles:

### fix: TalpaEComPaymentDetails int -> Decimal price/tax fields

TalpaEComPaymentDetails total_excl_tax, total and tax_amount fields were
incorrectly handled before, they were not integer values but were
handled as integer values. Now parsing the incoming JSON data which is
encoded as text, so that the floating point values that haven't yet been
decoded to floating point values but are still represented as text are
actually parsed as Python's Decimal instances to retain their accurate
values exactly.

refs VEN-1575

## Issues :bug:
### Closes :no_good_woman:

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ