### PR TITLE
fix: broken links in backend email templates

### DIFF
--- a/templates/email/messages/berth_invoice_en.html
+++ b/templates/email/messages/berth_invoice_en.html
@@ -168,8 +168,8 @@
             <b>If you wish to accept the boat berth, please:</b>
             <p>
                 1. Familiarize yourself with the
-                <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating/boat-berths/Berth-lease-terms">berth lease terms</a> and
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">marina rules</a>.
+                <a href="https://www.hel.fi/en/culture-and-leisure/outdoor-activities-parks-and-nature-destinations/boating/berths-for-rent#berth-lease-terms">berth lease terms</a> and
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">marina rules</a>.
             </p>
             <p>
                 2. Pay the invoice via this link before the due date {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -188,7 +188,7 @@
                 3. Contact customer service if you need a key to the pier gate of your berth.
             </p>
             <p>
-                4. For other questions, visit our boating <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating">website</a>.
+                4. For other questions, visit our boating <a href="https://www.hel.fi/boating">website</a>.
             </p>
 
             <b>If you do NOT wish to reserve the boat berth, please:</b>

--- a/templates/email/messages/berth_invoice_fi.html
+++ b/templates/email/messages/berth_invoice_fi.html
@@ -166,8 +166,8 @@
             <b>Jos haluat vastaanottaa venepaikan:</b>
             <p>
                 1. Tutustu venepaikan
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">vuokrasopimusehtoihin</a> ja
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">venesatamasääntöihin</a>.
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venepaikan-vuokrasopimusehdot">vuokrasopimusehtoihin</a> ja
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">venesatamasääntöihin</a>.
             </p>
             <p>
                 2. Maksa venepaikan lasku tämän linkin kautta eräpäivään mennessä {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -185,7 +185,7 @@
                 3. Ota yhteyttä asiakaspalveluun, mikäli tarvitset venepaikkasi laiturin porttiin avaimen.
             </p>
             <p>
-                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/Helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/">veneilysivuiltamme</a>.
+                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/veneily/">veneilysivuiltamme</a>.
             </p>
 
             <b>Jos ET halua vastaanottaa venepaikkaa:</b>

--- a/templates/email/messages/berth_invoice_sv.html
+++ b/templates/email/messages/berth_invoice_sv.html
@@ -167,8 +167,8 @@
             <b>Om du vill ta emot båtplatsen:</b>
             <p>
                 1. Läs
-                <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv/batplatser/Avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">båthamnens regler</a>.
+                <a href="https://www.hel.fi/sv/kultur-och-fritid/friluftsliv-parker-och-naturomraden/batliv/batplatser-som-kan-hyras#avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">båthamnens regler</a>.
             </p>
             <p>
                 2. Betala fakturan för båtplatsen via denna länk före förfallodatumet {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -186,7 +186,7 @@
                 3. Kontakta kundtjänst om du behöver nyckel till porten.
             </p>
             <p>
-                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv">hemsida</a>.
+                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/batliv">hemsida</a>.
             </p>
 
             <b>Om du INTE vill ta emot båtplatsen:</b>

--- a/templates/email/messages/berth_offer_new_en.html
+++ b/templates/email/messages/berth_offer_new_en.html
@@ -168,8 +168,8 @@
             <b>If you wish to accept the boat berth, please:</b>
             <p>
                 1. Familiarize yourself with the
-                <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating/boat-berths/Berth-lease-terms">berth lease terms</a> and
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">marina rules</a>.
+                <a href="https://www.hel.fi/en/culture-and-leisure/outdoor-activities-parks-and-nature-destinations/boating/berths-for-rent#berth-lease-terms">berth lease terms</a> and
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">marina rules</a>.
             </p>
             <p>
                 2. Pay the invoice via this link before the due date {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -188,7 +188,7 @@
                 3. Contact customer service if you need a key to the pier gate of your berth.
             </p>
             <p>
-                4. For other questions, visit our boating <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating">website</a>.
+                4. For other questions, visit our boating <a href="https://www.hel.fi/boating">website</a>.
             </p>
 
             <b>If you do NOT wish to reserve the boat berth, please:</b>

--- a/templates/email/messages/berth_offer_new_fi.html
+++ b/templates/email/messages/berth_offer_new_fi.html
@@ -167,8 +167,8 @@
             <b>Jos haluat vastaanottaa venepaikan:</b>
             <p>
                 1. Tutustu venepaikan
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">vuokrasopimusehtoihin</a> ja
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">venesatamasääntöihin</a>.
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venepaikan-vuokrasopimusehdot">vuokrasopimusehtoihin</a> ja
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">venesatamasääntöihin</a>.
             </p>
             <p>
                 2. Maksa venepaikan lasku tämän linkin kautta eräpäivään mennessä {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -186,7 +186,7 @@
                 3. Ota yhteyttä asiakaspalveluun, mikäli tarvitset venepaikkasi laiturin porttiin avaimen.
             </p>
             <p>
-                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/Helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/">veneilysivuiltamme</a>.
+                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/veneily/">veneilysivuiltamme</a>.
             </p>
 
             <b>Jos ET halua vastaanottaa venepaikkaa:</b>

--- a/templates/email/messages/berth_offer_new_sv.html
+++ b/templates/email/messages/berth_offer_new_sv.html
@@ -168,8 +168,8 @@
             <b>Om du vill ta emot båtplatsen:</b>
             <p>
                 1. Läs
-                <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv/batplatser/Avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">båthamnens regler</a>.
+                <a href="https://www.hel.fi/sv/kultur-och-fritid/friluftsliv-parker-och-naturomraden/batliv/batplatser-som-kan-hyras#avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">båthamnens regler</a>.
             </p>
             <p>
                 2. Betala fakturan för båtplatsen via denna länk före förfallodatumet {{ order.due_date.strftime("%d.%m.%Y") }}:
@@ -187,7 +187,7 @@
                 3. Kontakta kundtjänst om du behöver nyckel till porten.
             </p>
             <p>
-                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv">hemsida</a>.
+                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/batliv">hemsida</a>.
             </p>
 
             <b>Om du INTE vill ta emot båtplatsen:</b>

--- a/templates/email/messages/berth_offer_switch_en.html
+++ b/templates/email/messages/berth_offer_switch_en.html
@@ -112,8 +112,8 @@
             <b>If you accept the boat berth change offered, please:</b>
             <p>
                 1. Familiarize yourself with the
-                <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating/boat-berths/Berth-lease-terms">berth lease terms</a> and
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">marina rules</a>.
+                <a href="https://www.hel.fi/en/culture-and-leisure/outdoor-activities-parks-and-nature-destinations/boating/berths-for-rent#berth-lease-terms">berth lease terms</a> and
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">marina rules</a>.
             </p>
             <p>
                 2. Notify us that you accept the boat berth change offered via this link, the due date is {{ due_date }}:
@@ -132,7 +132,7 @@
                 3. Contact customer service if you need a key to the pier gate of your berth.
             </p>
             <p>
-                4. For other questions, visit our boating <a href="https://www.hel.fi/helsinki/en/culture/recreation/boating">website</a>.
+                4. For other questions, visit our boating <a href="https://www.hel.fi/boating">website</a>.
             </p>
 
             <b>If you do not wish to accept the boat berth change offered:</b>

--- a/templates/email/messages/berth_offer_switch_fi.html
+++ b/templates/email/messages/berth_offer_switch_fi.html
@@ -112,8 +112,8 @@
             <b>Jos haluat vastaanottaa vaihtopaikan:</b>
             <p>
                 1. Tutustu venepaikan
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">vuokrasopimusehtoihin</a> ja
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/venesatamasaannot/">venesatamasääntöihin</a>.
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venepaikan-vuokrasopimusehdot">vuokrasopimusehtoihin</a> ja
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">venesatamasääntöihin</a>.
             </p>
             <p>
                 2. Ilmoita meille, että otat vaihtopaikan vastaan tämän linkin kautta {{ due_date }} mennessä:
@@ -132,7 +132,7 @@
                 3. Ota yhteyttä asiakaspalveluun, mikäli tarvitset venepaikkasi laiturin porttiin avaimen.
             </p>
             <p>
-                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/Helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/">veneilysivuiltamme</a>.
+                4. Muihin kysymyksiin löydät tietoa <a href="https://www.hel.fi/veneily/">veneilysivuiltamme</a>.
             </p>
 
             <b>Jos et halua vastaanottaa vaihtopaikkaa:</b>

--- a/templates/email/messages/berth_offer_switch_sv.html
+++ b/templates/email/messages/berth_offer_switch_sv.html
@@ -112,8 +112,8 @@
             <b>Om du vill ta emot bytesplatsen:</b>
             <p>
                 1. Läs
-                <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv/batplatser/Avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
-                <a href="https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/ulkoilu/veneily/veneilyn-saannot/vuokrasopimusehdot/">båthamnens regler</a>.
+                <a href="https://www.hel.fi/sv/kultur-och-fritid/friluftsliv-parker-och-naturomraden/batliv/batplatser-som-kan-hyras#avtalsvillkoren-for-uthyrning-av-batplatser">hyresavtalsvillkoren för båtplatsen</a> och
+                <a href="https://www.hel.fi/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/veneily/vuokrattavat-venepaikat#venesatamien-satamasaannot">båthamnens regler</a>.
             </p>
             <p>
                 2. Meddela oss att du tar emot bytesplatsen via denna länk senast {{ due_date }}:
@@ -132,7 +132,7 @@
                 3. Kontakta kundtjänst om du behöver nyckel till porten.
             </p>
             <p>
-                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/helsinki/sv/kultur-och-fritid/friluftsliv/batliv">hemsida</a>.
+                4. Du kan hitta information om andra frågor på vår <a href="https://www.hel.fi/batliv">hemsida</a>.
             </p>
 
 


### PR DESCRIPTION
refs VEN-1589

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1589](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1589):** 

### Related :handshake:
VEN-1589
## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1589]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ