### PR TITLE
fix: increase uwsgi buffer-size

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -5,7 +5,7 @@ module = berth_reservations.wsgi
 static-map = /static=/var/berth/static
 uid = appuser
 gid = appuser
-buffer-size = 32768
+buffer-size = 65535 # Allow bigger requests that includes a big list of AD-groups. Default is 4096.
 master = 1
 processes = 2
 threads = 2


### PR DESCRIPTION
VEN-1584.

Keycloak will include so many ad-groups in the JWT that the request buffers-size needs to be increased. Set a consistent value copied from Kukkuu.
